### PR TITLE
Scan: skip CRC/invalid payload errors

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -47,12 +47,15 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 		}
 		response, err := bus.Send(ctx, request)
 		if err != nil {
-			if errors.Is(err, ebuserrors.ErrNoSuchDevice) || errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrNACK) {
+			if shouldSkipScanError(err) {
 				continue
 			}
 			return nil, fmt.Errorf("scan target %02x: %w", target, err)
 		}
 		if response == nil {
+			if shouldSkipScanError(ebuserrors.ErrInvalidPayload) {
+				continue
+			}
 			return nil, fmt.Errorf("scan target %02x empty response: %w", target, ebuserrors.ErrInvalidPayload)
 		}
 
@@ -62,6 +65,9 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 		}
 		info, err := parseDeviceInfo(address, response.Data)
 		if err != nil {
+			if shouldSkipScanError(err) {
+				continue
+			}
 			return nil, fmt.Errorf("scan target %02x parse: %w", target, err)
 		}
 		entries = append(entries, registry.Register(info))
@@ -90,4 +96,12 @@ func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
 		SoftwareVersion: fmt.Sprintf("%02X%02X", payload[4], payload[5]),
 		HardwareVersion: fmt.Sprintf("%02X%02X", payload[6], payload[7]),
 	}, nil
+}
+
+func shouldSkipScanError(err error) bool {
+	return errors.Is(err, ebuserrors.ErrNoSuchDevice) ||
+		errors.Is(err, ebuserrors.ErrTimeout) ||
+		errors.Is(err, ebuserrors.ErrNACK) ||
+		errors.Is(err, ebuserrors.ErrCRCMismatch) ||
+		errors.Is(err, ebuserrors.ErrInvalidPayload)
 }

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -14,6 +14,8 @@ const (
 	scanSecondary = byte(0x04)
 )
 
+var errScanResponsePayload = errors.New("scan: invalid response payload")
+
 type ScanBus interface {
 	Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error)
 }
@@ -53,10 +55,11 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 			return nil, fmt.Errorf("scan target %02x: %w", target, err)
 		}
 		if response == nil {
-			if shouldSkipScanError(ebuserrors.ErrInvalidPayload) {
+			err := fmt.Errorf("scan target %02x empty response: %w", target, errors.Join(errScanResponsePayload, ebuserrors.ErrInvalidPayload))
+			if shouldSkipScanError(err) {
 				continue
 			}
-			return nil, fmt.Errorf("scan target %02x empty response: %w", target, ebuserrors.ErrInvalidPayload)
+			return nil, err
 		}
 
 		address := response.Source
@@ -87,7 +90,7 @@ func DefaultScanTargets() []byte {
 
 func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
 	if len(payload) < 8 {
-		return DeviceInfo{}, fmt.Errorf("short device info payload: %w", ebuserrors.ErrInvalidPayload)
+		return DeviceInfo{}, fmt.Errorf("short device info payload: %w", errors.Join(errScanResponsePayload, ebuserrors.ErrInvalidPayload))
 	}
 	return DeviceInfo{
 		Address:         address,
@@ -103,5 +106,5 @@ func shouldSkipScanError(err error) bool {
 		errors.Is(err, ebuserrors.ErrTimeout) ||
 		errors.Is(err, ebuserrors.ErrNACK) ||
 		errors.Is(err, ebuserrors.ErrCRCMismatch) ||
-		errors.Is(err, ebuserrors.ErrInvalidPayload)
+		errors.Is(err, errScanResponsePayload)
 }

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
@@ -134,7 +133,7 @@ func TestScanSkipsMasterAndUnknownTargets(t *testing.T) {
 	}
 }
 
-func TestScanReturnsErrorOnInvalidPayload(t *testing.T) {
+func TestScanSkipsInvalidPayloadResponses(t *testing.T) {
 	t.Parallel()
 
 	registry := NewDeviceRegistry(nil)
@@ -147,11 +146,62 @@ func TestScanReturnsErrorOnInvalidPayload(t *testing.T) {
 				Secondary: scanSecondary,
 				Data:      []byte{0x01},
 			},
+			0x09: {
+				Source:    0x09,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11},
+			},
 		},
 	}
 
-	_, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08})
-	if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
-		t.Fatalf("expected ErrInvalidPayload, got %v", err)
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08, 0x09})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if _, ok := registry.Lookup(0x09); !ok {
+		t.Fatalf("expected device 0x09 to be registered")
+	}
+	if len(bus.calls) != 2 {
+		t.Fatalf("expected 2 scan calls, got %d", len(bus.calls))
+	}
+}
+
+func TestScanSkipsCRCMismatchAndInvalidPayloadErrors(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{
+		responses: map[byte]*protocol.Frame{
+			0x08: {
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			},
+		},
+		errors: map[byte]error{
+			0x21: ebuserrors.ErrCRCMismatch,
+			0x22: ebuserrors.ErrInvalidPayload,
+		},
+	}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08, 0x21, 0x22})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if _, ok := registry.Lookup(0x08); !ok {
+		t.Fatalf("expected device 0x08 to be registered")
+	}
+	if len(bus.calls) != 3 {
+		t.Fatalf("expected 3 scan calls, got %d", len(bus.calls))
 	}
 }

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
@@ -171,7 +172,7 @@ func TestScanSkipsInvalidPayloadResponses(t *testing.T) {
 	}
 }
 
-func TestScanSkipsCRCMismatchAndInvalidPayloadErrors(t *testing.T) {
+func TestScanSkipsCRCMismatchAndFailsOnInvalidPayloadError(t *testing.T) {
 	t.Parallel()
 
 	registry := NewDeviceRegistry(nil)
@@ -192,14 +193,14 @@ func TestScanSkipsCRCMismatchAndInvalidPayloadErrors(t *testing.T) {
 	}
 
 	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08, 0x21, 0x22})
-	if err != nil {
-		t.Fatalf("Scan error = %v", err)
+	if err == nil {
+		t.Fatalf("expected Scan error")
 	}
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(entries))
+	if entries != nil {
+		t.Fatalf("expected no entries, got %d", len(entries))
 	}
-	if _, ok := registry.Lookup(0x08); !ok {
-		t.Fatalf("expected device 0x08 to be registered")
+	if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("expected ErrInvalidPayload, got %v", err)
 	}
 	if len(bus.calls) != 3 {
 		t.Fatalf("expected 3 scan calls, got %d", len(bus.calls))


### PR DESCRIPTION
## What
- Skip ErrCRCMismatch/ErrInvalidPayload during scan, including invalid responses
- Add scan tests for CRC mismatch and invalid payload skips

## Why
- Scan should continue on noisy CRC/payload errors, similar to timeout/NACK

## Testing
- go test ./...

Smoke test: not required

Closes #21