### PR TITLE
registry.Scan: enrich Vaillant devices with scan.id

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -120,7 +120,7 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 			}
 
 			if info.Manufacturer == "Vaillant" && info.SerialNumber == "" {
-				if serial, ok := readVaillantScanID(ctx, bus, source, target); ok {
+				if serial, ok := readVaillantScanID(ctx, bus, source, address); ok {
 					info.SerialNumber = serial
 				}
 			}

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -128,6 +128,11 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 					info.SerialNumber = serial
 				}
 			}
+			if info.SerialNumber == "" {
+				if existing, ok := registry.Lookup(info.Address); ok {
+					info.SerialNumber = existing.SerialNumber()
+				}
+			}
 			entries = append(entries, registry.Register(info))
 			found[address] = struct{}{}
 		}

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -252,21 +252,21 @@ func formatVaillantSerial(raw string) string {
 	if len(raw) < 28 {
 		return raw
 	}
-	raw = raw[:28]
+	candidate := raw[:28]
 	for i := 0; i < 26; i++ {
-		if raw[i] < '0' || raw[i] > '9' {
+		if candidate[i] < '0' || candidate[i] > '9' {
 			return raw
 		}
 	}
 	return fmt.Sprintf(
 		"%s-%s-%s-%s-%s-%s-%s",
-		raw[0:2],
-		raw[2:4],
-		raw[4:6],
-		raw[6:16],
-		raw[16:20],
-		raw[20:26],
-		raw[26:28],
+		candidate[0:2],
+		candidate[2:4],
+		candidate[4:6],
+		candidate[6:16],
+		candidate[16:20],
+		candidate[20:26],
+		candidate[26:28],
 	)
 }
 

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -16,6 +16,11 @@ const (
 	scanSecondary = byte(0x04)
 )
 
+const (
+	vaillantPrimary        = byte(0xB5)
+	vaillantScanIDSecondary = byte(0x09)
+)
+
 var errScanResponsePayload = errors.New("scan: invalid response payload")
 
 type ScanBus interface {
@@ -113,6 +118,12 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 				}
 				return nil, fmt.Errorf("scan target %02x parse: %w", target, err)
 			}
+
+			if info.Manufacturer == "Vaillant" && info.SerialNumber == "" {
+				if serial, ok := readVaillantScanID(ctx, bus, source, target); ok {
+					info.SerialNumber = serial
+				}
+			}
 			entries = append(entries, registry.Register(info))
 			found[address] = struct{}{}
 		}
@@ -163,6 +174,84 @@ func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
 		SoftwareVersion: fmt.Sprintf("%02X%02X", payload[6], payload[7]),
 		HardwareVersion: fmt.Sprintf("%02X%02X", payload[8], payload[9]),
 	}, nil
+}
+
+func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target byte) (string, bool) {
+	if bus == nil {
+		return "", false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	raw := make([]byte, 0, 32)
+	for qq := byte(0x24); qq <= byte(0x27); qq++ {
+		request := protocol.Frame{
+			Source:    source,
+			Target:    target,
+			Primary:   vaillantPrimary,
+			Secondary: vaillantScanIDSecondary,
+			Data:      []byte{qq},
+		}
+		response, err := bus.Send(ctx, request)
+		if err != nil || response == nil {
+			return "", false
+		}
+		if len(response.Data) != 9 || response.Data[0] != 0x00 {
+			return "", false
+		}
+		raw = append(raw, response.Data[1:]...)
+	}
+
+	trimmed := trimScanIDBytes(raw)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+
+	formatted := formatVaillantSerial(string(trimmed))
+	if formatted == "" {
+		return "", false
+	}
+	return formatted, true
+}
+
+func trimScanIDBytes(data []byte) []byte {
+	end := len(data)
+	for end > 0 {
+		last := data[end-1]
+		if last == 0x00 || last == 0x20 || last == 0xFF {
+			end--
+			continue
+		}
+		break
+	}
+	return data[:end]
+}
+
+func formatVaillantSerial(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if len(raw) < 28 {
+		return raw
+	}
+	raw = raw[:28]
+	for i := 0; i < 26; i++ {
+		if raw[i] < '0' || raw[i] > '9' {
+			return raw
+		}
+	}
+	return fmt.Sprintf(
+		"%s-%s-%s-%s-%s-%s-%s",
+		raw[0:2],
+		raw[2:4],
+		raw[4:6],
+		raw[6:16],
+		raw[16:20],
+		raw[20:26],
+		raw[26:28],
+	)
 }
 
 func shouldSkipScanError(err error) bool {

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -128,8 +128,8 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 					info.SerialNumber = serial
 				}
 			}
-			if info.SerialNumber == "" {
-				if existing, ok := registry.Lookup(info.Address); ok {
+			if info.SerialNumber == "" && info.Manufacturer == "Vaillant" {
+				if existing, ok := registry.Lookup(info.Address); ok && shouldReuseSerial(info, existing) {
 					info.SerialNumber = existing.SerialNumber()
 				}
 			}
@@ -273,6 +273,25 @@ func formatVaillantSerial(raw string) string {
 		candidate[20:26],
 		candidate[26:28],
 	)
+}
+
+func shouldReuseSerial(info DeviceInfo, existing DeviceEntry) bool {
+	if existing == nil || existing.SerialNumber() == "" {
+		return false
+	}
+	if !strings.EqualFold(existing.Manufacturer(), info.Manufacturer) {
+		return false
+	}
+	if info.DeviceID != "" && existing.DeviceID() != info.DeviceID {
+		return false
+	}
+	if info.SoftwareVersion != "" && existing.SoftwareVersion() != info.SoftwareVersion {
+		return false
+	}
+	if info.HardwareVersion != "" && existing.HardwareVersion() != info.HardwareVersion {
+		return false
+	}
+	return true
 }
 
 func shouldSkipScanError(err error) bool {

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -17,7 +17,7 @@ const (
 )
 
 const (
-	vaillantPrimary        = byte(0xB5)
+	vaillantPrimary         = byte(0xB5)
 	vaillantScanIDSecondary = byte(0x09)
 )
 
@@ -120,7 +120,11 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 			}
 
 			if info.Manufacturer == "Vaillant" && info.SerialNumber == "" {
-				if serial, ok := readVaillantScanID(ctx, bus, source, address); ok {
+				serial, ok, err := readVaillantScanID(ctx, bus, source, address)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
 					info.SerialNumber = serial
 				}
 			}
@@ -176,9 +180,9 @@ func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
 	}, nil
 }
 
-func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target byte) (string, bool) {
+func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target byte) (string, bool, error) {
 	if bus == nil {
-		return "", false
+		return "", false, nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -194,25 +198,31 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 			Data:      []byte{qq},
 		}
 		response, err := bus.Send(ctx, request)
-		if err != nil || response == nil {
-			return "", false
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return "", false, err
+			}
+			return "", false, nil
+		}
+		if response == nil {
+			return "", false, nil
 		}
 		if len(response.Data) != 9 || response.Data[0] != 0x00 {
-			return "", false
+			return "", false, nil
 		}
 		raw = append(raw, response.Data[1:]...)
 	}
 
 	trimmed := trimScanIDBytes(raw)
 	if len(trimmed) == 0 {
-		return "", false
+		return "", false, nil
 	}
 
 	formatted := formatVaillantSerial(string(trimmed))
 	if formatted == "" {
-		return "", false
+		return "", false, nil
 	}
-	return formatted, true
+	return formatted, true, nil
 }
 
 func trimScanIDBytes(data []byte) []byte {

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -199,8 +199,14 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 		}
 		response, err := bus.Send(ctx, request)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if errors.Is(err, context.Canceled) {
 				return "", false, err
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return "", false, ctxErr
+				}
+				return "", false, nil
 			}
 			return "", false, nil
 		}

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -346,6 +346,39 @@ func TestScanPreservesKnownSerialWhenScanIDFails(t *testing.T) {
 	}
 }
 
+func TestScanDoesNotReuseSerialForDifferentDeviceIdentity(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x30,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "OLD30",
+		SerialNumber:    "21-22-09-0020184848-0082-005409-N4",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+	})
+	bus := &vaillantScanIDTimeoutBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x20})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry, ok := registry.Lookup(0x30)
+	if !ok {
+		t.Fatalf("expected device 0x30 to be registered")
+	}
+	if entry.DeviceID() != "DEV30" {
+		t.Fatalf("device id = %q; want DEV30", entry.DeviceID())
+	}
+	if entry.SerialNumber() != "" {
+		t.Fatalf("serial number = %q; want empty for identity mismatch", entry.SerialNumber())
+	}
+}
+
 func TestScanSkipsContextDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -316,6 +316,36 @@ func TestScanIgnoresScanIDTimeouts(t *testing.T) {
 	}
 }
 
+func TestScanPreservesKnownSerialWhenScanIDFails(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x30,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "DEV30",
+		SerialNumber:    "21-22-09-0020184848-0082-005409-N4",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+	})
+	bus := &vaillantScanIDTimeoutBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x20})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry, ok := registry.Lookup(0x30)
+	if !ok {
+		t.Fatalf("expected device 0x30 to be registered")
+	}
+	if entry.SerialNumber() != "21-22-09-0020184848-0082-005409-N4" {
+		t.Fatalf("serial number = %q; want preserved value", entry.SerialNumber())
+	}
+}
+
 func TestScanSkipsContextDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -474,3 +474,18 @@ func TestScanSkipsCRCMismatchAndFailsOnInvalidPayloadError(t *testing.T) {
 		t.Fatalf("expected 3 scan calls, got %d", len(bus.calls))
 	}
 }
+
+func TestFormatVaillantSerial(t *testing.T) {
+	t.Parallel()
+
+	formatted := formatVaillantSerial("21220900201848480082005409N4")
+	if formatted != "21-22-09-0020184848-0082-005409-N4" {
+		t.Fatalf("formatted = %q", formatted)
+	}
+
+	rawWithSuffix := "2122ABCD0020184848XYZZ005409N4TAIL"
+	got := formatVaillantSerial(rawWithSuffix)
+	if got != rawWithSuffix {
+		t.Fatalf("fallback serial = %q; want full raw value", got)
+	}
+}

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -212,6 +212,28 @@ func (bus *vaillantScanIDBus) Send(ctx context.Context, frame protocol.Frame) (*
 	return nil, ebuserrors.ErrNoSuchDevice
 }
 
+type vaillantScanIDCanceledBus struct {
+	calls []protocol.Frame
+}
+
+func (bus *vaillantScanIDCanceledBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	bus.calls = append(bus.calls, frame)
+
+	if frame.Primary == scanPrimary && frame.Secondary == scanSecondary {
+		return &protocol.Frame{
+			Source:    0x30,
+			Target:    frame.Source,
+			Primary:   scanPrimary,
+			Secondary: scanSecondary,
+			Data:      []byte{0xB5, 'D', 'E', 'V', '3', '0', 0x05, 0x14, 0x12, 0x04},
+		}, nil
+	}
+	if frame.Primary == vaillantPrimary && frame.Secondary == vaillantScanIDSecondary {
+		return nil, context.Canceled
+	}
+	return nil, ebuserrors.ErrNoSuchDevice
+}
+
 func TestScanUsesDiscoveredAddressForVaillantScanID(t *testing.T) {
 	t.Parallel()
 
@@ -236,6 +258,21 @@ func TestScanUsesDiscoveredAddressForVaillantScanID(t *testing.T) {
 
 	if len(bus.calls) != 5 {
 		t.Fatalf("expected 5 calls (scan + 4 scan.id), got %d", len(bus.calls))
+	}
+}
+
+func TestScanPropagatesContextCancellationFromVaillantScanID(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &vaillantScanIDCanceledBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x20})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Scan error = %v; want context.Canceled", err)
+	}
+	if entries != nil {
+		t.Fatalf("expected nil entries on cancellation, got %d", len(entries))
 	}
 }
 

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -161,6 +161,84 @@ func TestScanSkipsTimeoutAndNACK(t *testing.T) {
 	}
 }
 
+type vaillantScanIDBus struct {
+	calls []protocol.Frame
+}
+
+func (bus *vaillantScanIDBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	bus.calls = append(bus.calls, frame)
+
+	if frame.Primary == scanPrimary && frame.Secondary == scanSecondary {
+		if frame.Target != 0x20 {
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+		return &protocol.Frame{
+			Source:    0x30,
+			Target:    frame.Source,
+			Primary:   scanPrimary,
+			Secondary: scanSecondary,
+			Data:      []byte{0xB5, 'D', 'E', 'V', '3', '0', 0x05, 0x14, 0x12, 0x04},
+		}, nil
+	}
+
+	if frame.Primary == vaillantPrimary && frame.Secondary == vaillantScanIDSecondary {
+		if frame.Target != 0x30 || len(frame.Data) != 1 {
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+
+		var chunk []byte
+		switch frame.Data[0] {
+		case 0x24:
+			chunk = []byte("21220900")
+		case 0x25:
+			chunk = []byte("20184848")
+		case 0x26:
+			chunk = []byte("00820054")
+		case 0x27:
+			chunk = []byte{'0', '9', 'N', '4', 0x00, 0x00, 0x00, 0x00}
+		default:
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+
+		return &protocol.Frame{
+			Source:    frame.Target,
+			Target:    frame.Source,
+			Primary:   vaillantPrimary,
+			Secondary: vaillantScanIDSecondary,
+			Data:      append([]byte{0x00}, chunk...),
+		}, nil
+	}
+
+	return nil, ebuserrors.ErrNoSuchDevice
+}
+
+func TestScanUsesDiscoveredAddressForVaillantScanID(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &vaillantScanIDBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x20})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entry, ok := registry.Lookup(0x30)
+	if !ok {
+		t.Fatalf("expected device 0x30 to be registered")
+	}
+	if entry.SerialNumber() != "21-22-09-0020184848-0082-005409-N4" {
+		t.Fatalf("unexpected serial number: %q", entry.SerialNumber())
+	}
+
+	if len(bus.calls) != 5 {
+		t.Fatalf("expected 5 calls (scan + 4 scan.id), got %d", len(bus.calls))
+	}
+}
+
 func TestScanSkipsContextDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -234,6 +234,24 @@ func (bus *vaillantScanIDCanceledBus) Send(ctx context.Context, frame protocol.F
 	return nil, ebuserrors.ErrNoSuchDevice
 }
 
+type vaillantScanIDTimeoutBus struct{}
+
+func (bus *vaillantScanIDTimeoutBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	if frame.Primary == scanPrimary && frame.Secondary == scanSecondary {
+		return &protocol.Frame{
+			Source:    0x30,
+			Target:    frame.Source,
+			Primary:   scanPrimary,
+			Secondary: scanSecondary,
+			Data:      []byte{0xB5, 'D', 'E', 'V', '3', '0', 0x05, 0x14, 0x12, 0x04},
+		}, nil
+	}
+	if frame.Primary == vaillantPrimary && frame.Secondary == vaillantScanIDSecondary {
+		return nil, context.DeadlineExceeded
+	}
+	return nil, ebuserrors.ErrNoSuchDevice
+}
+
 func TestScanUsesDiscoveredAddressForVaillantScanID(t *testing.T) {
 	t.Parallel()
 
@@ -273,6 +291,28 @@ func TestScanPropagatesContextCancellationFromVaillantScanID(t *testing.T) {
 	}
 	if entries != nil {
 		t.Fatalf("expected nil entries on cancellation, got %d", len(entries))
+	}
+}
+
+func TestScanIgnoresScanIDTimeouts(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &vaillantScanIDTimeoutBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x20})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry, ok := registry.Lookup(0x30)
+	if !ok {
+		t.Fatalf("expected device 0x30 to be registered")
+	}
+	if entry.SerialNumber() != "" {
+		t.Fatalf("serial number = %q; want empty on timeout", entry.SerialNumber())
 	}
 }
 


### PR DESCRIPTION
Closes #73.

## What
- After a successful 07 04 identify response, Vaillant devices get best-effort scan.id enrichment via `0xB5 0x09` selectors `0x24..0x27`.
- The assembled scan.id is trimmed and formatted into a hyphenated serial string when possible.

## Notes
- Enrichment failures do **not** fail the scan; they simply leave `SerialNumber` empty.

## Tests
- `go test ./...`