### PR TITLE
Scan: skip per-target DeadlineExceeded timeouts

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -37,6 +37,10 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 
 	entries := make([]DeviceEntry, 0)
 	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		frameType := protocol.FrameTypeForTarget(target)
 		if frameType == protocol.FrameTypeMasterMaster || frameType == protocol.FrameTypeUnknown {
 			continue
@@ -49,6 +53,9 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 		}
 		response, err := bus.Send(ctx, request)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			if shouldSkipScanError(err) {
 				continue
 			}
@@ -104,6 +111,7 @@ func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
 func shouldSkipScanError(err error) bool {
 	return errors.Is(err, ebuserrors.ErrNoSuchDevice) ||
 		errors.Is(err, ebuserrors.ErrTimeout) ||
+		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, ebuserrors.ErrNACK) ||
 		errors.Is(err, ebuserrors.ErrCRCMismatch) ||
 		errors.Is(err, errScanResponsePayload)

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
@@ -113,6 +114,74 @@ func TestScanSkipsTimeoutAndNACK(t *testing.T) {
 	}
 	if len(bus.calls) != 3 {
 		t.Fatalf("expected 3 scan calls, got %d", len(bus.calls))
+	}
+}
+
+func TestScanSkipsContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{
+		responses: map[byte]*protocol.Frame{
+			0x08: {
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			},
+			0x09: {
+				Source:    0x09,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11},
+			},
+		},
+		errors: map[byte]error{
+			0x21: context.DeadlineExceeded,
+		},
+	}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08, 0x21, 0x09})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if _, ok := registry.Lookup(0x08); !ok {
+		t.Fatalf("expected device 0x08 to be registered")
+	}
+	if _, ok := registry.Lookup(0x09); !ok {
+		t.Fatalf("expected device 0x09 to be registered")
+	}
+	if len(bus.calls) != 3 {
+		t.Fatalf("expected 3 scan calls, got %d", len(bus.calls))
+	}
+}
+
+func TestScanFailsWhenContextDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{}
+
+	entries, err := Scan(ctx, bus, registry, 0x10, []byte{0x08})
+	if err == nil {
+		t.Fatalf("expected Scan error")
+	}
+	if entries != nil {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+	if len(bus.calls) != 0 {
+		t.Fatalf("expected 0 scan calls, got %d", len(bus.calls))
 	}
 }
 


### PR DESCRIPTION
Implements #24.

- Abort Scan immediately if ctx is done.
- Treat per-target context.DeadlineExceeded from bus.Send as a skippable timeout (same behavior as ErrTimeout).
- Adds tests covering both the skippable DeadlineExceeded case and the ctx-done failure case.

Closes #24.