### PR TITLE
registry: skip scan on timeout

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -47,7 +47,7 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 		}
 		response, err := bus.Send(ctx, request)
 		if err != nil {
-			if errors.Is(err, ebuserrors.ErrNoSuchDevice) {
+			if errors.Is(err, ebuserrors.ErrNoSuchDevice) || errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrNACK) {
 				continue
 			}
 			return nil, fmt.Errorf("scan target %02x: %w", target, err)

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -81,6 +81,41 @@ func TestScanRegistersDevices(t *testing.T) {
 	}
 }
 
+func TestScanSkipsTimeoutAndNACK(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{
+		responses: map[byte]*protocol.Frame{
+			0x08: {
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			},
+		},
+		errors: map[byte]error{
+			0x21: ebuserrors.ErrTimeout,
+			0x22: ebuserrors.ErrNACK,
+		},
+	}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08, 0x21, 0x22})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if _, ok := registry.Lookup(0x08); !ok {
+		t.Fatalf("expected device 0x08 to be registered")
+	}
+	if len(bus.calls) != 3 {
+		t.Fatalf("expected 3 scan calls, got %d", len(bus.calls))
+	}
+}
+
 func TestScanSkipsMasterAndUnknownTargets(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
- Skip scan targets on ErrTimeout (and ErrNACK).
- Add scan tests covering timeout skip.

## Why
Keeps scan resilient when a device does not respond within the timeout window.

## Acceptance Criteria
- [x] Scan continues on ErrTimeout
- [x] Unit tests cover timeout skip
- [x] CI green
- [ ] Smoke test required: NO

## Dependencies
- Depends on issue #19

Closes #19

Smoke test: not run (not required).