### PR TITLE
Add cross-plane projection invariants

### DIFF
--- a/registry/projection.go
+++ b/registry/projection.go
@@ -144,12 +144,128 @@ type Projection struct {
 	Edges []Edge
 }
 
+type CanonicalIndex struct {
+	canonicalByID map[NodeID]ProjectionPath
+	planePaths    map[string]map[NodeID]ProjectionPath
+}
+
+func (index CanonicalIndex) Canonical(id NodeID) (ProjectionPath, bool) {
+	if index.canonicalByID == nil {
+		return ProjectionPath{}, false
+	}
+	path, ok := index.canonicalByID[id]
+	return path, ok
+}
+
+func (index CanonicalIndex) PlanePath(plane string, id NodeID) (ProjectionPath, bool) {
+	if index.planePaths == nil {
+		return ProjectionPath{}, false
+	}
+	planeMap, ok := index.planePaths[plane]
+	if !ok {
+		return ProjectionPath{}, false
+	}
+	path, ok := planeMap[id]
+	return path, ok
+}
+
+func (index CanonicalIndex) PlanePaths(id NodeID) map[string]ProjectionPath {
+	if index.planePaths == nil {
+		return nil
+	}
+	out := make(map[string]ProjectionPath)
+	for plane, planeMap := range index.planePaths {
+		if path, ok := planeMap[id]; ok {
+			out[plane] = path
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func NewProjection(plane string, nodes []Node, edges []Edge) (Projection, error) {
 	projection := Projection{Plane: plane, Nodes: nodes, Edges: edges}
 	if err := projection.Validate(); err != nil {
 		return Projection{}, err
 	}
 	return projection, nil
+}
+
+func BuildCanonicalIndex(projections []Projection) (CanonicalIndex, error) {
+	index := CanonicalIndex{
+		canonicalByID: make(map[NodeID]ProjectionPath),
+		planePaths:    make(map[string]map[NodeID]ProjectionPath),
+	}
+	if len(projections) == 0 {
+		return index, nil
+	}
+
+	hasService := false
+	serviceIDs := make(map[NodeID]struct{})
+
+	for projectionIndex, projection := range projections {
+		if err := projection.Validate(); err != nil {
+			return CanonicalIndex{}, fmt.Errorf("projection %d: %w", projectionIndex, err)
+		}
+
+		plane := projection.Plane
+		if plane == ServicePlane {
+			hasService = true
+		}
+
+		planeMap, ok := index.planePaths[plane]
+		if !ok {
+			planeMap = make(map[NodeID]ProjectionPath, len(projection.Nodes))
+			index.planePaths[plane] = planeMap
+		}
+
+		for nodeIndex, node := range projection.Nodes {
+			expectedID, err := StableNodeID(node.CanonicalPath)
+			if err != nil {
+				return CanonicalIndex{}, fmt.Errorf("projection %d node %d canonical: %w", projectionIndex, nodeIndex, err)
+			}
+			if node.ID != expectedID {
+				return CanonicalIndex{}, fmt.Errorf("projection %d node %d id mismatch: %w", projectionIndex, nodeIndex, ErrProjectionInvalidNode)
+			}
+
+			if existing, ok := index.canonicalByID[node.ID]; ok {
+				if existing.String() != node.CanonicalPath.String() {
+					return CanonicalIndex{}, fmt.Errorf("projection %d node %d id collision: %w", projectionIndex, nodeIndex, ErrProjectionInvalidNode)
+				}
+			} else {
+				index.canonicalByID[node.ID] = node.CanonicalPath
+			}
+
+			if existing, ok := planeMap[node.ID]; ok {
+				if existing.String() != node.Path.String() {
+					return CanonicalIndex{}, fmt.Errorf("projection %d node %d plane path mismatch: %w", projectionIndex, nodeIndex, ErrProjectionInvalidNode)
+				}
+			} else {
+				planeMap[node.ID] = node.Path
+			}
+
+			if plane == ServicePlane {
+				serviceIDs[node.ID] = struct{}{}
+			}
+		}
+	}
+
+	if hasService {
+		for plane, planeMap := range index.planePaths {
+			if plane == ServicePlane {
+				continue
+			}
+			for id := range planeMap {
+				if _, ok := serviceIDs[id]; !ok {
+					return CanonicalIndex{}, fmt.Errorf("plane %q node %s missing service canonical: %w", plane, id, ErrProjectionInvalidNode)
+				}
+			}
+		}
+	}
+
+	return index, nil
 }
 
 func (projection Projection) Validate() error {

--- a/registry/projection.go
+++ b/registry/projection.go
@@ -229,6 +229,9 @@ func BuildCanonicalIndex(projections []Projection) (CanonicalIndex, error) {
 			if node.ID != expectedID {
 				return CanonicalIndex{}, fmt.Errorf("projection %d node %d id mismatch: %w", projectionIndex, nodeIndex, ErrProjectionInvalidNode)
 			}
+			if plane == ServicePlane && node.Path.String() != node.CanonicalPath.String() {
+				return CanonicalIndex{}, fmt.Errorf("projection %d node %d service path mismatch: %w", projectionIndex, nodeIndex, ErrProjectionInvalidNode)
+			}
 
 			if existing, ok := index.canonicalByID[node.ID]; ok {
 				if existing.String() != node.CanonicalPath.String() {

--- a/registry/projection_test.go
+++ b/registry/projection_test.go
@@ -270,6 +270,40 @@ func TestBuildCanonicalIndex_RejectsMismatch(t *testing.T) {
 	}
 }
 
+func TestBuildCanonicalIndex_RejectsServicePathMismatch(t *testing.T) {
+	canonical := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	servicePath := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "other"},
+		},
+	}
+	id, err := StableNodeID(canonical)
+	if err != nil {
+		t.Fatalf("unexpected stable id error: %v", err)
+	}
+	node := Node{
+		ID:            id,
+		Path:          servicePath,
+		CanonicalPath: canonical,
+	}
+	projection := Projection{
+		Plane: ServicePlane,
+		Nodes: []Node{node},
+	}
+
+	if _, err := BuildCanonicalIndex([]Projection{projection}); err == nil {
+		t.Fatalf("expected service path mismatch error")
+	}
+}
+
 func TestBuildCanonicalIndex_RequiresServicePlaneNodes(t *testing.T) {
 	canonicalA := ProjectionPath{
 		Plane: ServicePlane,

--- a/registry/projection_test.go
+++ b/registry/projection_test.go
@@ -163,3 +163,156 @@ func TestProjection_ValidatesPathsAndEdges(t *testing.T) {
 		t.Fatalf("expected error for missing edge nodes")
 	}
 }
+
+func TestBuildCanonicalIndex_Success(t *testing.T) {
+	canonical := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+	serviceNode, err := NewNode(canonical, canonical)
+	if err != nil {
+		t.Fatalf("unexpected service node error: %v", err)
+	}
+	obsNode, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}, canonical)
+	if err != nil {
+		t.Fatalf("unexpected observability node error: %v", err)
+	}
+
+	serviceProjection, err := NewProjection(ServicePlane, []Node{serviceNode}, nil)
+	if err != nil {
+		t.Fatalf("unexpected service projection error: %v", err)
+	}
+	obsProjection, err := NewProjection("Observability", []Node{obsNode}, nil)
+	if err != nil {
+		t.Fatalf("unexpected observability projection error: %v", err)
+	}
+
+	index, err := BuildCanonicalIndex([]Projection{serviceProjection, obsProjection})
+	if err != nil {
+		t.Fatalf("unexpected canonical index error: %v", err)
+	}
+
+	if path, ok := index.Canonical(serviceNode.ID); !ok || path.String() != canonical.String() {
+		t.Fatalf("unexpected canonical path: %v %v", ok, path.String())
+	}
+	if path, ok := index.PlanePath("Observability", serviceNode.ID); !ok || path.Plane != "Observability" {
+		t.Fatalf("unexpected observability path lookup")
+	}
+	paths := index.PlanePaths(serviceNode.ID)
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 plane paths, got %d", len(paths))
+	}
+}
+
+func TestBuildCanonicalIndex_RejectsMismatch(t *testing.T) {
+	canonicalA := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "temp"},
+		},
+	}
+	canonicalB := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+	nodeA, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "temp"},
+		},
+	}, canonicalA)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+	nodeB, err := NewNode(ProjectionPath{
+		Plane: "Debug",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}, canonicalB)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+	nodeB.ID = nodeA.ID
+
+	obsProjection, err := NewProjection("Observability", []Node{nodeA}, nil)
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+	debugProjection, err := NewProjection("Debug", []Node{nodeB}, nil)
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+
+	if _, err := BuildCanonicalIndex([]Projection{obsProjection, debugProjection}); err == nil {
+		t.Fatalf("expected canonical mismatch error")
+	}
+}
+
+func TestBuildCanonicalIndex_RequiresServicePlaneNodes(t *testing.T) {
+	canonicalA := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "a"},
+		},
+	}
+	canonicalB := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "b"},
+		},
+	}
+	serviceNode, err := NewNode(canonicalA, canonicalA)
+	if err != nil {
+		t.Fatalf("unexpected service node error: %v", err)
+	}
+	otherNode, err := NewNode(ProjectionPath{
+		Plane: "Debug",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "b"},
+		},
+	}, canonicalB)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+
+	serviceProjection, err := NewProjection(ServicePlane, []Node{serviceNode}, nil)
+	if err != nil {
+		t.Fatalf("unexpected service projection error: %v", err)
+	}
+	debugProjection, err := NewProjection("Debug", []Node{otherNode}, nil)
+	if err != nil {
+		t.Fatalf("unexpected debug projection error: %v", err)
+	}
+
+	if _, err := BuildCanonicalIndex([]Projection{serviceProjection, debugProjection}); err == nil {
+		t.Fatalf("expected missing service node error")
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -101,10 +101,17 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 		projections = append(projections, projectionProvider.CreateProjections(info, planes)...)
 	}
 
+	index, projectionErr := BuildCanonicalIndex(projections)
+	if projectionErr != nil {
+		projections = nil
+	}
+
 	entry := &deviceEntry{
 		info:        info,
 		planes:      planes,
 		projections: projections,
+		index:       index,
+		indexErr:    projectionErr,
 	}
 
 	r.mu.Lock()
@@ -152,6 +159,8 @@ type deviceEntry struct {
 	info        DeviceInfo
 	planes      []Plane
 	projections []Projection
+	index       CanonicalIndex
+	indexErr    error
 }
 
 func (d *deviceEntry) Address() byte {
@@ -188,4 +197,14 @@ func (d *deviceEntry) Planes() []Plane {
 
 func (d *deviceEntry) Projections() []Projection {
 	return d.projections
+}
+
+func CanonicalIndexForEntry(entry DeviceEntry) (CanonicalIndex, error) {
+	if entry == nil {
+		return CanonicalIndex{}, ErrProjectionInvalidNode
+	}
+	if internal, ok := entry.(*deviceEntry); ok {
+		return internal.index, internal.indexErr
+	}
+	return BuildCanonicalIndex(entry.Projections())
 }


### PR DESCRIPTION
Fixes #56.

- add canonical index per DeviceEntry for node ID → canonical path
- enforce cross-projection invariants (stable node IDs, canonical consistency)
- add validation tests for multi-plane projections

Tests: go test ./...