### PR TITLE
meta01: add local CI entrypoint and agent workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS
+
+These instructions apply to the entire repository.
+
+## Workflow
+
+1. Work one issue at a time and keep changes scoped to that issue.
+2. Keep at most one open PR for this repository at any time.
+3. Run `./scripts/ci_local.sh` before pushing.
+4. React (emoji) to every review comment and reply with status when actioned.
+5. If a change modifies externally visible behavior (exports, plane/method semantics, provider contracts), open/update the corresponding docs in `helianthus-docs-ebus` and merge docs alongside code (doc-gate).
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ go build ./...
 ### 2) CI-parity test run
 
 ```bash
+./scripts/ci_local.sh
 go test -race -count=1 ./...
 ```
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> terminology gate"
+if grep -RInwi --exclude-dir=.git -E 'm[a]ster|s[l]ave' .; then
+  echo "Found legacy terminology."
+  exit 1
+fi
+
+echo "==> gofmt"
+unformatted="$(git ls-files '*.go' | xargs -n 50 gofmt -l || true)"
+if [ -n "${unformatted}" ]; then
+  echo "gofmt required for:"
+  echo "${unformatted}"
+  exit 1
+fi
+
+echo "==> go vet"
+go vet ./...
+
+echo "==> go build"
+go build ./...
+
+echo "==> go test (race)"
+go test -race -count=1 ./...
+
+if command -v golangci-lint >/dev/null 2>&1; then
+  echo "==> golangci-lint"
+  golangci-lint run ./...
+else
+  echo "==> golangci-lint not found; skipping"
+fi
+
+if command -v tinygo >/dev/null 2>&1; then
+  echo "==> tinygo build (main packages)"
+  toolchain="${TINYGO_GOTOOLCHAIN:-go1.25.0}"
+  echo "Using GOTOOLCHAIN=${toolchain} for tinygo"
+  mains="$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... | sed '/^$/d')"
+  if [ -z "${mains}" ]; then
+    echo "No main packages found; skipping TinyGo build."
+    exit 0
+  fi
+  for pkg in ${mains}; do
+    echo "tinygo build -target esp32 ${pkg}"
+    GOTOOLCHAIN="${toolchain}" tinygo build -target esp32 "${pkg}"
+  done
+else
+  echo "==> tinygo not found; skipping"
+fi
+

--- a/vaillant/productids/catalog.go
+++ b/vaillant/productids/catalog.go
@@ -1,11 +1,11 @@
 package productids
 
 import (
+	_ "embed"
 	"encoding/csv"
 	"errors"
 	"io"
 	"strings"
-	_ "embed"
 )
 
 //go:embed product_ids.csv

--- a/vaillant/system/operational_data.go
+++ b/vaillant/system/operational_data.go
@@ -143,8 +143,8 @@ func decodeOperationalDateTime(payload []byte) (map[string]types.Value, error) {
 
 	var (
 		hour, minute, day, month, year types.Value
-		temp                          types.Value
-		err                           error
+		temp                           types.Value
+		err                            error
 	)
 	if len(payload) >= btiBdaSize {
 		// ebusd types:

--- a/vendor/github.com/d3vi1/helianthus-ebusgo/errors/errors_test.go
+++ b/vendor/github.com/d3vi1/helianthus-ebusgo/errors/errors_test.go
@@ -117,4 +117,3 @@ func TestClassifiers_CoverAllSentinels(t *testing.T) {
 		})
 	}
 }
-

--- a/vendor/github.com/d3vi1/helianthus-ebusgo/protocol/bus.go
+++ b/vendor/github.com/d3vi1/helianthus-ebusgo/protocol/bus.go
@@ -73,7 +73,7 @@ func NewBus(tr transport.RawTransport, config BusConfig, queueCapacity int) *Bus
 		queue:     newPriorityQueue(),
 		// Capacity 1 to coalesce wake-ups from multiple Send calls.
 		notify: make(chan struct{}, 1),
-		outCap:    queueCapacity,
+		outCap: queueCapacity,
 	}
 }
 

--- a/vendor/github.com/d3vi1/helianthus-ebusgo/types/data2b.go
+++ b/vendor/github.com/d3vi1/helianthus-ebusgo/types/data2b.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	data2bSize        = 2
-	data2bDivisor     = 256.0
-	data2bEpsilon     = 1e-9
-	data2bReplacement = uint16(0x8000)
+	data2bSize           = 2
+	data2bDivisor        = 256.0
+	data2bEpsilon        = 1e-9
+	data2bReplacement    = uint16(0x8000)
 	data2bReplacementInt = int64(-32768)
-	data2bMinInt      = int64(-32767)
-	data2bMaxInt      = int64(32767)
+	data2bMinInt         = int64(-32767)
+	data2bMaxInt         = int64(32767)
 )
 
 var (

--- a/vendor/github.com/d3vi1/helianthus-ebusgo/types/data2c.go
+++ b/vendor/github.com/d3vi1/helianthus-ebusgo/types/data2c.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	data2cSize        = 2
-	data2cDivisor     = 16.0
-	data2cEpsilon     = 1e-9
-	data2cReplacement = uint16(0x8000)
+	data2cSize           = 2
+	data2cDivisor        = 16.0
+	data2cEpsilon        = 1e-9
+	data2cReplacement    = uint16(0x8000)
 	data2cReplacementInt = int64(-32768)
-	data2cMinInt      = int64(-32767)
-	data2cMaxInt      = int64(32767)
+	data2cMinInt         = int64(-32767)
+	data2cMaxInt         = int64(32767)
 )
 
 var (


### PR DESCRIPTION
Fixes #76.

Adds:
- `scripts/ci_local.sh` (terminology gate, gofmt check, vet/build/test/race, golangci-lint, TinyGo build with toolchain pin)
- `AGENTS.md` baseline workflow rules
- README quickstart update