### PR TITLE
Fix B5/24 (B524h) extended register access

### DIFF
--- a/router/vaillant_ext_register_access_test.go
+++ b/router/vaillant_ext_register_access_test.go
@@ -1,0 +1,160 @@
+package router_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+	"github.com/d3vi1/helianthus-ebusreg/registry"
+	"github.com/d3vi1/helianthus-ebusreg/router"
+	"github.com/d3vi1/helianthus-ebusreg/vaillant/system"
+)
+
+func TestVaillantSystem_GetExtRegister_RequestEncodesPayload(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	bus := &vaillantMockBus{
+		response: &protocol.Frame{
+			Source:    0x08,
+			Target:    0x10,
+			Primary:   0xB5,
+			Secondary: 0x24,
+			Data:      []byte{0x02, 0x00, 0x00, 0x00, 0xAA},
+		},
+	}
+	eventRouter := router.NewBusEventRouter(bus)
+
+	_, err := eventRouter.Invoke(context.Background(), plane, "get_ext_register", map[string]any{
+		"source":   byte(0x10),
+		"group":    byte(0x00),
+		"instance": byte(0x00),
+		"addr":     uint16(0x5C00),
+	})
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0x00, 0x00, 0x00, 0x5C, 0x00}) {
+		t.Fatalf("unexpected request data %v; want [02 00 00 00 5c 00]", bus.lastRequest.Data)
+	}
+}
+
+func TestVaillantSystem_GetExtRegister_ResponseDecode(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	t.Run("normal payload", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x24,
+				Data:      []byte{0x02, 0x00, 0x00, 0x00, 0xAA, 0xBB},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_ext_register", map[string]any{
+			"source":   byte(0x10),
+			"group":    byte(0x00),
+			"instance": byte(0x00),
+			"addr":     uint16(0x5C00),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		if got := values["group"]; !got.Valid || got.Value != byte(0x00) {
+			t.Fatalf("group = %+v; want 0x00 valid", got)
+		}
+		if got := values["instance"]; !got.Valid || got.Value != byte(0x00) {
+			t.Fatalf("instance = %+v; want 0x00 valid", got)
+		}
+		if got := values["addr"]; !got.Valid || got.Value != uint16(0x5C00) {
+			t.Fatalf("addr = %+v; want 0x5C00 valid", got)
+		}
+		if got := values["addr_hex"]; !got.Valid || got.Value != "5C00" {
+			t.Fatalf("addr_hex = %+v; want 5C00 valid", got)
+		}
+		if got := values["prefix"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0x02, 0x00, 0x00, 0x00}) {
+			t.Fatalf("prefix = %+v; want [02 00 00 00] valid", got)
+		}
+		if got := values["value"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0xAA, 0xBB}) {
+			t.Fatalf("value = %+v; want [aa bb] valid", got)
+		}
+	})
+
+	t.Run("short zero payload", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x24,
+				Data:      []byte{0x00},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_ext_register", map[string]any{
+			"source":   byte(0x10),
+			"group":    byte(0x00),
+			"instance": byte(0x00),
+			"addr":     uint16(0x5C00),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		if got := values["value"]; got.Valid {
+			t.Fatalf("value = %+v; want invalid", got)
+		}
+	})
+}
+
+func TestVaillantSystem_SetExtRegister_SendsPayload(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{Manufacturer: "Vaillant", Address: 0x08})
+	plane := planes[0].(router.Plane)
+
+	bus := &vaillantMockBus{
+		response: &protocol.Frame{
+			Source:    0x08,
+			Target:    0x10,
+			Primary:   0xB5,
+			Secondary: 0x24,
+			Data:      nil,
+		},
+	}
+	eventRouter := router.NewBusEventRouter(bus)
+
+	_, err := eventRouter.Invoke(context.Background(), plane, "set_ext_register", map[string]any{
+		"source":   byte(0x10),
+		"group":    0,
+		"instance": 0,
+		"addr":     "5C00",
+		"data":     []byte{0xAA, 0xBB},
+	})
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0x01, 0x00, 0x00, 0x5C, 0x00, 0xAA, 0xBB}) {
+		t.Fatalf("unexpected request data %v; want [02 01 00 00 5c 00 aa bb]", bus.lastRequest.Data)
+	}
+}

--- a/vaillant/system/b524_ext_register_access.go
+++ b/vaillant/system/b524_ext_register_access.go
@@ -1,0 +1,140 @@
+package system
+
+import (
+	"fmt"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+)
+
+const (
+	methodGetExtRegister = "get_ext_register"
+	methodSetExtRegister = "set_ext_register"
+)
+
+const (
+	extRegisterCmdRead  = byte(0x00)
+	extRegisterCmdWrite = byte(0x01)
+	extRegisterPrefix   = byte(0x02)
+)
+
+type extRegisterReadTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template extRegisterReadTemplate) Primary() byte {
+	return template.primary
+}
+
+func (template extRegisterReadTemplate) Secondary() byte {
+	return template.secondary
+}
+
+func (template extRegisterReadTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("ext register read template missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	group, ok := uint8Param(params, "group")
+	if !ok {
+		return nil, fmt.Errorf("ext register read template group: %w", ebuserrors.ErrInvalidPayload)
+	}
+	instance, ok := uint8Param(params, "instance")
+	if !ok {
+		return nil, fmt.Errorf("ext register read template instance: %w", ebuserrors.ErrInvalidPayload)
+	}
+	addr, ok, err := registerAddrParam(params, "addr")
+	if err != nil {
+		return nil, fmt.Errorf("ext register read template addr: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("ext register read template addr: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	return []byte{extRegisterPrefix, extRegisterCmdRead, group, instance, byte(addr >> 8), byte(addr)}, nil
+}
+
+type extRegisterWriteTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template extRegisterWriteTemplate) Primary() byte {
+	return template.primary
+}
+
+func (template extRegisterWriteTemplate) Secondary() byte {
+	return template.secondary
+}
+
+func (template extRegisterWriteTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("ext register write template missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	group, ok := uint8Param(params, "group")
+	if !ok {
+		return nil, fmt.Errorf("ext register write template group: %w", ebuserrors.ErrInvalidPayload)
+	}
+	instance, ok := uint8Param(params, "instance")
+	if !ok {
+		return nil, fmt.Errorf("ext register write template instance: %w", ebuserrors.ErrInvalidPayload)
+	}
+	addr, ok, err := registerAddrParam(params, "addr")
+	if err != nil {
+		return nil, fmt.Errorf("ext register write template addr: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("ext register write template addr: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	data, hasData, err := bytesParam(params, "data")
+	if err != nil {
+		return nil, fmt.Errorf("ext register write template data: %w", err)
+	}
+	if !hasData {
+		data, _, err = bytesParam(params, "payload")
+		if err != nil {
+			return nil, fmt.Errorf("ext register write template payload: %w", err)
+		}
+	}
+
+	if len(data) > 0xF9 {
+		return nil, fmt.Errorf("ext register write template data too long: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	payload := make([]byte, 0, 6+len(data))
+	payload = append(payload, extRegisterPrefix, extRegisterCmdWrite, group, instance, byte(addr>>8), byte(addr))
+	payload = append(payload, data...)
+	return payload, nil
+}
+
+func decodeExtRegisterResponse(cmd byte, group, instance byte, addr uint16, payload []byte) map[string]types.Value {
+	values := map[string]types.Value{
+		"cmd":      {Value: cmd, Valid: true},
+		"group":    {Value: group, Valid: true},
+		"instance": {Value: instance, Valid: true},
+		"addr":     {Value: addr, Valid: true},
+		"addr_hex": {Value: fmt.Sprintf("%04X", addr), Valid: true},
+		"payload":  {Value: append([]byte(nil), payload...), Valid: true},
+	}
+
+	if len(payload) >= 4 {
+		values["prefix"] = types.Value{Value: append([]byte(nil), payload[:4]...), Valid: true}
+	} else {
+		values["prefix"] = types.Value{Valid: false}
+	}
+
+	if len(payload) == 1 && payload[0] == 0x00 {
+		values["value"] = types.Value{Valid: false}
+		return values
+	}
+	if len(payload) <= 4 {
+		values["value"] = types.Value{Valid: false}
+		return values
+	}
+
+	values["value"] = types.Value{Value: append([]byte(nil), payload[4:]...), Valid: true}
+	return values
+}

--- a/vaillant/system/router_plane.go
+++ b/vaillant/system/router_plane.go
@@ -106,6 +106,40 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
 		}
 		return decodeRegisterResponse(registerCmdWrite, addr, response.Data), nil
+	case methodGetExtRegister:
+		group, ok := uint8Param(params, "group")
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse group: %w", ebuserrors.ErrInvalidPayload)
+		}
+		instance, ok := uint8Param(params, "instance")
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse instance: %w", ebuserrors.ErrInvalidPayload)
+		}
+		addr, ok, err := registerAddrParam(params, "addr")
+		if err != nil {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeExtRegisterResponse(extRegisterCmdRead, group, instance, addr, response.Data), nil
+	case methodSetExtRegister:
+		group, ok := uint8Param(params, "group")
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse group: %w", ebuserrors.ErrInvalidPayload)
+		}
+		instance, ok := uint8Param(params, "instance")
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse instance: %w", ebuserrors.ErrInvalidPayload)
+		}
+		addr, ok, err := registerAddrParam(params, "addr")
+		if err != nil {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeExtRegisterResponse(extRegisterCmdWrite, group, instance, addr, response.Data), nil
 	default:
 		return nil, fmt.Errorf("system DecodeResponse unknown method %q: %w", method.Name(), ebuserrors.ErrInvalidPayload)
 	}

--- a/vaillant/system/system.go
+++ b/vaillant/system/system.go
@@ -53,6 +53,8 @@ func newSystemPlane(info registry.DeviceInfo) *plane {
 			method{name: methodSetOperationalData, readOnly: false, template: operationalWriteTemplate{primary: 0xB5, secondary: 0x05}, response: schema.SchemaSelector{}},
 			method{name: methodGetRegister, readOnly: true, template: registerReadTemplate{primary: 0xB5, secondary: 0x09}, response: schema.SchemaSelector{}},
 			method{name: methodSetRegister, readOnly: false, template: registerWriteTemplate{primary: 0xB5, secondary: 0x09}, response: schema.SchemaSelector{}},
+			method{name: methodGetExtRegister, readOnly: true, template: extRegisterReadTemplate{primary: 0xB5, secondary: 0x24}, response: schema.SchemaSelector{}},
+			method{name: methodSetExtRegister, readOnly: false, template: extRegisterWriteTemplate{primary: 0xB5, secondary: 0x24}, response: schema.SchemaSelector{}},
 		},
 		subscriptions: []router.Subscription{
 			{Primary: 0xB5, Secondary: 0x16},


### PR DESCRIPTION
Fixes #32

- Add Vaillant system methods `get_ext_register` and `set_ext_register` using B5/24 with payloads `02 00 <group> <instance> <addr_hi> <addr_lo>` and `02 01 ... <data...>`.
- Decode responses by exposing the 4-byte prefix and returning `value=payload[4:]` when present; treat single-byte `0x00` responses as invalid value.

Tests:
- `go test ./...` (helianthus-ebusreg)
- `go test ./...` (helianthus-ebusgateway)