### PR TITLE
vaillant: implement SetOperationalData (B5/05)

### DIFF
--- a/router/vaillant_operational_data_test.go
+++ b/router/vaillant_operational_data_test.go
@@ -126,3 +126,106 @@ func TestVaillantSystem_GetOperationalData_MissingParams(t *testing.T) {
 		t.Fatalf("expected ErrInvalidPayload, got %v", err)
 	}
 }
+
+func TestVaillantSystem_SetOperationalData_SendsPayload(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	bus := &vaillantMockBus{
+		response: &protocol.Frame{
+			Source:    0x08,
+			Target:    0x10,
+			Primary:   0xB5,
+			Secondary: 0x05,
+		},
+	}
+	eventRouter := router.NewBusEventRouter(bus)
+
+	result, err := eventRouter.Invoke(context.Background(), plane, "set_operational_data", map[string]any{
+		"source": byte(0x10),
+		"op":     byte(0x02),
+		"data":   []byte{0xAA, 0xBB},
+	})
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	if bus.lastRequest.Source != 0x10 || bus.lastRequest.Target != 0x08 {
+		t.Fatalf("unexpected request addresses: %+v", bus.lastRequest)
+	}
+	if bus.lastRequest.Primary != 0xB5 || bus.lastRequest.Secondary != 0x05 {
+		t.Fatalf("unexpected request type: %+v", bus.lastRequest)
+	}
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0xAA, 0xBB}) {
+		t.Fatalf("unexpected request data %v", bus.lastRequest.Data)
+	}
+
+	values, ok := result.(map[string]types.Value)
+	if !ok {
+		t.Fatalf("expected map[string]types.Value, got %T", result)
+	}
+	if op := values["op"]; !op.Valid || op.Value != byte(0x02) {
+		t.Fatalf("op = %+v; want 0x02 valid", op)
+	}
+	if got := values["payload"]; !got.Valid || len(got.Value.([]byte)) != 0 {
+		t.Fatalf("payload = %+v; want empty valid", got)
+	}
+}
+
+func TestVaillantSystem_SetOperationalData_InputValidation(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	eventRouter := router.NewBusEventRouter(&vaillantMockBus{})
+
+	_, err := eventRouter.Invoke(context.Background(), plane, "set_operational_data", map[string]any{
+		"source": byte(0x10),
+	})
+	if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("expected ErrInvalidPayload, got %v", err)
+	}
+
+	_, err = eventRouter.Invoke(context.Background(), plane, "set_operational_data", map[string]any{
+		"source": byte(0x10),
+		"op":     byte(0x02),
+		"data":   "nope",
+	})
+	if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("expected ErrInvalidPayload, got %v", err)
+	}
+}
+
+func TestVaillantSystem_SetOperationalData_TypedErrors(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "NACK", err: ebuserrors.ErrNACK},
+		{name: "NoDevice", err: ebuserrors.ErrNoSuchDevice},
+		{name: "Timeout", err: ebuserrors.ErrTimeout},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := &vaillantMockBus{err: tc.err}
+			eventRouter := router.NewBusEventRouter(bus)
+
+			_, err := eventRouter.Invoke(context.Background(), plane, "set_operational_data", map[string]any{
+				"source": byte(0x10),
+				"op":     byte(0x02),
+			})
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected %v, got %v", tc.err, err)
+			}
+		})
+	}
+}

--- a/vaillant/system/operational_data.go
+++ b/vaillant/system/operational_data.go
@@ -9,7 +9,10 @@ import (
 	"github.com/d3vi1/helianthus-ebusreg/schema"
 )
 
-const methodGetOperationalData = "get_operational_data"
+const (
+	methodGetOperationalData = "get_operational_data"
+	methodSetOperationalData = "set_operational_data"
+)
 
 type method struct {
 	name     string
@@ -59,6 +62,50 @@ func (template operationalTemplate) Build(params map[string]any) ([]byte, error)
 	return []byte{op}, nil
 }
 
+type operationalWriteTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template operationalWriteTemplate) Primary() byte {
+	return template.primary
+}
+
+func (template operationalWriteTemplate) Secondary() byte {
+	return template.secondary
+}
+
+func (template operationalWriteTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("operational write template missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	op, ok := uint8Param(params, "op")
+	if !ok {
+		return nil, fmt.Errorf("operational write template op: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	data, hasData, err := bytesParam(params, "data")
+	if err != nil {
+		return nil, fmt.Errorf("operational write template data: %w", err)
+	}
+	if !hasData {
+		data, _, err = bytesParam(params, "payload")
+		if err != nil {
+			return nil, fmt.Errorf("operational write template payload: %w", err)
+		}
+	}
+
+	if len(data) > 0xFE {
+		return nil, fmt.Errorf("operational write template data too long: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	payload := make([]byte, 0, 1+len(data))
+	payload = append(payload, op)
+	payload = append(payload, data...)
+	return payload, nil
+}
+
 func decodeOperationalData(op byte, payload []byte) (map[string]types.Value, error) {
 	values := map[string]types.Value{
 		"op":      {Value: op, Valid: true},
@@ -77,6 +124,13 @@ func decodeOperationalData(op byte, payload []byte) (map[string]types.Value, err
 		values[key] = value
 	}
 	return values, nil
+}
+
+func decodeOperationalWriteResponse(op byte, payload []byte) map[string]types.Value {
+	return map[string]types.Value{
+		"op":      {Value: op, Valid: true},
+		"payload": {Value: append([]byte(nil), payload...), Valid: true},
+	}
 }
 
 func decodeOperationalDateTime(payload []byte) (map[string]types.Value, error) {

--- a/vaillant/system/params.go
+++ b/vaillant/system/params.go
@@ -1,10 +1,18 @@
 package system
 
+import (
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+)
+
 func uint8Param(params map[string]any, key string) (byte, bool) {
 	value, ok := params[key]
 	if !ok {
 		return 0, false
 	}
+	return toByte(value)
+}
+
+func toByte(value any) (byte, bool) {
 	switch typed := value.(type) {
 	case int:
 		if typed < 0 || typed > 255 {
@@ -55,5 +63,44 @@ func uint8Param(params map[string]any, key string) (byte, bool) {
 		return byte(typed), true
 	default:
 		return 0, false
+	}
+}
+
+func bytesParam(params map[string]any, key string) ([]byte, bool, error) {
+	value, ok := params[key]
+	if !ok {
+		return nil, false, nil
+	}
+	if value == nil {
+		return nil, true, nil
+	}
+
+	switch typed := value.(type) {
+	case []byte:
+		return append([]byte(nil), typed...), true, nil
+	case []int:
+		out := make([]byte, len(typed))
+		for i, v := range typed {
+			if v < 0 || v > 255 {
+				return nil, true, ebuserrors.ErrInvalidPayload
+			}
+			out[i] = byte(v)
+		}
+		return out, true, nil
+	case []any:
+		out := make([]byte, len(typed))
+		for i, v := range typed {
+			b, ok := toByte(v)
+			if !ok {
+				return nil, true, ebuserrors.ErrInvalidPayload
+			}
+			out[i] = b
+		}
+		return out, true, nil
+	default:
+		if b, ok := toByte(value); ok {
+			return []byte{b}, true, nil
+		}
+		return nil, true, ebuserrors.ErrInvalidPayload
 	}
 }

--- a/vaillant/system/router_plane.go
+++ b/vaillant/system/router_plane.go
@@ -82,6 +82,12 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 			return nil, fmt.Errorf("system DecodeResponse operational: %w", err)
 		}
 		return decoded, nil
+	case methodSetOperationalData:
+		op, ok := uint8Param(params, "op")
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse op: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeOperationalWriteResponse(op, response.Data), nil
 	default:
 		return nil, fmt.Errorf("system DecodeResponse unknown method %q: %w", method.Name(), ebuserrors.ErrInvalidPayload)
 	}

--- a/vaillant/system/system.go
+++ b/vaillant/system/system.go
@@ -50,6 +50,7 @@ func newSystemPlane(info registry.DeviceInfo) *plane {
 		hwVersion: info.HardwareVersion,
 		methods: []registry.Method{
 			method{name: methodGetOperationalData, readOnly: true, template: operationalTemplate{primary: 0xB5, secondary: 0x04}, response: schema.SchemaSelector{}},
+			method{name: methodSetOperationalData, readOnly: false, template: operationalWriteTemplate{primary: 0xB5, secondary: 0x05}, response: schema.SchemaSelector{}},
 		},
 		subscriptions: []router.Subscription{
 			{Primary: 0xB5, Secondary: 0x16},

--- a/vaillant/system/system_test.go
+++ b/vaillant/system/system_test.go
@@ -50,3 +50,43 @@ func TestSubscriptions(t *testing.T) {
 		}
 	}
 }
+
+func TestMethods(t *testing.T) {
+	t.Parallel()
+
+	planes := NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	if len(planes) != 1 {
+		t.Fatalf("expected 1 plane, got %d", len(planes))
+	}
+
+	systemPlane, ok := planes[0].(*plane)
+	if !ok {
+		t.Fatalf("expected system plane type")
+	}
+
+	methods := systemPlane.Methods()
+	getMethod, ok := findMethod(methods, methodGetOperationalData)
+	if !ok || !getMethod.ReadOnly() {
+		t.Fatalf("expected get_operational_data method")
+	}
+	if getMethod.Template().Primary() != 0xB5 || getMethod.Template().Secondary() != 0x04 {
+		t.Fatalf("unexpected get_operational_data template")
+	}
+
+	setMethod, ok := findMethod(methods, methodSetOperationalData)
+	if !ok || setMethod.ReadOnly() {
+		t.Fatalf("expected set_operational_data method")
+	}
+	if setMethod.Template().Primary() != 0xB5 || setMethod.Template().Secondary() != 0x05 {
+		t.Fatalf("unexpected set_operational_data template")
+	}
+}
+
+func findMethod(methods []registry.Method, name string) (registry.Method, bool) {
+	for _, method := range methods {
+		if method.Name() == name {
+			return method, true
+		}
+	}
+	return nil, false
+}


### PR DESCRIPTION
Fixes #29.

- Add Vaillant write method `set_operational_data` (B5 05 + 1-byte `op` + optional bytes) on the system plane.
- Validate params (`source`, `op`, optional `data`/`payload`) and preserve typed bus errors (`ErrNACK`, `ErrNoSuchDevice`, `ErrTimeout`) via `errors.Is`.
- Add mocked-bus unit tests covering request encoding, input validation, and typed error propagation.
