### PR TITLE
vaillant/system: decode DateTime via BTI+BDA layout

### DIFF
--- a/router/vaillant_operational_data_test.go
+++ b/router/vaillant_operational_data_test.go
@@ -40,12 +40,14 @@ func TestVaillantSystem_GetOperationalData_DateTime(t *testing.T) {
 
 	payload := []byte{
 		0x01,       // dcfstate
-		0x12,       // hour (BCD 12)
+		0x56,       // second (BCD 56) [BTI is REV: SS,MM,HH]
 		0x34,       // minute (BCD 34)
-		0x03,       // day (BCD 03)
+		0x12,       // hour (BCD 12)
+		0x03,       // day (BCD 03) [BDA: DD,MM,<weekday>,YY]
 		0x02,       // month (BCD 02)
+		0x04,       // weekday (ignored)
 		0x26,       // year (BCD 26)
-		0x80, 0x14, // temp (DATA2b 20.5)
+		0x80, 0x14, // temp2 (DATA2b 20.5)
 	}
 
 	bus := &vaillantMockBus{

--- a/vaillant/system/operational_data.go
+++ b/vaillant/system/operational_data.go
@@ -134,34 +134,72 @@ func decodeOperationalWriteResponse(op byte, payload []byte) map[string]types.Va
 }
 
 func decodeOperationalDateTime(payload []byte) (map[string]types.Value, error) {
-	const expectedSize = 8
-	if len(payload) < expectedSize {
+	const legacySize = 8
+	const btiBdaSize = 10 // BTI (3 bytes) + BDA (4 bytes) + temp2 (2 bytes) + dcfstate
+
+	if len(payload) < legacySize {
 		return nil, fmt.Errorf("operational datetime short payload: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	hour, err := types.BCD{}.Decode(payload[1:2])
-	if err != nil {
-		return nil, fmt.Errorf("operational datetime hour: %w", err)
-	}
-	minute, err := types.BCD{}.Decode(payload[2:3])
-	if err != nil {
-		return nil, fmt.Errorf("operational datetime minute: %w", err)
-	}
-	day, err := types.BCD{}.Decode(payload[3:4])
-	if err != nil {
-		return nil, fmt.Errorf("operational datetime day: %w", err)
-	}
-	month, err := types.BCD{}.Decode(payload[4:5])
-	if err != nil {
-		return nil, fmt.Errorf("operational datetime month: %w", err)
-	}
-	year, err := types.BCD{}.Decode(payload[5:6])
-	if err != nil {
-		return nil, fmt.Errorf("operational datetime year: %w", err)
-	}
-	temp, err := types.DATA2b{}.Decode(payload[6:8])
-	if err != nil {
-		return nil, fmt.Errorf("operational datetime temp: %w", err)
+	var (
+		hour, minute, day, month, year types.Value
+		temp                          types.Value
+		err                           error
+	)
+	if len(payload) >= btiBdaSize {
+		// ebusd types:
+		// - BTI (24-bit, BCD|REV): wire order is SS,MM,HH
+		// - BDA (32-bit, BCD): DD,MM,<weekday>,YY
+		hour, err = types.BCD{}.Decode(payload[3:4])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime hour: %w", err)
+		}
+		minute, err = types.BCD{}.Decode(payload[2:3])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime minute: %w", err)
+		}
+		day, err = types.BCD{}.Decode(payload[4:5])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime day: %w", err)
+		}
+		month, err = types.BCD{}.Decode(payload[5:6])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime month: %w", err)
+		}
+		year, err = types.BCD{}.Decode(payload[7:8])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime year: %w", err)
+		}
+		temp, err = types.DATA2b{}.Decode(payload[8:10])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime temp: %w", err)
+		}
+	} else {
+		// Legacy layout (older configs): HH,MM,DD,MM,YY,temp2.
+		hour, err = types.BCD{}.Decode(payload[1:2])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime hour: %w", err)
+		}
+		minute, err = types.BCD{}.Decode(payload[2:3])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime minute: %w", err)
+		}
+		day, err = types.BCD{}.Decode(payload[3:4])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime day: %w", err)
+		}
+		month, err = types.BCD{}.Decode(payload[4:5])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime month: %w", err)
+		}
+		year, err = types.BCD{}.Decode(payload[5:6])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime year: %w", err)
+		}
+		temp, err = types.DATA2b{}.Decode(payload[6:8])
+		if err != nil {
+			return nil, fmt.Errorf("operational datetime temp: %w", err)
+		}
 	}
 
 	return map[string]types.Value{


### PR DESCRIPTION
Closes #40.

- Update `system.get_operational_data` (B5/04) `op=0x00` DateTime decoding to follow ebusd BTI+BDA layout:
  - BTI (3 bytes, BCD|REV): `SS,MM,HH`
  - BDA (4 bytes, BCD): `DD,MM,<weekday>,YY`
  - temp2 (2 bytes)
- Keep the legacy 8-byte layout as a fallback when payload length is shorter.

Tests:
- `go test ./...`
