### PR TITLE
RFE: Vaillant projection mapping (system/observability/debug)

### DIFF
--- a/vaillant/system/b524_profile.go
+++ b/vaillant/system/b524_profile.go
@@ -1,0 +1,21 @@
+package system
+
+type B524GroupProfile struct {
+	Group       byte
+	Opcode      byte
+	InstanceMax byte
+	RegisterMax uint16
+}
+
+const (
+	B524OpcodeLocal  = byte(0x02)
+	B524OpcodeRemote = byte(0x06)
+)
+
+var B524DiscoveryProfiles = []B524GroupProfile{
+	{Group: 0x02, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x0021},
+	{Group: 0x03, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x002F},
+	{Group: 0x09, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x002F},
+	{Group: 0x0A, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x003F},
+	{Group: 0x0C, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x003F},
+}

--- a/vaillant/system/b524_profile_test.go
+++ b/vaillant/system/b524_profile_test.go
@@ -1,0 +1,36 @@
+package system
+
+import "testing"
+
+func TestB524DiscoveryProfiles(t *testing.T) {
+	t.Parallel()
+
+	profiles := map[byte]B524GroupProfile{}
+	for _, profile := range B524DiscoveryProfiles {
+		profiles[profile.Group] = profile
+	}
+
+	assertProfile(t, profiles, 0x02, B524OpcodeLocal, 0x0A, 0x0021)
+	assertProfile(t, profiles, 0x03, B524OpcodeLocal, 0x0A, 0x002F)
+	assertProfile(t, profiles, 0x09, B524OpcodeRemote, 0x0A, 0x002F)
+	assertProfile(t, profiles, 0x0A, B524OpcodeRemote, 0x0A, 0x003F)
+	assertProfile(t, profiles, 0x0C, B524OpcodeRemote, 0x0A, 0x003F)
+}
+
+func assertProfile(t *testing.T, profiles map[byte]B524GroupProfile, group, opcode, instanceMax byte, registerMax uint16) {
+	t.Helper()
+
+	profile, ok := profiles[group]
+	if !ok {
+		t.Fatalf("missing profile for group 0x%02X", group)
+	}
+	if profile.Opcode != opcode {
+		t.Fatalf("group 0x%02X opcode = 0x%02X, want 0x%02X", group, profile.Opcode, opcode)
+	}
+	if profile.InstanceMax != instanceMax {
+		t.Fatalf("group 0x%02X instance max = 0x%02X, want 0x%02X", group, profile.InstanceMax, instanceMax)
+	}
+	if profile.RegisterMax != registerMax {
+		t.Fatalf("group 0x%02X register max = 0x%04X, want 0x%04X", group, profile.RegisterMax, registerMax)
+	}
+}

--- a/vaillant/system/projections.go
+++ b/vaillant/system/projections.go
@@ -1,0 +1,192 @@
+package system
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/d3vi1/helianthus-ebusreg/registry"
+)
+
+const (
+	projectionPlaneObservability = "Observability"
+	projectionPlaneDebug         = "Debug"
+	projectionPlaneSystem        = "System"
+	projectionPlaneHeating       = "Heating"
+	projectionPlaneDHW           = "DHW"
+	projectionPlaneSolar         = "Solar"
+)
+
+func (Provider) CreateProjections(info registry.DeviceInfo, planes []registry.Plane) []registry.Projection {
+	if !shouldCreateProjections(info) {
+		return nil
+	}
+
+	base := projectionBaseSegments(info)
+	canonicalRoot := registry.ProjectionPath{Plane: registry.ServicePlane, Segments: base}
+
+	rootService, ok := newNode(registry.ServicePlane, base, canonicalRoot)
+	if !ok {
+		return nil
+	}
+	rootObservability, ok := newNode(projectionPlaneObservability, base, canonicalRoot)
+	if !ok {
+		return nil
+	}
+	rootDebug, ok := newNode(projectionPlaneDebug, base, canonicalRoot)
+	if !ok {
+		return nil
+	}
+
+	operationalCanonical := registry.ProjectionPath{
+		Plane:    registry.ServicePlane,
+		Segments: appendSegment(base, methodSegment(methodGetOperationalData)),
+	}
+	operationalService, ok := newNode(registry.ServicePlane, operationalCanonical.Segments, operationalCanonical)
+	if !ok {
+		return nil
+	}
+	operationalObservability, ok := newNode(projectionPlaneObservability, operationalCanonical.Segments, operationalCanonical)
+	if !ok {
+		return nil
+	}
+
+	registerCanonical := registry.ProjectionPath{
+		Plane:    registry.ServicePlane,
+		Segments: appendSegment(base, methodSegment(methodGetRegister)),
+	}
+	registerDebug, ok := newNode(projectionPlaneDebug, appendSegment(base, registry.PathSegment{Name: "register@b509"}), registerCanonical)
+	if !ok {
+		return nil
+	}
+
+	extRegisterCanonical := registry.ProjectionPath{
+		Plane:    registry.ServicePlane,
+		Segments: appendSegment(base, methodSegment(methodGetExtRegister)),
+	}
+	extRegisterDebug, ok := newNode(projectionPlaneDebug, appendSegment(base, registry.PathSegment{Name: "register@b524"}), extRegisterCanonical)
+	if !ok {
+		return nil
+	}
+
+	projections := make([]registry.Projection, 0, 7)
+
+	serviceEdges := make([]registry.Edge, 0, 1)
+	if edge, err := registry.NewEdge(registry.ServicePlane, rootService.ID, operationalService.ID); err == nil {
+		serviceEdges = append(serviceEdges, edge)
+	}
+	if projection, err := registry.NewProjection(registry.ServicePlane, []registry.Node{rootService, operationalService}, serviceEdges); err == nil {
+		projections = append(projections, projection)
+	}
+
+	observabilityEdges := make([]registry.Edge, 0, 1)
+	if edge, err := registry.NewEdge(projectionPlaneObservability, rootObservability.ID, operationalObservability.ID); err == nil {
+		observabilityEdges = append(observabilityEdges, edge)
+	}
+	if projection, err := registry.NewProjection(projectionPlaneObservability, []registry.Node{rootObservability, operationalObservability}, observabilityEdges); err == nil {
+		projections = append(projections, projection)
+	}
+
+	debugEdges := make([]registry.Edge, 0, 2)
+	if edge, err := registry.NewEdge(projectionPlaneDebug, rootDebug.ID, registerDebug.ID); err == nil {
+		debugEdges = append(debugEdges, edge)
+	}
+	if edge, err := registry.NewEdge(projectionPlaneDebug, rootDebug.ID, extRegisterDebug.ID); err == nil {
+		debugEdges = append(debugEdges, edge)
+	}
+	if projection, err := registry.NewProjection(projectionPlaneDebug, []registry.Node{rootDebug, registerDebug, extRegisterDebug}, debugEdges); err == nil {
+		projections = append(projections, projection)
+	}
+
+	planeSet := planeNameSet(planes)
+	projections = append(projections, rootProjectionIfPresent(planeSet, projectionPlaneSystem, canonicalRoot, base)...)
+	projections = append(projections, rootProjectionIfPresent(planeSet, projectionPlaneHeating, canonicalRoot, base)...)
+	projections = append(projections, rootProjectionIfPresent(planeSet, projectionPlaneDHW, canonicalRoot, base)...)
+	projections = append(projections, rootProjectionIfPresent(planeSet, projectionPlaneSolar, canonicalRoot, base)...)
+
+	return projections
+}
+
+func rootProjectionIfPresent(planes map[string]struct{}, plane string, canonical registry.ProjectionPath, base []registry.PathSegment) []registry.Projection {
+	if _, ok := planes[strings.ToLower(plane)]; !ok {
+		return nil
+	}
+
+	node, ok := newNode(plane, base, canonical)
+	if !ok {
+		return nil
+	}
+	projection, err := registry.NewProjection(plane, []registry.Node{node}, nil)
+	if err != nil {
+		return nil
+	}
+	return []registry.Projection{projection}
+}
+
+func planeNameSet(planes []registry.Plane) map[string]struct{} {
+	out := make(map[string]struct{}, len(planes))
+	for _, plane := range planes {
+		if plane == nil {
+			continue
+		}
+		name := strings.TrimSpace(plane.Name())
+		if name == "" {
+			continue
+		}
+		out[strings.ToLower(name)] = struct{}{}
+	}
+	return out
+}
+
+func shouldCreateProjections(info registry.DeviceInfo) bool {
+	normalized := normalizeDeviceID(info.DeviceID)
+	switch normalized {
+	case "BASV2", "BAI00", "VR71":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeDeviceID(id string) string {
+	if strings.TrimSpace(id) == "" {
+		return ""
+	}
+	normalized := strings.ToUpper(strings.TrimSpace(id))
+	normalized = strings.ReplaceAll(normalized, "_", "")
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	normalized = strings.ReplaceAll(normalized, "-", "")
+	return normalized
+}
+
+func projectionBaseSegments(info registry.DeviceInfo) []registry.PathSegment {
+	addr := fmt.Sprintf("%02X", info.Address)
+	deviceID := strings.TrimSpace(info.DeviceID)
+	if deviceID == "" {
+		deviceID = addr
+	}
+	return []registry.PathSegment{
+		{Name: "ebus"},
+		{Name: fmt.Sprintf("addr@%s", addr)},
+		{Name: fmt.Sprintf("device@%s", deviceID)},
+	}
+}
+
+func methodSegment(name string) registry.PathSegment {
+	return registry.PathSegment{Name: "method@" + name}
+}
+
+func appendSegment(segments []registry.PathSegment, segment registry.PathSegment) []registry.PathSegment {
+	out := make([]registry.PathSegment, 0, len(segments)+1)
+	out = append(out, segments...)
+	out = append(out, segment)
+	return out
+}
+
+func newNode(plane string, segments []registry.PathSegment, canonical registry.ProjectionPath) (registry.Node, bool) {
+	path := registry.ProjectionPath{Plane: plane, Segments: segments}
+	node, err := registry.NewNode(path, canonical)
+	if err != nil {
+		return registry.Node{}, false
+	}
+	return node, true
+}

--- a/vaillant/system/projections_test.go
+++ b/vaillant/system/projections_test.go
@@ -1,0 +1,92 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebusreg/registry"
+)
+
+func TestCreateProjections_BASV2(t *testing.T) {
+	t.Parallel()
+
+	info := registry.DeviceInfo{
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		Address:      0x10,
+	}
+	planes := NewProvider().CreatePlanes(info)
+	projections := NewProvider().CreateProjections(info, planes)
+
+	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@10/device@BASV2/method@get_operational_data") {
+		t.Fatalf("missing Service operational node")
+	}
+	if !hasNodePath(projections, "Observability", "Observability:/ebus/addr@10/device@BASV2/method@get_operational_data") {
+		t.Fatalf("missing Observability operational node")
+	}
+	if !hasNodePath(projections, "Debug", "Debug:/ebus/addr@10/device@BASV2/register@b509") {
+		t.Fatalf("missing Debug b509 node")
+	}
+	if !hasNodePath(projections, "Debug", "Debug:/ebus/addr@10/device@BASV2/register@b524") {
+		t.Fatalf("missing Debug b524 node")
+	}
+}
+
+func TestCreateProjections_BAI00(t *testing.T) {
+	t.Parallel()
+
+	info := registry.DeviceInfo{
+		Manufacturer: "Vaillant",
+		DeviceID:     "BAI00",
+		Address:      0x08,
+	}
+	planes := NewProvider().CreatePlanes(info)
+	projections := NewProvider().CreateProjections(info, planes)
+
+	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@08/device@BAI00/method@get_operational_data") {
+		t.Fatalf("missing Service operational node")
+	}
+	if !hasNodePath(projections, "Observability", "Observability:/ebus/addr@08/device@BAI00/method@get_operational_data") {
+		t.Fatalf("missing Observability operational node")
+	}
+	if !hasNodePath(projections, "Debug", "Debug:/ebus/addr@08/device@BAI00/register@b509") {
+		t.Fatalf("missing Debug b509 node")
+	}
+	if !hasNodePath(projections, "Debug", "Debug:/ebus/addr@08/device@BAI00/register@b524") {
+		t.Fatalf("missing Debug b524 node")
+	}
+}
+
+func TestCreateProjections_DeviceFilter(t *testing.T) {
+	t.Parallel()
+
+	info := registry.DeviceInfo{
+		Manufacturer: "Vaillant",
+		DeviceID:     "VRC720",
+		Address:      0x10,
+	}
+	planes := NewProvider().CreatePlanes(info)
+	projections := NewProvider().CreateProjections(info, planes)
+	if len(projections) != 0 {
+		t.Fatalf("expected no projections, got %d", len(projections))
+	}
+
+	info.DeviceID = "VR_71"
+	projections = NewProvider().CreateProjections(info, planes)
+	if len(projections) == 0 {
+		t.Fatalf("expected projections for VR_71")
+	}
+}
+
+func hasNodePath(projections []registry.Projection, plane string, path string) bool {
+	for _, projection := range projections {
+		if projection.Plane != plane {
+			continue
+		}
+		for _, node := range projection.Nodes {
+			if node.Path.String() == path {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add Vaillant projection graph creation for BASV2/BAI00/VR71 using Service path convention
- include Debug nodes for B5 09 and B5 24 register access
- add B524 discovery profile metadata constants (vrc-explorer heuristics)
- add unit tests for projections and profiles

## Testing
- go test ./...

Closes #51