### PR TITLE
Use initiator/target terminology across repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
   pull_request:
 
 jobs:
+  terminology:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if grep -RInwi --exclude-dir=.git -E 'm[a]ster|s[l]ave' .; then
+            echo "Found legacy terminology."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -52,7 +52,7 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 			}
 
 			frameType := protocol.FrameTypeForTarget(target)
-			if frameType == protocol.FrameTypeMasterMaster || frameType == protocol.FrameTypeUnknown {
+			if frameType == protocol.FrameTypeUnknown || isInitiatorCapableAddress(target) {
 				continue
 			}
 
@@ -195,4 +195,25 @@ func dedupeScanTargets(targets []byte) []byte {
 		out = append(out, target)
 	}
 	return out
+}
+
+func isInitiatorCapableAddress(address byte) bool {
+	return initiatorPartIndex(address&0x0F) > 0 && initiatorPartIndex((address&0xF0)>>4) > 0
+}
+
+func initiatorPartIndex(bits byte) byte {
+	switch bits {
+	case 0x0:
+		return 1
+	case 0x1:
+		return 2
+	case 0x3:
+		return 3
+	case 0x7:
+		return 4
+	case 0xF:
+		return 5
+	default:
+		return 0
+	}
 }

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -229,7 +229,7 @@ func TestScanFailsWhenContextDone(t *testing.T) {
 	}
 }
 
-func TestScanSkipsMasterAndUnknownTargets(t *testing.T) {
+func TestScanSkipsInitiatorCapableAndUnknownTargets(t *testing.T) {
 	t.Parallel()
 
 	registry := NewDeviceRegistry(nil)

--- a/vendor/github.com/d3vi1/helianthus-ebusgo/errors/errors.go
+++ b/vendor/github.com/d3vi1/helianthus-ebusgo/errors/errors.go
@@ -6,7 +6,7 @@ var (
 	ErrBusCollision = stderrors.New("ebus: bus collision during arbitration")
 	ErrTimeout      = stderrors.New("ebus: no response within timeout window")
 	ErrCRCMismatch  = stderrors.New("ebus: CRC validation failed")
-	ErrNACK         = stderrors.New("ebus: slave returned NACK")
+	ErrNACK         = stderrors.New("ebus: target returned NACK")
 	ErrNoSuchDevice = stderrors.New("ebus: no device responded at address")
 
 	ErrRetryExhausted  = stderrors.New("ebus: retries exhausted")


### PR DESCRIPTION
## Summary
- replace remaining whole-word legacy role terminology with initiator/target wording
- keep scan behavior unchanged while renaming local scan terminology to initiator-capable language
- add a CI terminology gate that fails when whole-word legacy terms are introduced

## Validation
- go test ./...
- go vet ./...
- grep -RInw --exclude-dir=.git -E '(master|slave)' .

Closes #66

@codex review