### PR TITLE
B524: attach GG/RR constraint metadata on ext-register responses

### DIFF
--- a/router/vaillant_ext_register_access_test.go
+++ b/router/vaillant_ext_register_access_test.go
@@ -167,6 +167,45 @@ func TestVaillantSystem_GetExtRegister_ResponseDecode(t *testing.T) {
 		}
 	})
 
+	t.Run("echoed reply mapping overrides constraint record", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x24,
+				Data:      []byte{0x01, 0x03, 0x00, 0x05, 0x2A},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_ext_register", map[string]any{
+			"source":   byte(0x10),
+			"group":    byte(0x01),
+			"instance": byte(0x01),
+			"addr":     uint16(0x0400),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		if got := values["constraint_record"]; !got.Valid || got.Value != uint16(0x0500) {
+			t.Fatalf("constraint_record = %+v; want 0x0500 valid", got)
+		}
+		if got := values["constraint_record_hex"]; !got.Valid || got.Value != "0500" {
+			t.Fatalf("constraint_record_hex = %+v; want 0500 valid", got)
+		}
+		if got := values["constraint_min"]; !got.Valid || got.Value != float64(5) {
+			t.Fatalf("constraint_min = %+v; want 5 valid", got)
+		}
+		if got := values["constraint_max"]; !got.Valid || got.Value != float64(30) {
+			t.Fatalf("constraint_max = %+v; want 30 valid", got)
+		}
+	})
+
 	t.Run("short zero payload", func(t *testing.T) {
 		t.Parallel()
 

--- a/router/vaillant_ext_register_access_test.go
+++ b/router/vaillant_ext_register_access_test.go
@@ -206,6 +206,39 @@ func TestVaillantSystem_GetExtRegister_ResponseDecode(t *testing.T) {
 		}
 	})
 
+	t.Run("echoed reply without mapping clears request constraints", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x24,
+				Data:      []byte{0x01, 0x7F, 0x00, 0x01, 0x2A},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_ext_register", map[string]any{
+			"source":   byte(0x10),
+			"group":    byte(0x01),
+			"instance": byte(0x01),
+			"addr":     uint16(0x0400),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		if got, ok := values["constraints"]; ok {
+			t.Fatalf("constraints = %+v; want absent when echoed GG/RR has no mapping", got)
+		}
+		if got, ok := values["constraint_record"]; ok {
+			t.Fatalf("constraint_record = %+v; want absent when echoed GG/RR has no mapping", got)
+		}
+	})
+
 	t.Run("short zero payload", func(t *testing.T) {
 		t.Parallel()
 

--- a/router/vaillant_ext_register_access_test.go
+++ b/router/vaillant_ext_register_access_test.go
@@ -105,6 +105,66 @@ func TestVaillantSystem_GetExtRegister_ResponseDecode(t *testing.T) {
 		if got := values["value"]; !got.Valid || !bytes.Equal(got.Value.([]byte), []byte{0xAA, 0xBB}) {
 			t.Fatalf("value = %+v; want [aa bb] valid", got)
 		}
+		if got, ok := values["constraints"]; ok {
+			t.Fatalf("constraints = %+v; want absent for unknown mapping", got)
+		}
+	})
+
+	t.Run("known mapping adds constraints", func(t *testing.T) {
+		t.Parallel()
+
+		bus := &vaillantMockBus{
+			response: &protocol.Frame{
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   0xB5,
+				Secondary: 0x24,
+				Data:      []byte{0x01, 0x01, 0x00, 0x04, 0x2A},
+			},
+		}
+		eventRouter := router.NewBusEventRouter(bus)
+
+		result, err := eventRouter.Invoke(context.Background(), plane, "get_ext_register", map[string]any{
+			"source":   byte(0x10),
+			"group":    byte(0x01),
+			"instance": byte(0x01),
+			"addr":     uint16(0x0400),
+		})
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+
+		values := result.(map[string]types.Value)
+		constraintsValue, ok := values["constraints"]
+		if !ok || !constraintsValue.Valid {
+			t.Fatalf("constraints = %+v; want valid", constraintsValue)
+		}
+
+		constraints, ok := constraintsValue.Value.(map[string]any)
+		if !ok {
+			t.Fatalf("constraints type = %T; want map[string]any", constraintsValue.Value)
+		}
+		if constraints["type"] != "f32_range" || constraints["min"] != float64(35) || constraints["max"] != float64(70) || constraints["step"] != float64(1) {
+			t.Fatalf("constraints map = %#v; want f32_range/min=35/max=70/step=1", constraints)
+		}
+		if got := values["constraint_record"]; !got.Valid || got.Value != uint16(0x0400) {
+			t.Fatalf("constraint_record = %+v; want 0x0400 valid", got)
+		}
+		if got := values["constraint_record_hex"]; !got.Valid || got.Value != "0400" {
+			t.Fatalf("constraint_record_hex = %+v; want 0400 valid", got)
+		}
+		if got := values["constraint_type"]; !got.Valid || got.Value != "f32_range" {
+			t.Fatalf("constraint_type = %+v; want f32_range valid", got)
+		}
+		if got := values["constraint_min"]; !got.Valid || got.Value != float64(35) {
+			t.Fatalf("constraint_min = %+v; want 35 valid", got)
+		}
+		if got := values["constraint_max"]; !got.Valid || got.Value != float64(70) {
+			t.Fatalf("constraint_max = %+v; want 70 valid", got)
+		}
+		if got := values["constraint_step"]; !got.Valid || got.Value != float64(1) {
+			t.Fatalf("constraint_step = %+v; want 1 valid", got)
+		}
 	})
 
 	t.Run("short zero payload", func(t *testing.T) {

--- a/vaillant/system/b524_constraints.go
+++ b/vaillant/system/b524_constraints.go
@@ -1,0 +1,88 @@
+package system
+
+type b524ConstraintSelector struct {
+	Group  byte
+	Record uint16
+}
+
+type b524Constraint struct {
+	Type string
+	Min  float64
+	Max  float64
+	Step float64
+}
+
+func (constraint b524Constraint) mapValue() map[string]any {
+	return map[string]any{
+		"type": constraint.Type,
+		"min":  constraint.Min,
+		"max":  constraint.Max,
+		"step": constraint.Step,
+	}
+}
+
+var b524StaticConstraintsCatalog = map[b524ConstraintSelector]b524Constraint{
+	{Group: 0x00, Record: 0x0100}: {Type: "f32_range", Min: -20, Max: 50, Step: 1},
+	{Group: 0x00, Record: 0x0200}: {Type: "f32_range", Min: -26, Max: 10, Step: 1},
+	{Group: 0x00, Record: 0x0300}: {Type: "u16_range", Min: 0, Max: 12, Step: 1},
+	{Group: 0x00, Record: 0x0400}: {Type: "u16_range", Min: 0, Max: 300, Step: 10},
+	{Group: 0x00, Record: 0x8000}: {Type: "f32_range", Min: -10, Max: 10, Step: 1},
+
+	{Group: 0x01, Record: 0x0100}: {Type: "u16_range", Min: 0, Max: 1, Step: 1},
+	{Group: 0x01, Record: 0x0200}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+	{Group: 0x01, Record: 0x0300}: {Type: "u16_range", Min: 0, Max: 2, Step: 1},
+	{Group: 0x01, Record: 0x0400}: {Type: "f32_range", Min: 35, Max: 70, Step: 1},
+	{Group: 0x01, Record: 0x0500}: {Type: "f32_range", Min: 0, Max: 99, Step: 1},
+	{Group: 0x01, Record: 0x0600}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+
+	{Group: 0x02, Record: 0x0100}: {Type: "u16_range", Min: 1, Max: 2, Step: 1},
+	{Group: 0x02, Record: 0x0200}: {Type: "u16_range", Min: 0, Max: 4, Step: 1},
+	{Group: 0x02, Record: 0x0400}: {Type: "f32_range", Min: 15, Max: 80, Step: 1},
+	{Group: 0x02, Record: 0x0500}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+	{Group: 0x02, Record: 0x0600}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+
+	{Group: 0x03, Record: 0x0100}: {Type: "u16_range", Min: 0, Max: 2, Step: 1},
+	{Group: 0x03, Record: 0x0200}: {Type: "f32_range", Min: 15, Max: 30, Step: 0.5},
+	{Group: 0x03, Record: 0x0500}: {Type: "f32_range", Min: 5, Max: 30, Step: 1},
+	{Group: 0x03, Record: 0x0600}: {Type: "u16_range", Min: 0, Max: 2, Step: 1},
+
+	{Group: 0x04, Record: 0x0100}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+	{Group: 0x04, Record: 0x0200}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+	{Group: 0x04, Record: 0x0300}: {Type: "f32_range", Min: -40, Max: 155, Step: 1},
+	{Group: 0x04, Record: 0x0400}: {Type: "f32_range", Min: 0, Max: 99, Step: 1},
+	{Group: 0x04, Record: 0x0500}: {Type: "f32_range", Min: 110, Max: 150, Step: 1},
+	{Group: 0x04, Record: 0x0600}: {Type: "f32_range", Min: 75, Max: 115, Step: 1},
+
+	{Group: 0x05, Record: 0x0100}: {Type: "f32_range", Min: 0, Max: 99, Step: 1},
+	{Group: 0x05, Record: 0x0200}: {Type: "f32_range", Min: 2, Max: 25, Step: 1},
+	{Group: 0x05, Record: 0x0300}: {Type: "f32_range", Min: 1, Max: 20, Step: 1},
+	{Group: 0x05, Record: 0x0400}: {Type: "f32_range", Min: -10, Max: 110, Step: 1},
+
+	{Group: 0x08, Record: 0x0100}: {Type: "f32_range", Min: 0, Max: 99, Step: 1},
+	{Group: 0x08, Record: 0x0200}: {Type: "f32_range", Min: 0, Max: 99, Step: 1},
+	{Group: 0x08, Record: 0x0300}: {Type: "f32_range", Min: 2, Max: 25, Step: 1},
+	{Group: 0x08, Record: 0x0400}: {Type: "f32_range", Min: 1, Max: 20, Step: 1},
+	{Group: 0x08, Record: 0x0500}: {Type: "f32_range", Min: -10, Max: 110, Step: 1},
+	{Group: 0x08, Record: 0x0600}: {Type: "f32_range", Min: -10, Max: 110, Step: 1},
+
+	{Group: 0x09, Record: 0x0100}: {Type: "u16_range", Min: 0, Max: 255, Step: 1},
+	{Group: 0x09, Record: 0x0200}: {Type: "u16_range", Min: 1, Max: 3, Step: 1},
+	{Group: 0x09, Record: 0x0300}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+	{Group: 0x09, Record: 0x0400}: {Type: "u16_range", Min: 0, Max: 10, Step: 1},
+	{Group: 0x09, Record: 0x0500}: {Type: "u16_range", Min: 0, Max: 32768, Step: 1},
+	{Group: 0x09, Record: 0x0600}: {Type: "u16_range", Min: 0, Max: 32768, Step: 1},
+
+	{Group: 0x0A, Record: 0x0100}: {Type: "u8_range", Min: 0, Max: 3, Step: 1},
+	{Group: 0x0A, Record: 0x0200}: {Type: "u8_range", Min: 1, Max: 2, Step: 1},
+	{Group: 0x0A, Record: 0x0300}: {Type: "u8_range", Min: 1, Max: 2, Step: 1},
+	{Group: 0x0A, Record: 0x0500}: {Type: "u8_range", Min: 0, Max: 3, Step: 1},
+	{Group: 0x0A, Record: 0x0600}: {Type: "u8_range", Min: 0, Max: 1, Step: 1},
+}
+
+func lookupB524Constraint(group byte, record uint16) (b524Constraint, bool) {
+	constraint, ok := b524StaticConstraintsCatalog[b524ConstraintSelector{
+		Group:  group,
+		Record: record,
+	}]
+	return constraint, ok
+}

--- a/vaillant/system/b524_ext_register_access.go
+++ b/vaillant/system/b524_ext_register_access.go
@@ -130,6 +130,8 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 		"payload":  {Value: append([]byte(nil), payload...), Valid: true},
 	}
 
+	constraint, hasConstraint := lookupB524Constraint(group, addr)
+
 	if len(payload) >= 4 {
 		values["prefix"] = types.Value{Value: append([]byte(nil), payload[:4]...), Valid: true}
 		replyGroup := payload[1]
@@ -137,6 +139,10 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 		values["reply_group"] = types.Value{Value: replyGroup, Valid: true}
 		values["reply_addr"] = types.Value{Value: replyAddr, Valid: true}
 		values["reply_addr_hex"] = types.Value{Value: fmt.Sprintf("%04X", replyAddr), Valid: true}
+		if resolved, ok := lookupB524Constraint(replyGroup, replyAddr); ok {
+			constraint = resolved
+			hasConstraint = true
+		}
 	} else {
 		values["prefix"] = types.Value{Valid: false}
 	}
@@ -149,15 +155,31 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 
 	if len(payload) == 1 && payload[0] == 0x00 {
 		values["value"] = types.Value{Valid: false}
+		addB524ConstraintValues(values, constraint, hasConstraint)
 		return values
 	}
 	if len(payload) <= 4 {
 		values["value"] = types.Value{Valid: false}
+		addB524ConstraintValues(values, constraint, hasConstraint)
 		return values
 	}
 
 	values["value"] = types.Value{Value: append([]byte(nil), payload[4:]...), Valid: true}
+	addB524ConstraintValues(values, constraint, hasConstraint)
 	return values
+}
+
+func addB524ConstraintValues(values map[string]types.Value, constraint b524Constraint, hasConstraint bool) {
+	if !hasConstraint {
+		return
+	}
+	values["constraints"] = types.Value{Value: constraint.mapValue(), Valid: true}
+	values["constraint_record"] = types.Value{Value: values["addr"].Value, Valid: true}
+	values["constraint_record_hex"] = types.Value{Value: values["addr_hex"].Value, Valid: true}
+	values["constraint_type"] = types.Value{Value: constraint.Type, Valid: true}
+	values["constraint_min"] = types.Value{Value: constraint.Min, Valid: true}
+	values["constraint_max"] = types.Value{Value: constraint.Max, Valid: true}
+	values["constraint_step"] = types.Value{Value: constraint.Step, Valid: true}
 }
 
 func extRegisterOpcode(params map[string]any) (byte, error) {

--- a/vaillant/system/b524_ext_register_access.go
+++ b/vaillant/system/b524_ext_register_access.go
@@ -131,6 +131,7 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 	}
 
 	constraint, hasConstraint := lookupB524Constraint(group, addr)
+	constraintRecord := addr
 
 	if len(payload) >= 4 {
 		values["prefix"] = types.Value{Value: append([]byte(nil), payload[:4]...), Valid: true}
@@ -142,6 +143,7 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 		if resolved, ok := lookupB524Constraint(replyGroup, replyAddr); ok {
 			constraint = resolved
 			hasConstraint = true
+			constraintRecord = replyAddr
 		}
 	} else {
 		values["prefix"] = types.Value{Valid: false}
@@ -155,27 +157,27 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 
 	if len(payload) == 1 && payload[0] == 0x00 {
 		values["value"] = types.Value{Valid: false}
-		addB524ConstraintValues(values, constraint, hasConstraint)
+		addB524ConstraintValues(values, constraint, hasConstraint, constraintRecord)
 		return values
 	}
 	if len(payload) <= 4 {
 		values["value"] = types.Value{Valid: false}
-		addB524ConstraintValues(values, constraint, hasConstraint)
+		addB524ConstraintValues(values, constraint, hasConstraint, constraintRecord)
 		return values
 	}
 
 	values["value"] = types.Value{Value: append([]byte(nil), payload[4:]...), Valid: true}
-	addB524ConstraintValues(values, constraint, hasConstraint)
+	addB524ConstraintValues(values, constraint, hasConstraint, constraintRecord)
 	return values
 }
 
-func addB524ConstraintValues(values map[string]types.Value, constraint b524Constraint, hasConstraint bool) {
+func addB524ConstraintValues(values map[string]types.Value, constraint b524Constraint, hasConstraint bool, constraintRecord uint16) {
 	if !hasConstraint {
 		return
 	}
 	values["constraints"] = types.Value{Value: constraint.mapValue(), Valid: true}
-	values["constraint_record"] = types.Value{Value: values["addr"].Value, Valid: true}
-	values["constraint_record_hex"] = types.Value{Value: values["addr_hex"].Value, Valid: true}
+	values["constraint_record"] = types.Value{Value: constraintRecord, Valid: true}
+	values["constraint_record_hex"] = types.Value{Value: fmt.Sprintf("%04X", constraintRecord), Valid: true}
 	values["constraint_type"] = types.Value{Value: constraint.Type, Valid: true}
 	values["constraint_min"] = types.Value{Value: constraint.Min, Valid: true}
 	values["constraint_max"] = types.Value{Value: constraint.Max, Valid: true}

--- a/vaillant/system/b524_ext_register_access.go
+++ b/vaillant/system/b524_ext_register_access.go
@@ -144,6 +144,8 @@ func decodeExtRegisterResponse(cmd byte, opcode byte, group, instance byte, addr
 			constraint = resolved
 			hasConstraint = true
 			constraintRecord = replyAddr
+		} else {
+			hasConstraint = false
 		}
 	} else {
 		values["prefix"] = types.Value{Valid: false}


### PR DESCRIPTION
## Summary
- add a static B524 constraints catalog keyed by `(group, record)` where `record` is RR (`uint16`)
- enrich `get_ext_register` decoded output with constraint fields (`constraints`, `constraint_type/min/max/step`, `constraint_record`)
- prefer echoed response `GG/RR` when present to resolve constraint mapping

## Validation
- `go test ./...`

## Notes
- no `0x01 GG II` behavior introduced; mappings are RR-based only
