### PR TITLE
Data: add VRC 720f/3 (0020328845)

### DIFF
--- a/vaillant/productids/product_ids.csv
+++ b/vaillant/productids/product_ids.csv
@@ -542,4 +542,5 @@ Vaillant,SensoNET,VR921,0020282696,Gateway
 Vaillant,myVaillant Connect,VR940f,0020292012,Gateway
 Vaillant,myVaillant Connect,VR940,0020300000,Gateway
 Vaillant,myVaillant Connect,VR940f,0020306235,Gateway
+Vaillant,sensoCOMFORT RF,VRC 720f/3,0020328845,Regulator
 Vaillant,FM5 Functional Module,VR 71,8000015501,Control Centre


### PR DESCRIPTION
Adds missing Vaillant regulator product id entry for `VRC 720f/3` (part number `0020328845`).
