### PR TITLE
Fix B524 ext-register opcode + response decode

### DIFF
--- a/router/vaillant_ext_register_access_test.go
+++ b/router/vaillant_ext_register_access_test.go
@@ -24,7 +24,7 @@ func TestVaillantSystem_GetExtRegister_RequestEncodesPayload(t *testing.T) {
 			Target:    0x10,
 			Primary:   0xB5,
 			Secondary: 0x24,
-			Data:      []byte{0x02, 0x00, 0x00, 0x00, 0xAA},
+			Data:      []byte{0x01, 0x00, 0x00, 0x5C, 0xAA},
 		},
 	}
 	eventRouter := router.NewBusEventRouter(bus)
@@ -39,8 +39,8 @@ func TestVaillantSystem_GetExtRegister_RequestEncodesPayload(t *testing.T) {
 		t.Fatalf("Invoke error = %v", err)
 	}
 
-	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0x00, 0x00, 0x00, 0x5C, 0x00}) {
-		t.Fatalf("unexpected request data %v; want [02 00 00 00 5c 00]", bus.lastRequest.Data)
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x5C}) {
+		t.Fatalf("unexpected request data %v; want [02 00 00 00 00 5c]", bus.lastRequest.Data)
 	}
 }
 
@@ -59,7 +59,7 @@ func TestVaillantSystem_GetExtRegister_ResponseDecode(t *testing.T) {
 				Target:    0x10,
 				Primary:   0xB5,
 				Secondary: 0x24,
-				Data:      []byte{0x02, 0x00, 0x00, 0x00, 0xAA, 0xBB},
+				Data:      []byte{0x01, 0x00, 0x00, 0x5C, 0xAA, 0xBB},
 			},
 		}
 		eventRouter := router.NewBusEventRouter(bus)
@@ -87,8 +87,20 @@ func TestVaillantSystem_GetExtRegister_ResponseDecode(t *testing.T) {
 		if got := values["addr_hex"]; !got.Valid || got.Value != "5C00" {
 			t.Fatalf("addr_hex = %+v; want 5C00 valid", got)
 		}
-		if got := values["prefix"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0x02, 0x00, 0x00, 0x00}) {
-			t.Fatalf("prefix = %+v; want [02 00 00 00] valid", got)
+		if got := values["prefix"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0x01, 0x00, 0x00, 0x5C}) {
+			t.Fatalf("prefix = %+v; want [01 00 00 5c] valid", got)
+		}
+		if got := values["reply_kind"]; !got.Valid || got.Value != byte(0x01) {
+			t.Fatalf("reply_kind = %+v; want 0x01 valid", got)
+		}
+		if got := values["reply_group"]; !got.Valid || got.Value != byte(0x00) {
+			t.Fatalf("reply_group = %+v; want 0x00 valid", got)
+		}
+		if got := values["reply_addr"]; !got.Valid || got.Value != uint16(0x5C00) {
+			t.Fatalf("reply_addr = %+v; want 0x5C00 valid", got)
+		}
+		if got := values["reply_addr_hex"]; !got.Valid || got.Value != "5C00" {
+			t.Fatalf("reply_addr_hex = %+v; want 5C00 valid", got)
 		}
 		if got := values["value"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0xAA, 0xBB}) {
 			t.Fatalf("value = %+v; want [aa bb] valid", got)
@@ -154,7 +166,7 @@ func TestVaillantSystem_SetExtRegister_SendsPayload(t *testing.T) {
 		t.Fatalf("Invoke error = %v", err)
 	}
 
-	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0x01, 0x00, 0x00, 0x5C, 0x00, 0xAA, 0xBB}) {
-		t.Fatalf("unexpected request data %v; want [02 01 00 00 5c 00 aa bb]", bus.lastRequest.Data)
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x02, 0x01, 0x00, 0x00, 0x00, 0x5C, 0xAA, 0xBB}) {
+		t.Fatalf("unexpected request data %v; want [02 01 00 00 00 5c aa bb]", bus.lastRequest.Data)
 	}
 }

--- a/vaillant/system/b524_ext_register_access.go
+++ b/vaillant/system/b524_ext_register_access.go
@@ -13,9 +13,10 @@ const (
 )
 
 const (
-	extRegisterCmdRead  = byte(0x00)
-	extRegisterCmdWrite = byte(0x01)
-	extRegisterPrefix   = byte(0x02)
+	extRegisterOpLocal  = byte(0x02)
+	extRegisterOpRemote = byte(0x06)
+	extRegisterOpRead   = byte(0x00)
+	extRegisterOpWrite  = byte(0x01)
 )
 
 type extRegisterReadTemplate struct {
@@ -36,6 +37,10 @@ func (template extRegisterReadTemplate) Build(params map[string]any) ([]byte, er
 		return nil, fmt.Errorf("ext register read template missing params: %w", ebuserrors.ErrInvalidPayload)
 	}
 
+	opcode, err := extRegisterOpcode(params)
+	if err != nil {
+		return nil, fmt.Errorf("ext register read template opcode: %w", err)
+	}
 	group, ok := uint8Param(params, "group")
 	if !ok {
 		return nil, fmt.Errorf("ext register read template group: %w", ebuserrors.ErrInvalidPayload)
@@ -52,7 +57,7 @@ func (template extRegisterReadTemplate) Build(params map[string]any) ([]byte, er
 		return nil, fmt.Errorf("ext register read template addr: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	return []byte{extRegisterPrefix, extRegisterCmdRead, group, instance, byte(addr >> 8), byte(addr)}, nil
+	return []byte{opcode, extRegisterOpRead, group, instance, byte(addr), byte(addr >> 8)}, nil
 }
 
 type extRegisterWriteTemplate struct {
@@ -73,6 +78,10 @@ func (template extRegisterWriteTemplate) Build(params map[string]any) ([]byte, e
 		return nil, fmt.Errorf("ext register write template missing params: %w", ebuserrors.ErrInvalidPayload)
 	}
 
+	opcode, err := extRegisterOpcode(params)
+	if err != nil {
+		return nil, fmt.Errorf("ext register write template opcode: %w", err)
+	}
 	group, ok := uint8Param(params, "group")
 	if !ok {
 		return nil, fmt.Errorf("ext register write template group: %w", ebuserrors.ErrInvalidPayload)
@@ -105,14 +114,15 @@ func (template extRegisterWriteTemplate) Build(params map[string]any) ([]byte, e
 	}
 
 	payload := make([]byte, 0, 6+len(data))
-	payload = append(payload, extRegisterPrefix, extRegisterCmdWrite, group, instance, byte(addr>>8), byte(addr))
+	payload = append(payload, opcode, extRegisterOpWrite, group, instance, byte(addr), byte(addr>>8))
 	payload = append(payload, data...)
 	return payload, nil
 }
 
-func decodeExtRegisterResponse(cmd byte, group, instance byte, addr uint16, payload []byte) map[string]types.Value {
+func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr uint16, payload []byte) map[string]types.Value {
 	values := map[string]types.Value{
-		"cmd":      {Value: cmd, Valid: true},
+		"optype":   {Value: cmd, Valid: true},
+		"opcode":   {Value: opcode, Valid: true},
 		"group":    {Value: group, Valid: true},
 		"instance": {Value: instance, Valid: true},
 		"addr":     {Value: addr, Valid: true},
@@ -122,8 +132,19 @@ func decodeExtRegisterResponse(cmd byte, group, instance byte, addr uint16, payl
 
 	if len(payload) >= 4 {
 		values["prefix"] = types.Value{Value: append([]byte(nil), payload[:4]...), Valid: true}
+		replyGroup := payload[1]
+		replyAddr := uint16(payload[3])<<8 | uint16(payload[2])
+		values["reply_group"] = types.Value{Value: replyGroup, Valid: true}
+		values["reply_addr"] = types.Value{Value: replyAddr, Valid: true}
+		values["reply_addr_hex"] = types.Value{Value: fmt.Sprintf("%04X", replyAddr), Valid: true}
 	} else {
 		values["prefix"] = types.Value{Valid: false}
+	}
+
+	if len(payload) >= 1 {
+		values["reply_kind"] = types.Value{Value: payload[0], Valid: true}
+	} else {
+		values["reply_kind"] = types.Value{Valid: false}
 	}
 
 	if len(payload) == 1 && payload[0] == 0x00 {
@@ -137,4 +158,23 @@ func decodeExtRegisterResponse(cmd byte, group, instance byte, addr uint16, payl
 
 	values["value"] = types.Value{Value: append([]byte(nil), payload[4:]...), Valid: true}
 	return values
+}
+
+func extRegisterOpcode(params map[string]any) (byte, error) {
+	if params == nil {
+		return extRegisterOpLocal, nil
+	}
+	if opcode, ok := uint8Param(params, "opcode"); ok {
+		if opcode != extRegisterOpLocal && opcode != extRegisterOpRemote {
+			return 0, ebuserrors.ErrInvalidPayload
+		}
+		return opcode, nil
+	}
+	if opcode, ok := uint8Param(params, "op"); ok {
+		if opcode != extRegisterOpLocal && opcode != extRegisterOpRemote {
+			return 0, ebuserrors.ErrInvalidPayload
+		}
+		return opcode, nil
+	}
+	return extRegisterOpLocal, nil
 }

--- a/vaillant/system/router_plane.go
+++ b/vaillant/system/router_plane.go
@@ -115,6 +115,10 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 		if !ok {
 			return nil, fmt.Errorf("system DecodeResponse instance: %w", ebuserrors.ErrInvalidPayload)
 		}
+		opcode, err := extRegisterOpcode(params)
+		if err != nil {
+			return nil, fmt.Errorf("system DecodeResponse opcode: %w", err)
+		}
 		addr, ok, err := registerAddrParam(params, "addr")
 		if err != nil {
 			return nil, fmt.Errorf("system DecodeResponse addr: %w", err)
@@ -122,7 +126,7 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 		if !ok {
 			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
 		}
-		return decodeExtRegisterResponse(extRegisterCmdRead, group, instance, addr, response.Data), nil
+		return decodeExtRegisterResponse(extRegisterOpRead, opcode, group, instance, addr, response.Data), nil
 	case methodSetExtRegister:
 		group, ok := uint8Param(params, "group")
 		if !ok {
@@ -132,6 +136,10 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 		if !ok {
 			return nil, fmt.Errorf("system DecodeResponse instance: %w", ebuserrors.ErrInvalidPayload)
 		}
+		opcode, err := extRegisterOpcode(params)
+		if err != nil {
+			return nil, fmt.Errorf("system DecodeResponse opcode: %w", err)
+		}
 		addr, ok, err := registerAddrParam(params, "addr")
 		if err != nil {
 			return nil, fmt.Errorf("system DecodeResponse addr: %w", err)
@@ -139,7 +147,7 @@ func (plane *plane) DecodeResponse(method registry.Method, response protocol.Fra
 		if !ok {
 			return nil, fmt.Errorf("system DecodeResponse addr: %w", ebuserrors.ErrInvalidPayload)
 		}
-		return decodeExtRegisterResponse(extRegisterCmdWrite, group, instance, addr, response.Data), nil
+		return decodeExtRegisterResponse(extRegisterOpWrite, opcode, group, instance, addr, response.Data), nil
 	default:
 		return nil, fmt.Errorf("system DecodeResponse unknown method %q: %w", method.Name(), ebuserrors.ErrInvalidPayload)
 	}


### PR DESCRIPTION
Fixes #49.

- Encode B524 ext-register payloads with opcode/optype + RR little-endian.
- Decode reply header fields (kind/group/addr) and expose in response map.
- Support opcode selection (0x02/0x06).

Tests: 