### PR TITLE
Fix B5/16 energy stats broadcast events

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -7,12 +7,23 @@ import (
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusgo/types"
 	"github.com/d3vi1/helianthus-ebusreg/registry"
 )
 
 type Subscription struct {
 	Primary   byte
 	Secondary byte
+}
+
+type BroadcastEvent struct {
+	Plane  string
+	Frame  protocol.Frame
+	Values map[string]types.Value
+}
+
+type BroadcastDecoder interface {
+	DecodeBroadcast(frame protocol.Frame) (map[string]types.Value, bool, error)
 }
 
 type Plane interface {
@@ -32,6 +43,7 @@ type BusEventRouter struct {
 	bus           Bus
 	mu            sync.RWMutex
 	subscriptions map[subscriptionKey][]Plane
+	events        chan BroadcastEvent
 }
 
 type subscriptionKey struct {
@@ -43,7 +55,15 @@ func NewBusEventRouter(bus Bus) *BusEventRouter {
 	return &BusEventRouter{
 		bus:           bus,
 		subscriptions: make(map[subscriptionKey][]Plane),
+		events:        make(chan BroadcastEvent, 64),
 	}
+}
+
+func (router *BusEventRouter) Events() <-chan BroadcastEvent {
+	if router == nil {
+		return nil
+	}
+	return router.events
 }
 
 func (router *BusEventRouter) SetPlanes(planes []Plane) {
@@ -75,6 +95,29 @@ func (router *BusEventRouter) HandleBroadcast(frame protocol.Frame) []error {
 	for _, plane := range planes {
 		if err := plane.OnBroadcast(frame); err != nil {
 			errors = append(errors, err)
+		}
+
+		decoder, ok := plane.(BroadcastDecoder)
+		if !ok {
+			continue
+		}
+		decoded, handled, err := decoder.DecodeBroadcast(frame)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		if !handled {
+			continue
+		}
+
+		event := BroadcastEvent{
+			Plane:  plane.Name(),
+			Frame:  frame,
+			Values: decoded,
+		}
+		select {
+		case router.events <- event:
+		default:
 		}
 	}
 	return errors

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusgo/types"
 	"github.com/d3vi1/helianthus-ebusreg/registry"
 	"github.com/d3vi1/helianthus-ebusreg/schema"
 )
@@ -208,5 +210,53 @@ func TestBusEventRouter_InvokeMissingMethod(t *testing.T) {
 	_, err := router.Invoke(context.Background(), plane, "missing", map[string]any{})
 	if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
 		t.Fatalf("expected ErrInvalidPayload, got %v", err)
+	}
+}
+
+type decodingPlane struct {
+	*mockPlane
+	decoded map[string]types.Value
+	handled bool
+	err     error
+}
+
+func (plane *decodingPlane) DecodeBroadcast(frame protocol.Frame) (map[string]types.Value, bool, error) {
+	return plane.decoded, plane.handled, plane.err
+}
+
+func TestBusEventRouter_EmitsDecodedBroadcastEvents(t *testing.T) {
+	t.Parallel()
+
+	router := NewBusEventRouter(&mockBus{})
+	plane := &decodingPlane{
+		mockPlane: &mockPlane{
+			name: "A",
+			subscriptions: []Subscription{
+				{Primary: 0xB5, Secondary: 0x16},
+			},
+		},
+		decoded: map[string]types.Value{
+			"foo": {Value: uint8(1), Valid: true},
+		},
+		handled: true,
+	}
+	router.SetPlanes([]Plane{plane})
+
+	errors := router.HandleBroadcast(protocol.Frame{Primary: 0xB5, Secondary: 0x16})
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	select {
+	case event := <-router.Events():
+		if event.Plane != "A" {
+			t.Fatalf("event.Plane = %q; want A", event.Plane)
+		}
+		value, ok := event.Values["foo"]
+		if !ok || !value.Valid || value.Value != uint8(1) {
+			t.Fatalf("event.Values[foo] = %+v; want valid 1", value)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for broadcast event")
 	}
 }

--- a/vaillant/system/b516_energy_broadcast.go
+++ b/vaillant/system/b516_energy_broadcast.go
@@ -1,0 +1,252 @@
+package system
+
+import (
+	"fmt"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+	"github.com/d3vi1/helianthus-ebusreg/schema"
+)
+
+const (
+	energyStatsPrimary   = byte(0xB5)
+	energyStatsSecondary = byte(0x16)
+)
+
+func (plane *plane) DecodeBroadcast(frame protocol.Frame) (map[string]types.Value, bool, error) {
+	if frame.Primary != energyStatsPrimary || frame.Secondary != energyStatsSecondary {
+		return nil, false, nil
+	}
+
+	selector, ok := parseEnergyStatsSelector(frame.Data)
+	if !ok {
+		return nil, false, nil
+	}
+
+	values := map[string]types.Value{
+		"payload":         {Value: append([]byte(nil), frame.Data...), Valid: true},
+		"selector":        {Value: append([]byte(nil), selector.raw...), Valid: true},
+		"period_code":     {Value: selector.period, Valid: true},
+		"source_code":     {Value: selector.source, Valid: true},
+		"usage_code":      {Value: selector.usage, Valid: true},
+		"selector_w":      {Value: selector.w, Valid: true},
+		"selector_v":      {Value: selector.v, Valid: true},
+		"selector_q":      {Value: selector.q, Valid: true},
+		"selector_is_rsp": {Value: selector.isResponse, Valid: true},
+	}
+
+	if periodName, ok := energyStatsPeriodName(selector.period); ok {
+		values["period"] = types.Value{Value: periodName, Valid: true}
+	} else {
+		values["period"] = types.Value{Valid: false}
+	}
+	if sourceName, ok := energyStatsSourceName(selector.source); ok {
+		values["source"] = types.Value{Value: sourceName, Valid: true}
+	} else {
+		values["source"] = types.Value{Valid: false}
+	}
+	if usageName, ok := energyStatsUsageName(selector.usage); ok {
+		values["usage"] = types.Value{Value: usageName, Valid: true}
+	} else {
+		values["usage"] = types.Value{Valid: false}
+	}
+
+	if yearKind, ok := energyStatsYearKind(selector.period, selector.q); ok {
+		values["year_kind"] = types.Value{Value: yearKind, Valid: true}
+	} else {
+		values["year_kind"] = types.Value{Valid: false}
+	}
+
+	if month, ok := energyStatsMonth(selector.period, selector.w, selector.q); ok {
+		values["month"] = types.Value{Value: month, Valid: true}
+	} else {
+		values["month"] = types.Value{Valid: false}
+	}
+
+	if day, ok := energyStatsDay(selector.period, selector.w, selector.v); ok {
+		values["day"] = types.Value{Value: day, Valid: true}
+	} else {
+		values["day"] = types.Value{Valid: false}
+	}
+
+	if selector.isResponse {
+		responseSchema := schema.Schema{
+			Fields: []schema.SchemaField{
+				{Name: "wh", Type: types.EXP{}},
+			},
+		}
+		decoded, err := responseSchema.Decode(frame.Data[len(frame.Data)-4:])
+		if err != nil {
+			return nil, true, fmt.Errorf("energy stats decode wh: %w", err)
+		}
+		values["wh"] = decoded["wh"]
+	}
+
+	return values, true, nil
+}
+
+type energyStatsSelector struct {
+	raw        []byte
+	period     uint8
+	source     uint8
+	usage      uint8
+	w          uint8
+	v          uint8
+	q          uint8
+	isResponse bool
+}
+
+func parseEnergyStatsSelector(payload []byte) (energyStatsSelector, bool) {
+	switch len(payload) {
+	case 8:
+		if payload[0] != 0x10 {
+			return energyStatsSelector{}, false
+		}
+		if payload[2] != 0xFF || payload[3] != 0xFF {
+			return energyStatsSelector{}, false
+		}
+		if payload[7]&0xF0 != 0x30 {
+			return energyStatsSelector{}, false
+		}
+
+		wv := payload[6]
+		return energyStatsSelector{
+			raw:        append([]byte(nil), payload...),
+			period:     payload[1] & 0x0F,
+			source:     payload[4] & 0x0F,
+			usage:      payload[5] & 0x0F,
+			w:          (wv >> 4) & 0x0F,
+			v:          wv & 0x0F,
+			q:          payload[7] & 0x0F,
+			isResponse: false,
+		}, true
+	case 11:
+		if payload[0] > 0x03 {
+			return energyStatsSelector{}, false
+		}
+		if payload[6]&0xF0 != 0x30 {
+			return energyStatsSelector{}, false
+		}
+
+		wv := payload[5]
+		return energyStatsSelector{
+			raw:        append([]byte(nil), payload[:7]...),
+			period:     payload[0] & 0x0F,
+			source:     payload[3] & 0x0F,
+			usage:      payload[4] & 0x0F,
+			w:          (wv >> 4) & 0x0F,
+			v:          wv & 0x0F,
+			q:          payload[6] & 0x0F,
+			isResponse: true,
+		}, true
+	default:
+		return energyStatsSelector{}, false
+	}
+}
+
+func energyStatsPeriodName(code uint8) (string, bool) {
+	switch code {
+	case 0:
+		return "all", true
+	case 1:
+		return "day", true
+	case 2:
+		return "month", true
+	case 3:
+		return "year", true
+	default:
+		return "", false
+	}
+}
+
+func energyStatsSourceName(code uint8) (string, bool) {
+	switch code {
+	case 1:
+		return "solar", true
+	case 2:
+		return "environmental", true
+	case 3:
+		return "electricity", true
+	case 4:
+		return "gas", true
+	case 9:
+		return "heat_pump", true
+	default:
+		return "", false
+	}
+}
+
+func energyStatsUsageName(code uint8) (string, bool) {
+	switch code {
+	case 0:
+		return "all", true
+	case 3:
+		return "heating", true
+	case 4:
+		return "hot_water", true
+	case 5:
+		return "cooling", true
+	default:
+		return "", false
+	}
+}
+
+func energyStatsYearKind(period, q uint8) (string, bool) {
+	switch period {
+	case 1, 2, 3:
+	default:
+		return "", false
+	}
+
+	switch q {
+	case 0, 1:
+		return "previous", true
+	case 2, 3:
+		return "current", true
+	default:
+		return "", false
+	}
+}
+
+func energyStatsMonth(period, w, q uint8) (uint8, bool) {
+	if period != 1 && period != 2 {
+		return 0, false
+	}
+
+	baseW := w
+	if period == 1 && baseW%2 == 1 {
+		baseW--
+	}
+
+	switch q {
+	case 0, 2:
+		month := baseW / 2
+		if month < 1 || month > 7 {
+			return 0, false
+		}
+		return month, true
+	case 1, 3:
+		month := 8 + baseW/2
+		if month < 8 || month > 12 {
+			return 0, false
+		}
+		return month, true
+	default:
+		return 0, false
+	}
+}
+
+func energyStatsDay(period, w, v uint8) (uint8, bool) {
+	if period != 1 {
+		return 0, false
+	}
+
+	day := v
+	if w%2 == 1 {
+		day = 16 + v
+	}
+	if day < 1 || day > 31 {
+		return 0, false
+	}
+	return day, true
+}

--- a/vaillant/system/b516_energy_broadcast_test.go
+++ b/vaillant/system/b516_energy_broadcast_test.go
@@ -1,0 +1,80 @@
+package system
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusreg/registry"
+)
+
+func TestSystemPlane_DecodeBroadcast_EnergyStatsSelectorRequest(t *testing.T) {
+	t.Parallel()
+
+	planes := NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	systemPlane := planes[0].(*plane)
+
+	frame := protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x10, 0x03, 0xFF, 0xFF, 0x04, 0x04, 0x00, 0x32},
+	}
+
+	values, handled, err := systemPlane.DecodeBroadcast(frame)
+	if err != nil {
+		t.Fatalf("DecodeBroadcast error = %v", err)
+	}
+	if !handled {
+		t.Fatal("expected handled=true")
+	}
+
+	if got := values["period"]; !got.Valid || got.Value != "year" {
+		t.Fatalf("period = %+v; want year valid", got)
+	}
+	if got := values["year_kind"]; !got.Valid || got.Value != "current" {
+		t.Fatalf("year_kind = %+v; want current valid", got)
+	}
+	if got := values["source"]; !got.Valid || got.Value != "gas" {
+		t.Fatalf("source = %+v; want gas valid", got)
+	}
+	if got := values["usage"]; !got.Valid || got.Value != "hot_water" {
+		t.Fatalf("usage = %+v; want hot_water valid", got)
+	}
+	if got := values["month"]; got.Valid {
+		t.Fatalf("month = %+v; want invalid", got)
+	}
+	if got := values["day"]; got.Valid {
+		t.Fatalf("day = %+v; want invalid", got)
+	}
+}
+
+func TestSystemPlane_DecodeBroadcast_EnergyStatsResponseWh(t *testing.T) {
+	t.Parallel()
+
+	planes := NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	systemPlane := planes[0].(*plane)
+
+	wantWh := float32(12345.0)
+	whBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(whBytes, math.Float32bits(wantWh))
+
+	payload := append([]byte{0x03, 0x00, 0xFF, 0x04, 0x04, 0x00, 0x32}, whBytes...)
+	frame := protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      payload,
+	}
+
+	values, handled, err := systemPlane.DecodeBroadcast(frame)
+	if err != nil {
+		t.Fatalf("DecodeBroadcast error = %v", err)
+	}
+	if !handled {
+		t.Fatal("expected handled=true")
+	}
+
+	if got := values["wh"]; !got.Valid || got.Value != wantWh {
+		t.Fatalf("wh = %+v; want %v valid", got, wantWh)
+	}
+}


### PR DESCRIPTION
Fixes #30

- Add `router.BroadcastEvent` + buffered event channel and `Events()` accessor.
- Add optional `router.BroadcastDecoder` interface and publish decoded events from `HandleBroadcast`.
- Implement Vaillant system B5/16 energy-stats selector decoding (request/response) incl. EXP Wh.
- Add unit tests for router event emission and selector/EXP decoding.

Tests:
- `go test ./...` (helianthus-ebusreg)
- `go test ./...` (helianthus-ebusgateway)