### PR TITLE
router: scheduler coalescing + refresh policy (META-09.1)

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -2,8 +2,11 @@ package router
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
@@ -44,6 +47,11 @@ type BusEventRouter struct {
 	mu            sync.RWMutex
 	subscriptions map[subscriptionKey][]Plane
 	events        chan BroadcastEvent
+
+	invokeMu    sync.Mutex
+	invokeCache map[string]*invokeEntry
+	options     RouterOptions
+	now         func() time.Time
 }
 
 type subscriptionKey struct {
@@ -51,11 +59,59 @@ type subscriptionKey struct {
 	secondary byte
 }
 
+type RefreshClass string
+
+const (
+	RefreshClassState  RefreshClass = "state"
+	RefreshClassConfig RefreshClass = "config"
+)
+
+const (
+	defaultStateRefreshInterval  = 1 * time.Minute
+	defaultConfigRefreshInterval = 5 * time.Minute
+)
+
+type ClassifyInvocationFunc func(
+	planeName string,
+	methodName string,
+	params map[string]any,
+) RefreshClass
+
+type RouterOptions struct {
+	StateRefreshInterval  time.Duration
+	ConfigRefreshInterval time.Duration
+	ClassifyInvocation    ClassifyInvocationFunc
+	DisableCoalescing     bool
+}
+
+type invokeEntry struct {
+	running bool
+	done    chan struct{}
+
+	lastOKAt     time.Time
+	lastFrame    protocol.Frame
+	hasLastFrame bool
+}
+
 func NewBusEventRouter(bus Bus) *BusEventRouter {
+	return NewBusEventRouterWithOptions(bus, RouterOptions{})
+}
+
+func NewBusEventRouterWithOptions(bus Bus, options RouterOptions) *BusEventRouter {
+	if options.StateRefreshInterval <= 0 {
+		options.StateRefreshInterval = defaultStateRefreshInterval
+	}
+	if options.ConfigRefreshInterval <= 0 {
+		options.ConfigRefreshInterval = defaultConfigRefreshInterval
+	}
+
 	return &BusEventRouter{
 		bus:           bus,
 		subscriptions: make(map[subscriptionKey][]Plane),
 		events:        make(chan BroadcastEvent, 64),
+		invokeCache:   make(map[string]*invokeEntry),
+		options:       options,
+		now:           time.Now,
 	}
 }
 
@@ -127,6 +183,9 @@ func (router *BusEventRouter) Invoke(ctx context.Context, plane Plane, methodNam
 	if plane == nil {
 		return nil, fmt.Errorf("router.Invoke missing plane: %w", ebuserrors.ErrInvalidPayload)
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	method, ok := findMethod(plane.Methods(), methodName)
 	if !ok {
@@ -138,19 +197,218 @@ func (router *BusEventRouter) Invoke(ctx context.Context, plane Plane, methodNam
 		return nil, fmt.Errorf("router.Invoke build plane=%s method=%s: %w", plane.Name(), method.Name(), err)
 	}
 
-	response, err := router.bus.Send(ctx, request)
-	if err != nil {
-		return nil, fmt.Errorf("router.Invoke send plane=%s method=%s: %w", plane.Name(), method.Name(), err)
-	}
-	if response == nil {
-		return nil, fmt.Errorf("router.Invoke empty response plane=%s method=%s: %w", plane.Name(), method.Name(), ebuserrors.ErrInvalidPayload)
+	maxAge := router.invokeMaxAge(plane.Name(), method, params)
+	if maxAge <= 0 {
+		decoded, _, err := router.sendAndDecode(ctx, plane, method, params, request)
+		return decoded, err
 	}
 
-	decoded, err := plane.DecodeResponse(method, *response, params)
+	cacheKey, err := buildInvokeCacheKey(plane.Name(), method.Name(), params)
 	if err != nil {
-		return nil, fmt.Errorf("router.Invoke decode plane=%s method=%s: %w", plane.Name(), method.Name(), err)
+		return nil, fmt.Errorf("router.Invoke key plane=%s method=%s: %w", plane.Name(), method.Name(), err)
 	}
-	return decoded, nil
+
+	for {
+		router.invokeMu.Lock()
+		entry := router.invokeCache[cacheKey]
+		if entry == nil {
+			entry = &invokeEntry{}
+			router.invokeCache[cacheKey] = entry
+		}
+
+		if !entry.running && entry.hasLastFrame {
+			age := router.now().Sub(entry.lastOKAt)
+			if age >= 0 && age <= maxAge {
+				frame := cloneFrame(entry.lastFrame)
+				router.invokeMu.Unlock()
+				decoded, decodeErr := plane.DecodeResponse(method, frame, params)
+				if decodeErr != nil {
+					return nil, fmt.Errorf(
+						"router.Invoke decode plane=%s method=%s: %w",
+						plane.Name(),
+						method.Name(),
+						decodeErr,
+					)
+				}
+				return decoded, nil
+			}
+		}
+
+		if entry.running {
+			done := entry.done
+			router.invokeMu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-done:
+				continue
+			}
+		}
+
+		entry.running = true
+		entry.done = make(chan struct{})
+		done := entry.done
+		router.invokeMu.Unlock()
+
+		decoded, frame, invokeErr := router.sendAndDecode(ctx, plane, method, params, request)
+
+		router.invokeMu.Lock()
+		entry.running = false
+		if invokeErr == nil {
+			entry.lastOKAt = router.now()
+			entry.lastFrame = cloneFrame(frame)
+			entry.hasLastFrame = true
+		}
+		close(done)
+		router.invokeMu.Unlock()
+
+		if invokeErr != nil {
+			return nil, invokeErr
+		}
+		return decoded, nil
+	}
+}
+
+func (router *BusEventRouter) sendAndDecode(
+	ctx context.Context,
+	plane Plane,
+	method registry.Method,
+	params map[string]any,
+	request protocol.Frame,
+) (any, protocol.Frame, error) {
+	response, err := router.bus.Send(ctx, request)
+	if err != nil {
+		return nil, protocol.Frame{}, fmt.Errorf(
+			"router.Invoke send plane=%s method=%s: %w",
+			plane.Name(),
+			method.Name(),
+			err,
+		)
+	}
+	if response == nil {
+		return nil, protocol.Frame{}, fmt.Errorf(
+			"router.Invoke empty response plane=%s method=%s: %w",
+			plane.Name(),
+			method.Name(),
+			ebuserrors.ErrInvalidPayload,
+		)
+	}
+	frame := cloneFrame(*response)
+
+	decoded, err := plane.DecodeResponse(method, frame, params)
+	if err != nil {
+		return nil, protocol.Frame{}, fmt.Errorf(
+			"router.Invoke decode plane=%s method=%s: %w",
+			plane.Name(),
+			method.Name(),
+			err,
+		)
+	}
+	return decoded, frame, nil
+}
+
+func (router *BusEventRouter) invokeMaxAge(
+	planeName string,
+	method registry.Method,
+	params map[string]any,
+) time.Duration {
+	if router == nil || router.options.DisableCoalescing || method == nil || !method.ReadOnly() {
+		return 0
+	}
+
+	class := inferRefreshClass(method.Name())
+	if router.options.ClassifyInvocation != nil {
+		override := router.options.ClassifyInvocation(planeName, method.Name(), params)
+		if override != "" {
+			class = override
+		}
+	}
+	if paramClass, ok := refreshClassFromParams(params); ok {
+		class = paramClass
+	}
+
+	if class == RefreshClassConfig {
+		return router.options.ConfigRefreshInterval
+	}
+	return router.options.StateRefreshInterval
+}
+
+func inferRefreshClass(methodName string) RefreshClass {
+	normalized := strings.ToLower(strings.TrimSpace(methodName))
+	if normalized == "" {
+		return RefreshClassState
+	}
+
+	configTokens := []string{
+		"config",
+		"setpoint",
+		"desired",
+		"mode",
+		"curve",
+		"holiday",
+		"name",
+		"limit",
+		"offset",
+		"schedule",
+		"timer",
+		"mapping",
+	}
+	for _, token := range configTokens {
+		if strings.Contains(normalized, token) {
+			return RefreshClassConfig
+		}
+	}
+	return RefreshClassState
+}
+
+func refreshClassFromParams(params map[string]any) (RefreshClass, bool) {
+	if len(params) == 0 {
+		return "", false
+	}
+	for _, key := range []string{"cache_class", "refresh_class"} {
+		value, ok := params[key]
+		if !ok {
+			continue
+		}
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		normalized := strings.ToLower(strings.TrimSpace(text))
+		switch normalized {
+		case string(RefreshClassState):
+			return RefreshClassState, true
+		case string(RefreshClassConfig):
+			return RefreshClassConfig, true
+		}
+	}
+	return "", false
+}
+
+func buildInvokeCacheKey(
+	planeName string,
+	methodName string,
+	params map[string]any,
+) (string, error) {
+	normalizedParams := params
+	if normalizedParams == nil {
+		normalizedParams = map[string]any{}
+	}
+	serialized, err := json.Marshal(normalizedParams)
+	if err != nil {
+		return "", err
+	}
+	return planeName + "|" + methodName + "|" + string(serialized), nil
+}
+
+func cloneFrame(frame protocol.Frame) protocol.Frame {
+	return protocol.Frame{
+		Source:    frame.Source,
+		Target:    frame.Target,
+		Primary:   frame.Primary,
+		Secondary: frame.Secondary,
+		Data:      append([]byte(nil), frame.Data...),
+	}
 }
 
 func findMethod(methods []registry.Method, name string) (registry.Method, bool) {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,6 +98,35 @@ func (bus *mockBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.F
 	bus.callCount++
 	bus.lastRequest = frame
 	return bus.response, bus.err
+}
+
+type coalescingBus struct {
+	mu        sync.Mutex
+	response  protocol.Frame
+	delay     time.Duration
+	callCount int
+}
+
+func (bus *coalescingBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	if bus.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(bus.delay):
+		}
+	}
+
+	bus.mu.Lock()
+	bus.callCount++
+	response := cloneFrame(bus.response)
+	bus.mu.Unlock()
+	return &response, nil
+}
+
+func (bus *coalescingBus) Calls() int {
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	return bus.callCount
 }
 
 func TestBusEventRouter_BroadcastFanOut(t *testing.T) {
@@ -258,5 +288,212 @@ func TestBusEventRouter_EmitsDecodedBroadcastEvents(t *testing.T) {
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timeout waiting for broadcast event")
+	}
+}
+
+func TestBusEventRouter_InvokeCoalescesConcurrentReadOnlyCalls(t *testing.T) {
+	t.Parallel()
+
+	method := mockMethod{
+		name:     "read_state",
+		readOnly: true,
+		template: mockTemplate{primary: 0xB5, secondary: 0x24},
+	}
+
+	plane := &mockPlane{
+		name:    "system",
+		methods: []registry.Method{method},
+		buildRequest: func(method registry.Method, params map[string]any) (protocol.Frame, error) {
+			return protocol.Frame{Source: 0x31, Target: 0x15, Primary: 0xB5, Secondary: 0x24}, nil
+		},
+		decodeResponse: func(method registry.Method, response protocol.Frame, params map[string]any) (any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	}
+
+	bus := &coalescingBus{
+		response: protocol.Frame{Source: 0x15, Target: 0x31, Primary: 0xB5, Secondary: 0x24, Data: []byte{0x01}},
+		delay:    40 * time.Millisecond,
+	}
+	eventRouter := NewBusEventRouter(bus)
+
+	const workers = 6
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := eventRouter.Invoke(context.Background(), plane, "read_state", map[string]any{"addr": 0x10})
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("Invoke error = %v", err)
+		}
+	}
+	if got := bus.Calls(); got != 1 {
+		t.Fatalf("bus calls = %d; want 1", got)
+	}
+}
+
+func TestBusEventRouter_InvokeUsesRefreshPolicyWindows(t *testing.T) {
+	t.Parallel()
+
+	methodState := mockMethod{
+		name:     "read_state",
+		readOnly: true,
+		template: mockTemplate{primary: 0xB5, secondary: 0x24},
+	}
+	methodConfig := mockMethod{
+		name:     "read_config",
+		readOnly: true,
+		template: mockTemplate{primary: 0xB5, secondary: 0x24},
+	}
+	plane := &mockPlane{
+		name:    "system",
+		methods: []registry.Method{methodState, methodConfig},
+		buildRequest: func(method registry.Method, params map[string]any) (protocol.Frame, error) {
+			return protocol.Frame{Source: 0x31, Target: 0x15, Primary: 0xB5, Secondary: 0x24}, nil
+		},
+		decodeResponse: func(method registry.Method, response protocol.Frame, params map[string]any) (any, error) {
+			return map[string]any{"name": method.Name()}, nil
+		},
+	}
+
+	bus := &coalescingBus{
+		response: protocol.Frame{Source: 0x15, Target: 0x31, Primary: 0xB5, Secondary: 0x24, Data: []byte{0x01}},
+	}
+
+	eventRouter := NewBusEventRouterWithOptions(bus, RouterOptions{
+		StateRefreshInterval:  30 * time.Millisecond,
+		ConfigRefreshInterval: 90 * time.Millisecond,
+	})
+
+	_, err := eventRouter.Invoke(context.Background(), plane, "read_state", map[string]any{"addr": 0x10})
+	if err != nil {
+		t.Fatalf("Invoke state #1 error = %v", err)
+	}
+	_, err = eventRouter.Invoke(context.Background(), plane, "read_state", map[string]any{"addr": 0x10})
+	if err != nil {
+		t.Fatalf("Invoke state #2 error = %v", err)
+	}
+	if got := bus.Calls(); got != 1 {
+		t.Fatalf("state warm cache calls = %d; want 1", got)
+	}
+
+	time.Sleep(35 * time.Millisecond)
+	_, err = eventRouter.Invoke(context.Background(), plane, "read_state", map[string]any{"addr": 0x10})
+	if err != nil {
+		t.Fatalf("Invoke state #3 error = %v", err)
+	}
+	if got := bus.Calls(); got != 2 {
+		t.Fatalf("state after ttl calls = %d; want 2", got)
+	}
+
+	_, err = eventRouter.Invoke(context.Background(), plane, "read_config", map[string]any{"addr": 0x11})
+	if err != nil {
+		t.Fatalf("Invoke config #1 error = %v", err)
+	}
+	time.Sleep(35 * time.Millisecond)
+	_, err = eventRouter.Invoke(context.Background(), plane, "read_config", map[string]any{"addr": 0x11})
+	if err != nil {
+		t.Fatalf("Invoke config #2 error = %v", err)
+	}
+	if got := bus.Calls(); got != 3 {
+		t.Fatalf("config still cached calls = %d; want 3", got)
+	}
+	time.Sleep(65 * time.Millisecond)
+	_, err = eventRouter.Invoke(context.Background(), plane, "read_config", map[string]any{"addr": 0x11})
+	if err != nil {
+		t.Fatalf("Invoke config #3 error = %v", err)
+	}
+	if got := bus.Calls(); got != 4 {
+		t.Fatalf("config after ttl calls = %d; want 4", got)
+	}
+}
+
+func TestBusEventRouter_InvokeRefreshClassParamOverridesMethodHeuristic(t *testing.T) {
+	t.Parallel()
+
+	method := mockMethod{
+		name:     "read_state",
+		readOnly: true,
+		template: mockTemplate{primary: 0xB5, secondary: 0x24},
+	}
+	plane := &mockPlane{
+		name:    "system",
+		methods: []registry.Method{method},
+		buildRequest: func(method registry.Method, params map[string]any) (protocol.Frame, error) {
+			return protocol.Frame{Source: 0x31, Target: 0x15, Primary: 0xB5, Secondary: 0x24}, nil
+		},
+		decodeResponse: func(method registry.Method, response protocol.Frame, params map[string]any) (any, error) {
+			return map[string]any{"name": method.Name()}, nil
+		},
+	}
+	bus := &coalescingBus{
+		response: protocol.Frame{Source: 0x15, Target: 0x31, Primary: 0xB5, Secondary: 0x24, Data: []byte{0x01}},
+	}
+
+	eventRouter := NewBusEventRouterWithOptions(bus, RouterOptions{
+		StateRefreshInterval:  25 * time.Millisecond,
+		ConfigRefreshInterval: 80 * time.Millisecond,
+	})
+
+	params := map[string]any{"addr": 0x12, "cache_class": "config"}
+	_, err := eventRouter.Invoke(context.Background(), plane, "read_state", params)
+	if err != nil {
+		t.Fatalf("Invoke #1 error = %v", err)
+	}
+	time.Sleep(30 * time.Millisecond)
+	_, err = eventRouter.Invoke(context.Background(), plane, "read_state", params)
+	if err != nil {
+		t.Fatalf("Invoke #2 error = %v", err)
+	}
+	if got := bus.Calls(); got != 1 {
+		t.Fatalf("calls = %d; want 1 with config override", got)
+	}
+}
+
+func TestBusEventRouter_InvokeWriteMethodsDoNotUseCache(t *testing.T) {
+	t.Parallel()
+
+	method := mockMethod{
+		name:     "set_register",
+		readOnly: false,
+		template: mockTemplate{primary: 0xB5, secondary: 0x24},
+	}
+	plane := &mockPlane{
+		name:    "system",
+		methods: []registry.Method{method},
+		buildRequest: func(method registry.Method, params map[string]any) (protocol.Frame, error) {
+			return protocol.Frame{Source: 0x31, Target: 0x15, Primary: 0xB5, Secondary: 0x24}, nil
+		},
+		decodeResponse: func(method registry.Method, response protocol.Frame, params map[string]any) (any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	bus := &coalescingBus{
+		response: protocol.Frame{Source: 0x15, Target: 0x31, Primary: 0xB5, Secondary: 0x24, Data: []byte{0x01}},
+	}
+	eventRouter := NewBusEventRouterWithOptions(bus, RouterOptions{
+		StateRefreshInterval:  1 * time.Minute,
+		ConfigRefreshInterval: 5 * time.Minute,
+	})
+
+	_, err := eventRouter.Invoke(context.Background(), plane, "set_register", map[string]any{"addr": 0x20})
+	if err != nil {
+		t.Fatalf("Invoke #1 error = %v", err)
+	}
+	_, err = eventRouter.Invoke(context.Background(), plane, "set_register", map[string]any{"addr": 0x20})
+	if err != nil {
+		t.Fatalf("Invoke #2 error = %v", err)
+	}
+	if got := bus.Calls(); got != 2 {
+		t.Fatalf("calls = %d; want 2 for write method", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add invoke coalescing in `router.BusEventRouter` for read-only methods, keyed by `(plane, method, params)`
- add tunable refresh policy windows (state/config) with default `1m`/`5m`
- add refresh-class selection from method-name heuristics and explicit params (`cache_class` / `refresh_class`)
- add concurrency and policy tests covering coalescing, TTL expiry, override behavior, and write-method bypass

## Validation
- ./scripts/ci_local.sh

Closes #77
