### PR TITLE
Issue #50: projection graph core

### DIFF
--- a/registry/projection.go
+++ b/registry/projection.go
@@ -1,0 +1,207 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const ServicePlane = "Service"
+
+var (
+	ErrProjectionInvalidPlane   = errors.New("projection: invalid plane")
+	ErrProjectionInvalidSegment = errors.New("projection: invalid path segment")
+	ErrProjectionInvalidPath    = errors.New("projection: invalid path")
+	ErrProjectionInvalidNode    = errors.New("projection: invalid node")
+	ErrProjectionInvalidEdge    = errors.New("projection: invalid edge")
+)
+
+type PathSegment struct {
+	Name     string
+	Location bool
+}
+
+func (segment PathSegment) String() string {
+	if segment.Location {
+		return "@" + segment.Name
+	}
+	return segment.Name
+}
+
+func (segment PathSegment) validate() error {
+	if strings.TrimSpace(segment.Name) == "" {
+		return ErrProjectionInvalidSegment
+	}
+	if strings.ContainsAny(segment.Name, "/:") {
+		return ErrProjectionInvalidSegment
+	}
+	if strings.HasPrefix(segment.Name, "@") {
+		return ErrProjectionInvalidSegment
+	}
+	return nil
+}
+
+type ProjectionPath struct {
+	Plane    string
+	Segments []PathSegment
+}
+
+func (path ProjectionPath) String() string {
+	if path.Plane == "" {
+		return ""
+	}
+	builder := strings.Builder{}
+	builder.WriteString(path.Plane)
+	builder.WriteString(":/")
+	for index, segment := range path.Segments {
+		if index > 0 {
+			builder.WriteString("/")
+		}
+		builder.WriteString(segment.String())
+	}
+	return builder.String()
+}
+
+func (path ProjectionPath) Validate() error {
+	if strings.TrimSpace(path.Plane) == "" {
+		return ErrProjectionInvalidPlane
+	}
+	if strings.ContainsAny(path.Plane, "/:") {
+		return ErrProjectionInvalidPlane
+	}
+	for index, segment := range path.Segments {
+		if err := segment.validate(); err != nil {
+			return fmt.Errorf("segment %d: %w", index, errors.Join(err, ErrProjectionInvalidPath))
+		}
+	}
+	return nil
+}
+
+type NodeID string
+type EdgeID string
+
+type Node struct {
+	ID            NodeID
+	Path          ProjectionPath
+	CanonicalPath ProjectionPath
+}
+
+func StableNodeID(canonical ProjectionPath) (NodeID, error) {
+	if err := canonical.Validate(); err != nil {
+		return "", fmt.Errorf("canonical path: %w", err)
+	}
+	if canonical.Plane != ServicePlane {
+		return "", fmt.Errorf("canonical plane %q: %w", canonical.Plane, ErrProjectionInvalidNode)
+	}
+	return NodeID(canonical.String()), nil
+}
+
+func NewNode(path ProjectionPath, canonical ProjectionPath) (Node, error) {
+	if err := path.Validate(); err != nil {
+		return Node{}, fmt.Errorf("path: %w", err)
+	}
+	id, err := StableNodeID(canonical)
+	if err != nil {
+		return Node{}, err
+	}
+	if path.Plane == ServicePlane && path.String() != canonical.String() {
+		return Node{}, fmt.Errorf("service path mismatch: %w", ErrProjectionInvalidNode)
+	}
+	return Node{
+		ID:            id,
+		Path:          path,
+		CanonicalPath: canonical,
+	}, nil
+}
+
+type Edge struct {
+	ID   EdgeID
+	From NodeID
+	To   NodeID
+}
+
+func StableEdgeID(plane string, from NodeID, to NodeID) (EdgeID, error) {
+	if strings.TrimSpace(plane) == "" || strings.ContainsAny(plane, "/:") {
+		return "", ErrProjectionInvalidPlane
+	}
+	if from == "" || to == "" {
+		return "", ErrProjectionInvalidEdge
+	}
+	return EdgeID(fmt.Sprintf("%s:%s->%s", plane, from, to)), nil
+}
+
+func NewEdge(plane string, from NodeID, to NodeID) (Edge, error) {
+	id, err := StableEdgeID(plane, from, to)
+	if err != nil {
+		return Edge{}, err
+	}
+	return Edge{ID: id, From: from, To: to}, nil
+}
+
+type Projection struct {
+	Plane string
+	Nodes []Node
+	Edges []Edge
+}
+
+func NewProjection(plane string, nodes []Node, edges []Edge) (Projection, error) {
+	projection := Projection{Plane: plane, Nodes: nodes, Edges: edges}
+	if err := projection.Validate(); err != nil {
+		return Projection{}, err
+	}
+	return projection, nil
+}
+
+func (projection Projection) Validate() error {
+	if strings.TrimSpace(projection.Plane) == "" || strings.ContainsAny(projection.Plane, "/:") {
+		return ErrProjectionInvalidPlane
+	}
+
+	paths := make(map[string]struct{}, len(projection.Nodes))
+	nodesByID := make(map[NodeID]ProjectionPath, len(projection.Nodes))
+	for index, node := range projection.Nodes {
+		if node.ID == "" {
+			return fmt.Errorf("node %d missing id: %w", index, ErrProjectionInvalidNode)
+		}
+		if err := node.Path.Validate(); err != nil {
+			return fmt.Errorf("node %d path: %w", index, err)
+		}
+		if node.Path.Plane != projection.Plane {
+			return fmt.Errorf("node %d plane %q: %w", index, node.Path.Plane, ErrProjectionInvalidNode)
+		}
+		if err := node.CanonicalPath.Validate(); err != nil {
+			return fmt.Errorf("node %d canonical: %w", index, err)
+		}
+		if node.CanonicalPath.Plane != ServicePlane {
+			return fmt.Errorf("node %d canonical plane %q: %w", index, node.CanonicalPath.Plane, ErrProjectionInvalidNode)
+		}
+		pathKey := node.Path.String()
+		if _, ok := paths[pathKey]; ok {
+			return fmt.Errorf("duplicate path %q: %w", pathKey, ErrProjectionInvalidNode)
+		}
+		paths[pathKey] = struct{}{}
+		if existing, ok := nodesByID[node.ID]; ok {
+			if existing.String() != node.CanonicalPath.String() {
+				return fmt.Errorf("node %d id collision: %w", index, ErrProjectionInvalidNode)
+			}
+		} else {
+			nodesByID[node.ID] = node.CanonicalPath
+		}
+	}
+
+	for index, edge := range projection.Edges {
+		if edge.ID == "" {
+			return fmt.Errorf("edge %d missing id: %w", index, ErrProjectionInvalidEdge)
+		}
+		if edge.From == "" || edge.To == "" {
+			return fmt.Errorf("edge %d missing endpoints: %w", index, ErrProjectionInvalidEdge)
+		}
+		if _, ok := nodesByID[edge.From]; !ok {
+			return fmt.Errorf("edge %d missing from node: %w", index, ErrProjectionInvalidEdge)
+		}
+		if _, ok := nodesByID[edge.To]; !ok {
+			return fmt.Errorf("edge %d missing to node: %w", index, ErrProjectionInvalidEdge)
+		}
+	}
+	return nil
+}

--- a/registry/projection_test.go
+++ b/registry/projection_test.go
@@ -1,0 +1,165 @@
+package registry
+
+import "testing"
+
+func TestProjectionPath_StringAndValidate(t *testing.T) {
+	path := ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "zone1", Location: true},
+		},
+	}
+
+	if got := path.String(); got != "Observability:/devices/boiler/@zone1" {
+		t.Fatalf("unexpected path string: %s", got)
+	}
+	if err := path.Validate(); err != nil {
+		t.Fatalf("unexpected validate error: %v", err)
+	}
+
+	invalid := []ProjectionPath{
+		{Plane: "", Segments: []PathSegment{{Name: "devices"}}},
+		{Plane: "Bad/Plane", Segments: []PathSegment{{Name: "devices"}}},
+		{Plane: "Bad:Plane", Segments: []PathSegment{{Name: "devices"}}},
+		{Plane: "Service", Segments: []PathSegment{{Name: ""}}},
+		{Plane: "Service", Segments: []PathSegment{{Name: "bad/seg"}}},
+		{Plane: "Service", Segments: []PathSegment{{Name: "bad:seg"}}},
+		{Plane: "Service", Segments: []PathSegment{{Name: "@loc"}}},
+	}
+
+	for index, candidate := range invalid {
+		if err := candidate.Validate(); err == nil {
+			t.Fatalf("expected error for invalid path %d", index)
+		}
+	}
+}
+
+func TestStableNodeID_UsesServicePlane(t *testing.T) {
+	service := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	id, err := StableNodeID(service)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != NodeID("Service:/devices/boiler") {
+		t.Fatalf("unexpected id: %s", id)
+	}
+
+	nonService := ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+		},
+	}
+	if _, err := StableNodeID(nonService); err == nil {
+		t.Fatalf("expected error for non-service canonical path")
+	}
+}
+
+func TestNewNode_ServicePathInvariant(t *testing.T) {
+	canonical := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	path := ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	node, err := NewNode(path, canonical)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.ID != NodeID(canonical.String()) {
+		t.Fatalf("unexpected id: %s", node.ID)
+	}
+
+	if _, err := NewNode(ProjectionPath{Plane: ServicePlane, Segments: []PathSegment{{Name: "other"}}}, canonical); err == nil {
+		t.Fatalf("expected error for service path mismatch")
+	}
+}
+
+func TestProjection_ValidatesPathsAndEdges(t *testing.T) {
+	canonicalA := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "temp"},
+		},
+	}
+	canonicalB := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+
+	nodeA, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "temp"},
+		},
+	}, canonicalA)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+
+	nodeB, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}, canonicalB)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+
+	edge, err := NewEdge("Observability", nodeA.ID, nodeB.ID)
+	if err != nil {
+		t.Fatalf("unexpected edge error: %v", err)
+	}
+
+	projection, err := NewProjection("Observability", []Node{nodeA, nodeB}, []Edge{edge})
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+	if projection.Plane != "Observability" {
+		t.Fatalf("unexpected projection plane: %s", projection.Plane)
+	}
+
+	duplicatePath := projection
+	duplicatePath.Nodes = append(duplicatePath.Nodes, nodeA)
+	if err := duplicatePath.Validate(); err == nil {
+		t.Fatalf("expected error for duplicate path")
+	}
+
+	missingEdge := Projection{
+		Plane: "Observability",
+		Nodes: []Node{nodeA},
+		Edges: []Edge{
+			{ID: "Observability:missing->missing", From: "missing", To: "missing"},
+		},
+	}
+	if err := missingEdge.Validate(); err == nil {
+		t.Fatalf("expected error for missing edge nodes")
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -25,6 +25,7 @@ type DeviceEntry interface {
 	SoftwareVersion() string
 	HardwareVersion() string
 	Planes() []Plane
+	Projections() []Projection
 }
 
 type Plane interface {
@@ -36,6 +37,10 @@ type PlaneProvider interface {
 	Name() string
 	Match(info DeviceInfo) bool
 	CreatePlanes(info DeviceInfo) []Plane
+}
+
+type ProjectionProvider interface {
+	CreateProjections(info DeviceInfo, planes []Plane) []Projection
 }
 
 type Method interface {
@@ -79,15 +84,27 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	r.mu.RUnlock()
 
 	planes := make([]Plane, 0)
+	matched := make([]PlaneProvider, 0, len(providers))
 	for _, provider := range providers {
 		if provider.Match(info) {
+			matched = append(matched, provider)
 			planes = append(planes, provider.CreatePlanes(info)...)
 		}
 	}
 
+	projections := make([]Projection, 0)
+	for _, provider := range matched {
+		projectionProvider, ok := provider.(ProjectionProvider)
+		if !ok {
+			continue
+		}
+		projections = append(projections, projectionProvider.CreateProjections(info, planes)...)
+	}
+
 	entry := &deviceEntry{
-		info:   info,
-		planes: planes,
+		info:        info,
+		planes:      planes,
+		projections: projections,
 	}
 
 	r.mu.Lock()
@@ -132,8 +149,9 @@ func (r *DeviceRegistry) Iterate(fn func(DeviceEntry) bool) {
 }
 
 type deviceEntry struct {
-	info   DeviceInfo
-	planes []Plane
+	info        DeviceInfo
+	planes      []Plane
+	projections []Projection
 }
 
 func (d *deviceEntry) Address() byte {
@@ -166,4 +184,8 @@ func (d *deviceEntry) HardwareVersion() string {
 
 func (d *deviceEntry) Planes() []Plane {
 	return d.planes
+}
+
+func (d *deviceEntry) Projections() []Projection {
+	return d.projections
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -73,6 +73,15 @@ func (p mockProvider) CreatePlanes(info DeviceInfo) []Plane {
 	return p.planes
 }
 
+type mockProjectionProvider struct {
+	mockProvider
+	projections []Projection
+}
+
+func (p mockProjectionProvider) CreateProjections(info DeviceInfo, planes []Plane) []Projection {
+	return p.projections
+}
+
 type countingProvider struct {
 	name        string
 	matchFn     func(DeviceInfo) bool
@@ -177,6 +186,46 @@ func TestDeviceRegistry_RegisterLookupIterate(t *testing.T) {
 	}
 	if addresses[0] != 0x08 || addresses[1] != 0x10 {
 		t.Fatalf("unexpected iteration order: %v", addresses)
+	}
+}
+
+func TestDeviceRegistry_Projections(t *testing.T) {
+	path := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	node, err := NewNode(path, path)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+	projection, err := NewProjection(ServicePlane, []Node{node}, nil)
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+
+	provider := mockProjectionProvider{
+		mockProvider: mockProvider{
+			name:  "projection",
+			match: func(info DeviceInfo) bool { return info.Address == 0x08 },
+			planes: []Plane{
+				mockPlane{name: "heating"},
+			},
+		},
+		projections: []Projection{projection},
+	}
+
+	registry := NewDeviceRegistry([]PlaneProvider{provider})
+	entry := registry.Register(DeviceInfo{Address: 0x08})
+
+	projections := entry.Projections()
+	if len(projections) != 1 {
+		t.Fatalf("expected 1 projection, got %d", len(projections))
+	}
+	if projections[0].Plane != ServicePlane {
+		t.Fatalf("unexpected projection plane: %s", projections[0].Plane)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add projection graph core types and validation (plane-qualified paths, stable IDs, per-plane uniqueness)
- add projection providers and expose projections on device entries
- add unit tests for projection invariants and registry exposure

## Testing
- go test ./...

## Issue
Closes #50

## Smoke Test
Smoke test required: NO (per issue #50)