### PR TITLE
Handle typed-nil device entries in portal index

### DIFF
--- a/registry/portal.go
+++ b/registry/portal.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 var (
@@ -39,10 +40,15 @@ type PortalIndex struct {
 
 // PortalIndexForEntry builds a portal index from the entry projections.
 func PortalIndexForEntry(entry DeviceEntry) (PortalIndex, error) {
-	if entry == nil {
+	if entry == nil || isNilDeviceEntry(entry) {
 		return PortalIndex{}, ErrPortalInvalidEntry
 	}
 	return NewPortalIndex(entry.Projections())
+}
+
+func isNilDeviceEntry(entry DeviceEntry) bool {
+	value := reflect.ValueOf(entry)
+	return value.Kind() == reflect.Ptr && value.IsNil()
 }
 
 // PlaneIndex returns the plane-specific index if present.

--- a/registry/portal_test.go
+++ b/registry/portal_test.go
@@ -249,3 +249,10 @@ func TestPortalIndexForEntry_Nil(t *testing.T) {
 		t.Fatalf("expected invalid entry error, got %v", err)
 	}
 }
+
+func TestPortalIndexForEntry_TypedNil(t *testing.T) {
+	var entry DeviceEntry = (*deviceEntry)(nil)
+	if _, err := PortalIndexForEntry(entry); err == nil || !errors.Is(err, ErrPortalInvalidEntry) {
+		t.Fatalf("expected invalid entry error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #60.

- Treat typed-nil DeviceEntry values as invalid in PortalIndexForEntry
- Add regression test for typed-nil input

Tests: go test ./...