### PR TITLE
Add portal projection index queries

### DIFF
--- a/registry/portal.go
+++ b/registry/portal.go
@@ -1,0 +1,270 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrPortalDuplicatePlane = errors.New("portal: duplicate plane")
+	ErrPortalDuplicateNode  = errors.New("portal: duplicate node")
+	ErrPortalDuplicateEdge  = errors.New("portal: duplicate edge")
+	ErrPortalInvalidEntry   = errors.New("portal: invalid entry")
+)
+
+// PortalIndex provides plane-scoped projection lookups for a single device entry.
+//
+// Example:
+//
+//	portal, err := NewPortalIndex(entry.Projections())
+//	if err != nil {
+//	    return err
+//	}
+//	node, ok, err := portal.NodeByCanonical("Observability", ProjectionPath{
+//	    Plane: ServicePlane,
+//	    Segments: []PathSegment{
+//	        {Name: "devices"},
+//	        {Name: "boiler"},
+//	    },
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	if ok {
+//	    _ = node.Path
+//	}
+type PortalIndex struct {
+	planes map[string]*PlaneIndex
+}
+
+// PortalIndexForEntry builds a portal index from the entry projections.
+func PortalIndexForEntry(entry DeviceEntry) (PortalIndex, error) {
+	if entry == nil {
+		return PortalIndex{}, ErrPortalInvalidEntry
+	}
+	return NewPortalIndex(entry.Projections())
+}
+
+// PlaneIndex returns the plane-specific index if present.
+//
+// Example:
+//
+//	plane, ok := portal.PlaneIndex("Observability")
+//	if ok {
+//	    _ = plane.Plane()
+//	}
+func (portal PortalIndex) PlaneIndex(plane string) (*PlaneIndex, bool) {
+	if portal.planes == nil {
+		return nil, false
+	}
+	index, ok := portal.planes[plane]
+	return index, ok
+}
+
+// NodeByCanonical looks up a node by plane and canonical Service path.
+//
+// Example:
+//
+//	node, ok, err := portal.NodeByCanonical("Observability", ProjectionPath{
+//	    Plane: ServicePlane,
+//	    Segments: []PathSegment{
+//	        {Name: "devices"},
+//	        {Name: "boiler"},
+//	    },
+//	})
+func (portal PortalIndex) NodeByCanonical(plane string, canonical ProjectionPath) (Node, bool, error) {
+	index, ok := portal.PlaneIndex(plane)
+	if !ok {
+		return Node{}, false, nil
+	}
+	return index.NodeByCanonical(canonical)
+}
+
+// EdgeByID looks up an edge by plane and edge ID.
+func (portal PortalIndex) EdgeByID(plane string, edgeID EdgeID) (Edge, bool) {
+	index, ok := portal.PlaneIndex(plane)
+	if !ok {
+		return Edge{}, false
+	}
+	return index.EdgeByID(edgeID)
+}
+
+// NewPortalIndex builds a read-only portal index from projections.
+//
+// Example:
+//
+//	portal, err := NewPortalIndex(entry.Projections())
+//	if err != nil {
+//	    return err
+//	}
+func NewPortalIndex(projections []Projection) (PortalIndex, error) {
+	if len(projections) == 0 {
+		return PortalIndex{}, nil
+	}
+	planes := make(map[string]*PlaneIndex, len(projections))
+	for _, projection := range projections {
+		if _, exists := planes[projection.Plane]; exists {
+			return PortalIndex{}, fmt.Errorf("portal plane %q: %w", projection.Plane, ErrPortalDuplicatePlane)
+		}
+		index, err := NewPlaneIndex(projection)
+		if err != nil {
+			return PortalIndex{}, fmt.Errorf("portal plane %q: %w", projection.Plane, err)
+		}
+		planes[projection.Plane] = &index
+	}
+	return PortalIndex{planes: planes}, nil
+}
+
+// PlaneIndex provides indexed access to nodes and edges within a projection plane.
+//
+// Example:
+//
+//	plane, ok := portal.PlaneIndex("Observability")
+//	if ok {
+//	    node, ok, err := plane.NodeByCanonical(ProjectionPath{
+//	        Plane: ServicePlane,
+//	        Segments: []PathSegment{
+//	            {Name: "devices"},
+//	            {Name: "boiler"},
+//	        },
+//	    })
+//	    _ = node
+//	    _ = err
+//	}
+type PlaneIndex struct {
+	plane      string
+	nodesByID  map[NodeID]Node
+	paths      map[string]Node
+	edgesByID  map[EdgeID]Edge
+	edgesFrom  map[NodeID][]Edge
+	edgesTo    map[NodeID][]Edge
+	edgeCounts int
+}
+
+// Plane returns the plane name for this index.
+func (index *PlaneIndex) Plane() string {
+	if index == nil {
+		return ""
+	}
+	return index.plane
+}
+
+// NodeByCanonical looks up a node by canonical Service path.
+func (index *PlaneIndex) NodeByCanonical(canonical ProjectionPath) (Node, bool, error) {
+	if index == nil {
+		return Node{}, false, nil
+	}
+	id, err := StableNodeID(canonical)
+	if err != nil {
+		return Node{}, false, err
+	}
+	node, ok := index.NodeByID(id)
+	return node, ok, nil
+}
+
+// NodeByID looks up a node by stable node ID.
+func (index *PlaneIndex) NodeByID(id NodeID) (Node, bool) {
+	if index == nil {
+		return Node{}, false
+	}
+	node, ok := index.nodesByID[id]
+	return node, ok
+}
+
+// NodeByPath looks up a node by its plane-specific path.
+func (index *PlaneIndex) NodeByPath(path ProjectionPath) (Node, bool, error) {
+	if index == nil {
+		return Node{}, false, nil
+	}
+	if err := path.Validate(); err != nil {
+		return Node{}, false, err
+	}
+	if path.Plane != index.plane {
+		return Node{}, false, ErrProjectionInvalidPlane
+	}
+	node, ok := index.paths[path.String()]
+	return node, ok, nil
+}
+
+// EdgeByID looks up an edge by its stable ID.
+func (index *PlaneIndex) EdgeByID(id EdgeID) (Edge, bool) {
+	if index == nil {
+		return Edge{}, false
+	}
+	edge, ok := index.edgesByID[id]
+	return edge, ok
+}
+
+// EdgesFrom returns edges originating from the provided node ID.
+func (index *PlaneIndex) EdgesFrom(id NodeID) []Edge {
+	if index == nil {
+		return nil
+	}
+	edges := index.edgesFrom[id]
+	if len(edges) == 0 {
+		return nil
+	}
+	out := make([]Edge, len(edges))
+	copy(out, edges)
+	return out
+}
+
+// EdgesTo returns edges targeting the provided node ID.
+func (index *PlaneIndex) EdgesTo(id NodeID) []Edge {
+	if index == nil {
+		return nil
+	}
+	edges := index.edgesTo[id]
+	if len(edges) == 0 {
+		return nil
+	}
+	out := make([]Edge, len(edges))
+	copy(out, edges)
+	return out
+}
+
+// EdgeCount returns the number of edges indexed for the plane.
+func (index *PlaneIndex) EdgeCount() int {
+	if index == nil {
+		return 0
+	}
+	return index.edgeCounts
+}
+
+// NewPlaneIndex builds an index from a single projection.
+func NewPlaneIndex(projection Projection) (PlaneIndex, error) {
+	if err := projection.Validate(); err != nil {
+		return PlaneIndex{}, err
+	}
+	nodesByID := make(map[NodeID]Node, len(projection.Nodes))
+	paths := make(map[string]Node, len(projection.Nodes))
+	for _, node := range projection.Nodes {
+		if _, exists := nodesByID[node.ID]; exists {
+			return PlaneIndex{}, fmt.Errorf("node %s: %w", node.ID, ErrPortalDuplicateNode)
+		}
+		nodesByID[node.ID] = node
+		paths[node.Path.String()] = node
+	}
+
+	edgesByID := make(map[EdgeID]Edge, len(projection.Edges))
+	edgesFrom := make(map[NodeID][]Edge)
+	edgesTo := make(map[NodeID][]Edge)
+	for _, edge := range projection.Edges {
+		if _, exists := edgesByID[edge.ID]; exists {
+			return PlaneIndex{}, fmt.Errorf("edge %s: %w", edge.ID, ErrPortalDuplicateEdge)
+		}
+		edgesByID[edge.ID] = edge
+		edgesFrom[edge.From] = append(edgesFrom[edge.From], edge)
+		edgesTo[edge.To] = append(edgesTo[edge.To], edge)
+	}
+
+	return PlaneIndex{
+		plane:      projection.Plane,
+		nodesByID:  nodesByID,
+		paths:      paths,
+		edgesByID:  edgesByID,
+		edgesFrom:  edgesFrom,
+		edgesTo:    edgesTo,
+		edgeCounts: len(projection.Edges),
+	}, nil
+}

--- a/registry/portal_test.go
+++ b/registry/portal_test.go
@@ -1,0 +1,251 @@
+package registry
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPortalIndex_QueryByCanonical(t *testing.T) {
+	canonicalRoot := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	canonicalChild := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+	rootPath := ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	childPath := ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+
+	rootNode, err := NewNode(rootPath, canonicalRoot)
+	if err != nil {
+		t.Fatalf("unexpected root node error: %v", err)
+	}
+	childNode, err := NewNode(childPath, canonicalChild)
+	if err != nil {
+		t.Fatalf("unexpected child node error: %v", err)
+	}
+
+	edge, err := NewEdge("Observability", rootNode.ID, childNode.ID)
+	if err != nil {
+		t.Fatalf("unexpected edge error: %v", err)
+	}
+
+	projection, err := NewProjection("Observability", []Node{rootNode, childNode}, []Edge{edge})
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+
+	portal, err := NewPortalIndex([]Projection{projection})
+	if err != nil {
+		t.Fatalf("unexpected portal index error: %v", err)
+	}
+
+	found, ok, err := portal.NodeByCanonical("Observability", canonicalChild)
+	if err != nil {
+		t.Fatalf("unexpected canonical lookup error: %v", err)
+	}
+	if !ok || found.ID != childNode.ID {
+		t.Fatalf("unexpected canonical lookup result: %v %v", ok, found.ID)
+	}
+
+	plane, ok := portal.PlaneIndex("Observability")
+	if !ok || plane.Plane() != "Observability" {
+		t.Fatalf("unexpected plane index lookup")
+	}
+
+	byPath, ok, err := plane.NodeByPath(childPath)
+	if err != nil {
+		t.Fatalf("unexpected path lookup error: %v", err)
+	}
+	if !ok || byPath.ID != childNode.ID {
+		t.Fatalf("unexpected path lookup result: %v %v", ok, byPath.ID)
+	}
+
+	edgeOut, ok := portal.EdgeByID("Observability", edge.ID)
+	if !ok || edgeOut.ID != edge.ID {
+		t.Fatalf("unexpected edge lookup result")
+	}
+
+	fromEdges := plane.EdgesFrom(rootNode.ID)
+	if len(fromEdges) != 1 || fromEdges[0].ID != edge.ID {
+		t.Fatalf("unexpected edges from result: %v", fromEdges)
+	}
+	toEdges := plane.EdgesTo(childNode.ID)
+	if len(toEdges) != 1 || toEdges[0].ID != edge.ID {
+		t.Fatalf("unexpected edges to result: %v", toEdges)
+	}
+	if plane.EdgeCount() != 1 {
+		t.Fatalf("unexpected edge count: %d", plane.EdgeCount())
+	}
+}
+
+func TestPortalIndex_NodeByCanonicalRejectsNonServicePlane(t *testing.T) {
+	canonical := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+		},
+	}
+	path := ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+		},
+	}
+	node, err := NewNode(path, canonical)
+	if err != nil {
+		t.Fatalf("unexpected node error: %v", err)
+	}
+	projection, err := NewProjection("Observability", []Node{node}, nil)
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+	portal, err := NewPortalIndex([]Projection{projection})
+	if err != nil {
+		t.Fatalf("unexpected portal error: %v", err)
+	}
+
+	_, _, err = portal.NodeByCanonical("Observability", ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected error for non-service canonical plane")
+	}
+}
+
+func TestPortalIndex_DuplicatePlane(t *testing.T) {
+	projection, err := NewProjection("Observability", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+	if _, err := NewPortalIndex([]Projection{projection, projection}); err == nil || !errors.Is(err, ErrPortalDuplicatePlane) {
+		t.Fatalf("expected duplicate plane error, got %v", err)
+	}
+}
+
+func TestPlaneIndex_DuplicateNodeID(t *testing.T) {
+	canonical := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	nodeA, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}, canonical)
+	if err != nil {
+		t.Fatalf("unexpected nodeA error: %v", err)
+	}
+	nodeB, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "alt"},
+		},
+	}, canonical)
+	if err != nil {
+		t.Fatalf("unexpected nodeB error: %v", err)
+	}
+
+	projection, err := NewProjection("Observability", []Node{nodeA, nodeB}, nil)
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+	if _, err := NewPlaneIndex(projection); err == nil || !errors.Is(err, ErrPortalDuplicateNode) {
+		t.Fatalf("expected duplicate node error, got %v", err)
+	}
+}
+
+func TestPlaneIndex_DuplicateEdgeID(t *testing.T) {
+	canonicalA := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "a"},
+		},
+	}
+	canonicalB := ProjectionPath{
+		Plane: ServicePlane,
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "b"},
+		},
+	}
+	nodeA, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "a"},
+		},
+	}, canonicalA)
+	if err != nil {
+		t.Fatalf("unexpected nodeA error: %v", err)
+	}
+	nodeB, err := NewNode(ProjectionPath{
+		Plane: "Observability",
+		Segments: []PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "b"},
+		},
+	}, canonicalB)
+	if err != nil {
+		t.Fatalf("unexpected nodeB error: %v", err)
+	}
+
+	edgeA, err := NewEdge("Observability", nodeA.ID, nodeB.ID)
+	if err != nil {
+		t.Fatalf("unexpected edgeA error: %v", err)
+	}
+	edgeB, err := NewEdge("Observability", nodeA.ID, nodeB.ID)
+	if err != nil {
+		t.Fatalf("unexpected edgeB error: %v", err)
+	}
+
+	projection, err := NewProjection("Observability", []Node{nodeA, nodeB}, []Edge{edgeA, edgeB})
+	if err != nil {
+		t.Fatalf("unexpected projection error: %v", err)
+	}
+	if _, err := NewPlaneIndex(projection); err == nil || !errors.Is(err, ErrPortalDuplicateEdge) {
+		t.Fatalf("expected duplicate edge error, got %v", err)
+	}
+}
+
+func TestPortalIndexForEntry_Nil(t *testing.T) {
+	if _, err := PortalIndexForEntry(nil); err == nil || !errors.Is(err, ErrPortalInvalidEntry) {
+		t.Fatalf("expected invalid entry error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add portal projection index helpers for plane/canonical lookups
- add portal index tests for queries and duplicate detection

## Testing
- GOWORK=off go test ./...

## Issue
Closes #57

## Smoke Test
- Not required (not run)
