### PR TITLE
Fix B5/09 (B509h) register access

### DIFF
--- a/router/vaillant_register_access_test.go
+++ b/router/vaillant_register_access_test.go
@@ -1,0 +1,176 @@
+package router_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+	"github.com/d3vi1/helianthus-ebusreg/registry"
+	"github.com/d3vi1/helianthus-ebusreg/router"
+	"github.com/d3vi1/helianthus-ebusreg/vaillant/system"
+)
+
+func TestVaillantSystem_GetRegister_RequestEncodesAddr(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	cases := []struct {
+		name string
+		addr any
+	}{
+		{name: "uint16", addr: uint16(0xF600)},
+		{name: "hex string", addr: "F600"},
+		{name: "0x-prefixed hex string", addr: "0xF600"},
+		{name: "bytes", addr: []byte{0xF6, 0x00}},
+		{name: "ints", addr: []int{0xF6, 0x00}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bus := &vaillantMockBus{
+				response: &protocol.Frame{
+					Source:    0x08,
+					Target:    0x10,
+					Primary:   0xB5,
+					Secondary: 0x09,
+					Data:      []byte{0x12, 0x34},
+				},
+			}
+			eventRouter := router.NewBusEventRouter(bus)
+
+			_, err := eventRouter.Invoke(context.Background(), plane, "get_register", map[string]any{
+				"source": byte(0x10),
+				"addr":   tc.addr,
+			})
+			if err != nil {
+				t.Fatalf("Invoke error = %v", err)
+			}
+
+			if bus.lastRequest.Primary != 0xB5 || bus.lastRequest.Secondary != 0x09 {
+				t.Fatalf("unexpected request type: %+v", bus.lastRequest)
+			}
+			if !bytes.Equal(bus.lastRequest.Data, []byte{0x0D, 0xF6, 0x00}) {
+				t.Fatalf("unexpected request data %v; want [0d f6 00]", bus.lastRequest.Data)
+			}
+		})
+	}
+}
+
+func TestVaillantSystem_GetRegister_ResponseDecode(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	t.Run("normal payload", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x12, 0x34},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_register", map[string]any{
+			"source": byte(0x10),
+			"addr":   uint16(0xF600),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		if got := values["cmd"]; !got.Valid || got.Value != byte(0x0D) {
+			t.Fatalf("cmd = %+v; want 0x0D valid", got)
+		}
+		if got := values["addr"]; !got.Valid || got.Value != uint16(0xF600) {
+			t.Fatalf("addr = %+v; want 0xF600 valid", got)
+		}
+		if got := values["addr_hex"]; !got.Valid || got.Value != "F600" {
+			t.Fatalf("addr_hex = %+v; want F600 valid", got)
+		}
+		if got := values["payload"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0x12, 0x34}) {
+			t.Fatalf("payload = %+v; want [12 34] valid", got)
+		}
+		if got := values["value"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0x12, 0x34}) {
+			t.Fatalf("value = %+v; want [12 34] valid", got)
+		}
+	})
+
+	t.Run("short zero payload", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x00},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_register", map[string]any{
+			"source": byte(0x10),
+			"addr":   uint16(0xF600),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		if got := values["payload"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0x00}) {
+			t.Fatalf("payload = %+v; want [00] valid", got)
+		}
+		if got := values["value"]; got.Valid {
+			t.Fatalf("value = %+v; want invalid", got)
+		}
+	})
+}
+
+func TestVaillantSystem_SetRegister_SendsPayload(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	bus := &vaillantMockBus{
+		response: &protocol.Frame{
+			Source:    0x08,
+			Target:    0x10,
+			Primary:   0xB5,
+			Secondary: 0x09,
+			Data:      nil,
+		},
+	}
+	eventRouter := router.NewBusEventRouter(bus)
+
+	_, err := eventRouter.Invoke(context.Background(), plane, "set_register", map[string]any{
+		"source": byte(0x10),
+		"addr":   "F600",
+		"data":   []byte{0xAA, 0xBB},
+	})
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	if bus.lastRequest.Primary != 0xB5 || bus.lastRequest.Secondary != 0x09 {
+		t.Fatalf("unexpected request type: %+v", bus.lastRequest)
+	}
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x0E, 0xF6, 0x00, 0xAA, 0xBB}) {
+		t.Fatalf("unexpected request data %v; want [0e f6 00 aa bb]", bus.lastRequest.Data)
+	}
+}

--- a/vaillant/system/b509_register_access.go
+++ b/vaillant/system/b509_register_access.go
@@ -1,0 +1,200 @@
+package system
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+)
+
+const (
+	methodGetRegister = "get_register"
+	methodSetRegister = "set_register"
+)
+
+const (
+	registerCmdRead  = byte(0x0D)
+	registerCmdWrite = byte(0x0E)
+)
+
+type registerReadTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template registerReadTemplate) Primary() byte {
+	return template.primary
+}
+
+func (template registerReadTemplate) Secondary() byte {
+	return template.secondary
+}
+
+func (template registerReadTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("register read template missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	addr, ok, err := registerAddrParam(params, "addr")
+	if err != nil {
+		return nil, fmt.Errorf("register read template addr: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("register read template addr: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	return []byte{registerCmdRead, byte(addr >> 8), byte(addr)}, nil
+}
+
+type registerWriteTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template registerWriteTemplate) Primary() byte {
+	return template.primary
+}
+
+func (template registerWriteTemplate) Secondary() byte {
+	return template.secondary
+}
+
+func (template registerWriteTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("register write template missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	addr, ok, err := registerAddrParam(params, "addr")
+	if err != nil {
+		return nil, fmt.Errorf("register write template addr: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("register write template addr: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	data, hasData, err := bytesParam(params, "data")
+	if err != nil {
+		return nil, fmt.Errorf("register write template data: %w", err)
+	}
+	if !hasData {
+		data, _, err = bytesParam(params, "payload")
+		if err != nil {
+			return nil, fmt.Errorf("register write template payload: %w", err)
+		}
+	}
+
+	if len(data) > 0xFC {
+		return nil, fmt.Errorf("register write template data too long: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	payload := make([]byte, 0, 3+len(data))
+	payload = append(payload, registerCmdWrite, byte(addr>>8), byte(addr))
+	payload = append(payload, data...)
+	return payload, nil
+}
+
+func decodeRegisterResponse(cmd byte, addr uint16, payload []byte) map[string]types.Value {
+	values := map[string]types.Value{
+		"cmd":      {Value: cmd, Valid: true},
+		"addr":     {Value: addr, Valid: true},
+		"addr_hex": {Value: fmt.Sprintf("%04X", addr), Valid: true},
+		"payload":  {Value: append([]byte(nil), payload...), Valid: true},
+	}
+
+	if len(payload) == 1 && payload[0] == 0x00 {
+		values["value"] = types.Value{Valid: false}
+		return values
+	}
+
+	values["value"] = types.Value{Value: append([]byte(nil), payload...), Valid: true}
+	return values
+}
+
+func registerAddrParam(params map[string]any, key string) (uint16, bool, error) {
+	value, ok := params[key]
+	if !ok {
+		return 0, false, nil
+	}
+	if value == nil {
+		return 0, true, ebuserrors.ErrInvalidPayload
+	}
+
+	switch typed := value.(type) {
+	case uint16:
+		return typed, true, nil
+	case int:
+		if typed < 0 || typed > 0xFFFF {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed), true, nil
+	case int32:
+		if typed < 0 || typed > 0xFFFF {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed), true, nil
+	case int64:
+		if typed < 0 || typed > 0xFFFF {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed), true, nil
+	case uint:
+		if typed > 0xFFFF {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed), true, nil
+	case uint32:
+		if typed > 0xFFFF {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed), true, nil
+	case uint64:
+		if typed > 0xFFFF {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed), true, nil
+	case string:
+		s := strings.TrimSpace(typed)
+		s = strings.TrimPrefix(s, "0x")
+		s = strings.TrimPrefix(s, "0X")
+		if len(s) != 4 {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		parsed, err := strconv.ParseUint(s, 16, 16)
+		if err != nil {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(parsed), true, nil
+	case []byte:
+		if len(typed) != 2 {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(typed[0])<<8 | uint16(typed[1]), true, nil
+	case []int:
+		if len(typed) != 2 {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		for _, v := range typed {
+			if v < 0 || v > 255 {
+				return 0, true, ebuserrors.ErrInvalidPayload
+			}
+		}
+		return uint16(byte(typed[0]))<<8 | uint16(byte(typed[1])), true, nil
+	case []any:
+		if len(typed) != 2 {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		hi, ok := toByte(typed[0])
+		if !ok {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		lo, ok := toByte(typed[1])
+		if !ok {
+			return 0, true, ebuserrors.ErrInvalidPayload
+		}
+		return uint16(hi)<<8 | uint16(lo), true, nil
+	default:
+		return 0, true, ebuserrors.ErrInvalidPayload
+	}
+}

--- a/vaillant/system/router_plane.go
+++ b/vaillant/system/router_plane.go
@@ -88,6 +88,24 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 			return nil, fmt.Errorf("system DecodeResponse op: %w", ebuserrors.ErrInvalidPayload)
 		}
 		return decodeOperationalWriteResponse(op, response.Data), nil
+	case methodGetRegister:
+		addr, ok, err := registerAddrParam(params, "addr")
+		if err != nil {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeRegisterResponse(registerCmdRead, addr, response.Data), nil
+	case methodSetRegister:
+		addr, ok, err := registerAddrParam(params, "addr")
+		if err != nil {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeRegisterResponse(registerCmdWrite, addr, response.Data), nil
 	default:
 		return nil, fmt.Errorf("system DecodeResponse unknown method %q: %w", method.Name(), ebuserrors.ErrInvalidPayload)
 	}

--- a/vaillant/system/system.go
+++ b/vaillant/system/system.go
@@ -51,6 +51,8 @@ func newSystemPlane(info registry.DeviceInfo) *plane {
 		methods: []registry.Method{
 			method{name: methodGetOperationalData, readOnly: true, template: operationalTemplate{primary: 0xB5, secondary: 0x04}, response: schema.SchemaSelector{}},
 			method{name: methodSetOperationalData, readOnly: false, template: operationalWriteTemplate{primary: 0xB5, secondary: 0x05}, response: schema.SchemaSelector{}},
+			method{name: methodGetRegister, readOnly: true, template: registerReadTemplate{primary: 0xB5, secondary: 0x09}, response: schema.SchemaSelector{}},
+			method{name: methodSetRegister, readOnly: false, template: registerWriteTemplate{primary: 0xB5, secondary: 0x09}, response: schema.SchemaSelector{}},
 		},
 		subscriptions: []router.Subscription{
 			{Primary: 0xB5, Secondary: 0x16},


### PR DESCRIPTION
Fixes #31

- Add Vaillant system methods `get_register` and `set_register` using B5/09 with 0x0D/0x0E payloads.
- Support addr parsing from uint16, hex string ("F600"/"0xF600"), or 2-byte arrays.
- Decode responses as `{cmd, addr, payload}` and mark `value` invalid for the common single-byte `0x00` short-payload case.

Tests:
- `go test ./...` (helianthus-ebusreg)
- `go test ./...` (helianthus-ebusgateway)