### PR TITLE
Fix 07/04 scan ident payload parsing

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
@@ -133,15 +134,21 @@ func DefaultScanTargets() []byte {
 }
 
 func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
-	if len(payload) < 8 {
+	if len(payload) < 10 {
 		return DeviceInfo{}, fmt.Errorf("short device info payload: %w", errors.Join(errScanResponsePayload, ebuserrors.ErrInvalidPayload))
 	}
+
+	manufacturer := fmt.Sprintf("0x%02X", payload[0])
+	if payload[0] == 0xB5 {
+		manufacturer = "Vaillant"
+	}
+
 	return DeviceInfo{
 		Address:         address,
-		Manufacturer:    fmt.Sprintf("%02X%02X", payload[0], payload[1]),
-		DeviceID:        fmt.Sprintf("%02X%02X", payload[2], payload[3]),
-		SoftwareVersion: fmt.Sprintf("%02X%02X", payload[4], payload[5]),
-		HardwareVersion: fmt.Sprintf("%02X%02X", payload[6], payload[7]),
+		Manufacturer:    manufacturer,
+		DeviceID:        strings.Trim(string(payload[1:6]), " \x00"),
+		SoftwareVersion: fmt.Sprintf("%02X%02X", payload[6], payload[7]),
+		HardwareVersion: fmt.Sprintf("%02X%02X", payload[8], payload[9]),
 	}, nil
 }
 

--- a/registry/scan_parse_test.go
+++ b/registry/scan_parse_test.go
@@ -1,0 +1,29 @@
+package registry
+
+import "testing"
+
+func TestParseDeviceInfo_VaillantBAI00(t *testing.T) {
+	t.Parallel()
+
+	info, err := parseDeviceInfo(0x08, []byte{
+		0xB5, 'B', 'A', 'I', '0', '0', // MF + ID(5)
+		0x07, 0x04, // SW(PIN=2)
+		0x76, 0x03, // HW(PIN=2)
+	})
+	if err != nil {
+		t.Fatalf("parseDeviceInfo error = %v", err)
+	}
+
+	if info.Manufacturer != "Vaillant" {
+		t.Fatalf("Manufacturer = %q, want %q", info.Manufacturer, "Vaillant")
+	}
+	if info.DeviceID != "BAI00" {
+		t.Fatalf("DeviceID = %q, want %q", info.DeviceID, "BAI00")
+	}
+	if info.SoftwareVersion != "0704" {
+		t.Fatalf("SoftwareVersion = %q, want %q", info.SoftwareVersion, "0704")
+	}
+	if info.HardwareVersion != "7603" {
+		t.Fatalf("HardwareVersion = %q, want %q", info.HardwareVersion, "7603")
+	}
+}

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -28,9 +28,9 @@ func (bus *mockScanBus) Send(ctx context.Context, frame protocol.Frame) (*protoc
 }
 
 type collisionThenResponseBus struct {
-	response  *protocol.Frame
-	calls     []protocol.Frame
-	collided  bool
+	response *protocol.Frame
+	calls    []protocol.Frame
+	collided bool
 }
 
 func (bus *collisionThenResponseBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
@@ -53,14 +53,14 @@ func TestScanRegistersDevices(t *testing.T) {
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				Data:      []byte{0x01, 'D', 'E', 'V', '0', '8', 0x05, 0x06, 0x07, 0x08},
 			},
 			0x09: {
 				Source:    0x09,
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11},
+				Data:      []byte{0x0A, 'D', 'E', 'V', '0', '9', 0x0E, 0x0F, 0x10, 0x11},
 			},
 		},
 		errors: map[byte]error{
@@ -80,7 +80,7 @@ func TestScanRegistersDevices(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected device 0x08 to be registered")
 	}
-	if entry.Manufacturer() != "0102" || entry.DeviceID() != "0304" || entry.SoftwareVersion() != "0506" || entry.HardwareVersion() != "0708" {
+	if entry.Manufacturer() != "0x01" || entry.DeviceID() != "DEV08" || entry.SoftwareVersion() != "0506" || entry.HardwareVersion() != "0708" {
 		t.Fatalf("unexpected device 0x08 info: %+v", entry)
 	}
 
@@ -88,7 +88,7 @@ func TestScanRegistersDevices(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected device 0x09 to be registered")
 	}
-	if entry.Manufacturer() != "0A0B" || entry.DeviceID() != "0C0D" || entry.SoftwareVersion() != "0E0F" || entry.HardwareVersion() != "1011" {
+	if entry.Manufacturer() != "0x0A" || entry.DeviceID() != "DEV09" || entry.SoftwareVersion() != "0E0F" || entry.HardwareVersion() != "1011" {
 		t.Fatalf("unexpected device 0x09 info: %+v", entry)
 	}
 
@@ -107,7 +107,7 @@ func TestScanRetriesBusCollision(t *testing.T) {
 			Target:    0x10,
 			Primary:   scanPrimary,
 			Secondary: scanSecondary,
-			Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			Data:      []byte{0x01, 'D', 'E', 'V', '0', '8', 0x05, 0x06, 0x07, 0x08},
 		},
 	}
 
@@ -137,7 +137,7 @@ func TestScanSkipsTimeoutAndNACK(t *testing.T) {
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				Data:      []byte{0x01, 'D', 'E', 'V', '0', '8', 0x05, 0x06, 0x07, 0x08},
 			},
 		},
 		errors: map[byte]error{
@@ -172,14 +172,14 @@ func TestScanSkipsContextDeadlineExceeded(t *testing.T) {
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				Data:      []byte{0x01, 'D', 'E', 'V', '0', '8', 0x05, 0x06, 0x07, 0x08},
 			},
 			0x09: {
 				Source:    0x09,
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11},
+				Data:      []byte{0x0A, 'D', 'E', 'V', '0', '9', 0x0E, 0x0F, 0x10, 0x11},
 			},
 		},
 		errors: map[byte]error{
@@ -265,7 +265,7 @@ func TestScanSkipsInvalidPayloadResponses(t *testing.T) {
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11},
+				Data:      []byte{0x0A, 'D', 'E', 'V', '0', '9', 0x0E, 0x0F, 0x10, 0x11},
 			},
 		},
 	}
@@ -296,7 +296,7 @@ func TestScanSkipsCRCMismatchAndFailsOnInvalidPayloadError(t *testing.T) {
 				Target:    0x10,
 				Primary:   scanPrimary,
 				Secondary: scanSecondary,
-				Data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				Data:      []byte{0x01, 'D', 'E', 'V', '0', '8', 0x05, 0x06, 0x07, 0x08},
 			},
 		},
 		errors: map[byte]error{


### PR DESCRIPTION
Fixes #38

- Parse scan (07/04) identification payload as MF(1) + ID(5) + SW(PIN=2) + HW(PIN=2) to match ebusd.
- Map manufacturer 0xB5 to "Vaillant" (unknown values kept as 0xNN).
- Add unit test coverage for a known Vaillant BAI00 payload.

Tests: `go test ./...`