### PR TITLE
Registry: canonical physical identity with alias addresses (#80)

### DIFF
--- a/registry/identity.go
+++ b/registry/identity.go
@@ -1,0 +1,63 @@
+package registry
+
+import "strings"
+
+type physicalIdentity struct {
+	manufacturer    string
+	deviceID        string
+	serialNumber    string
+	macAddress      string
+	softwareVersion string
+	hardwareVersion string
+}
+
+func canonicalPhysicalIdentity(info DeviceInfo) physicalIdentity {
+	return physicalIdentity{
+		manufacturer:    normalizeIdentityPart(info.Manufacturer),
+		deviceID:        normalizeIdentityPart(info.DeviceID),
+		serialNumber:    normalizeIdentityPart(info.SerialNumber),
+		macAddress:      normalizeIdentityPart(info.MacAddress),
+		softwareVersion: normalizeIdentityPart(info.SoftwareVersion),
+		hardwareVersion: normalizeIdentityPart(info.HardwareVersion),
+	}
+}
+
+func (identity physicalIdentity) key() string {
+	if identity.manufacturer == "" || identity.deviceID == "" {
+		return identity.withFallbackModelSignature()
+	}
+	if identity.serialNumber != "" {
+		return strings.Join([]string{
+			"sn",
+			identity.manufacturer,
+			identity.deviceID,
+			identity.serialNumber,
+		}, "|")
+	}
+	if identity.macAddress != "" {
+		return strings.Join([]string{
+			"mac",
+			identity.manufacturer,
+			identity.deviceID,
+			identity.macAddress,
+		}, "|")
+	}
+	return identity.withFallbackModelSignature()
+}
+
+func (identity physicalIdentity) withFallbackModelSignature() string {
+	if identity.manufacturer == "" || identity.deviceID == "" || identity.softwareVersion == "" || identity.hardwareVersion == "" {
+		return ""
+	}
+	return strings.Join([]string{
+		"sig",
+		identity.manufacturer,
+		identity.deviceID,
+		identity.softwareVersion,
+		identity.hardwareVersion,
+	}, "|")
+}
+
+func normalizeIdentityPart(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -18,6 +18,7 @@ type DeviceInfo struct {
 
 type DeviceEntry interface {
 	Address() byte
+	Addresses() []byte
 	Manufacturer() string
 	DeviceID() string
 	SerialNumber() string
@@ -59,7 +60,8 @@ type DeviceRegistry struct {
 	mu        sync.RWMutex
 	providers []PlaneProvider
 	entries   map[byte]*deviceEntry
-	order     []byte
+	identity  map[string]*deviceEntry
+	order     []*deviceEntry
 }
 
 func NewDeviceRegistry(providers []PlaneProvider) *DeviceRegistry {
@@ -68,6 +70,7 @@ func NewDeviceRegistry(providers []PlaneProvider) *DeviceRegistry {
 	return &DeviceRegistry{
 		providers: providerCopy,
 		entries:   make(map[byte]*deviceEntry),
+		identity:  make(map[string]*deviceEntry),
 	}
 }
 
@@ -78,17 +81,59 @@ func (r *DeviceRegistry) RegisterProvider(provider PlaneProvider) {
 }
 
 func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
-	r.mu.RLock()
-	providers := make([]PlaneProvider, len(r.providers))
-	copy(providers, r.providers)
-	r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
+	physical := canonicalPhysicalIdentity(info)
+	identityKey := physical.key()
 	planes := make([]Plane, 0)
-	matched := make([]PlaneProvider, 0, len(providers))
-	for _, provider := range providers {
-		if provider.Match(info) {
+	matched := make([]PlaneProvider, 0, len(r.providers))
+
+	existingByAddress := r.entries[info.Address]
+	if identityKey == "" && existingByAddress != nil {
+		physical = existingByAddress.physical
+		identityKey = existingByAddress.identityKey
+	}
+
+	existingByIdentity := (*deviceEntry)(nil)
+	if identityKey != "" {
+		existingByIdentity = r.identity[identityKey]
+	}
+
+	entry := existingByIdentity
+	if entry == nil {
+		entry = existingByAddress
+	}
+	if entry == nil {
+		if fallback, ok := r.lookupCompatibleBySignatureLocked(info); ok {
+			entry = fallback
+		}
+	}
+
+	if existingByAddress != nil && existingByAddress != entry {
+		r.detachAddressLocked(existingByAddress, info.Address)
+	}
+
+	if entry == nil {
+		entry = &deviceEntry{
+			primaryAddress: info.Address,
+			addresses:      []byte{info.Address},
+		}
+		r.order = append(r.order, entry)
+	} else if !containsAddress(entry.addresses, info.Address) {
+		entry.addresses = append(entry.addresses, info.Address)
+	}
+
+	storedInfo := info
+	storedInfo.Address = entry.primaryAddress
+	if info.SerialNumber == "" && info.MacAddress == "" && entry.identityKey != "" {
+		identityKey = entry.identityKey
+	}
+
+	for _, provider := range r.providers {
+		if provider.Match(storedInfo) {
 			matched = append(matched, provider)
-			planes = append(planes, provider.CreatePlanes(info)...)
+			planes = append(planes, provider.CreatePlanes(storedInfo)...)
 		}
 	}
 
@@ -98,7 +143,7 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 		if !ok {
 			continue
 		}
-		projections = append(projections, projectionProvider.CreateProjections(info, planes)...)
+		projections = append(projections, projectionProvider.CreateProjections(storedInfo, planes)...)
 	}
 
 	index, projectionErr := BuildCanonicalIndex(projections)
@@ -106,22 +151,89 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 		projections = nil
 	}
 
-	entry := &deviceEntry{
-		info:        info,
-		planes:      planes,
-		projections: projections,
-		index:       index,
-		indexErr:    projectionErr,
+	if entry.identityKey != "" && entry.identityKey != identityKey {
+		delete(r.identity, entry.identityKey)
 	}
+	entry.info = storedInfo
+	entry.physical = physical
+	entry.identityKey = identityKey
+	entry.planes = planes
+	entry.projections = projections
+	entry.index = index
+	entry.indexErr = projectionErr
 
-	r.mu.Lock()
-	if _, exists := r.entries[info.Address]; !exists {
-		r.order = append(r.order, info.Address)
+	if identityKey != "" {
+		r.identity[identityKey] = entry
 	}
 	r.entries[info.Address] = entry
-	r.mu.Unlock()
 
 	return entry
+}
+
+func (r *DeviceRegistry) lookupByIdentity(info DeviceInfo) (DeviceEntry, bool) {
+	identity := canonicalPhysicalIdentity(info).key()
+	if identity == "" {
+		return r.lookupBySignature(info)
+	}
+
+	r.mu.RLock()
+	entry, ok := r.identity[identity]
+	r.mu.RUnlock()
+	if !ok {
+		return r.lookupBySignature(info)
+	}
+	return entry, true
+}
+
+func (r *DeviceRegistry) lookupBySignature(info DeviceInfo) (DeviceEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.lookupCompatibleBySignatureLocked(info)
+	if !ok {
+		return nil, false
+	}
+	return entry, true
+}
+
+func (r *DeviceRegistry) lookupCompatibleBySignatureLocked(info DeviceInfo) (*deviceEntry, bool) {
+	signature := canonicalPhysicalIdentity(info).withFallbackModelSignature()
+	if signature == "" {
+		return nil, false
+	}
+	var match *deviceEntry
+	for _, candidate := range r.order {
+		if candidate == nil {
+			continue
+		}
+		if candidate.physical.withFallbackModelSignature() != signature {
+			continue
+		}
+		if !canMergeIdentity(info, candidate.info) {
+			continue
+		}
+		if match != nil && match != candidate {
+			return nil, false
+		}
+		match = candidate
+	}
+	if match == nil {
+		return nil, false
+	}
+	return match, true
+}
+
+func canMergeIdentity(incoming DeviceInfo, existing DeviceInfo) bool {
+	normalizedIncomingSerial := normalizeIdentityPart(incoming.SerialNumber)
+	normalizedExistingSerial := normalizeIdentityPart(existing.SerialNumber)
+	if normalizedIncomingSerial != "" && normalizedExistingSerial != "" && normalizedIncomingSerial != normalizedExistingSerial {
+		return false
+	}
+	normalizedIncomingMAC := normalizeIdentityPart(incoming.MacAddress)
+	normalizedExistingMAC := normalizeIdentityPart(existing.MacAddress)
+	if normalizedIncomingMAC != "" && normalizedExistingMAC != "" && normalizedIncomingMAC != normalizedExistingMAC {
+		return false
+	}
+	return true
 }
 
 func (r *DeviceRegistry) Lookup(address byte) (DeviceEntry, bool) {
@@ -136,17 +248,12 @@ func (r *DeviceRegistry) Lookup(address byte) (DeviceEntry, bool) {
 
 func (r *DeviceRegistry) Iterate(fn func(DeviceEntry) bool) {
 	r.mu.RLock()
-	order := make([]byte, len(r.order))
+	order := make([]*deviceEntry, len(r.order))
 	copy(order, r.order)
-	entries := make(map[byte]*deviceEntry, len(r.entries))
-	for address, entry := range r.entries {
-		entries[address] = entry
-	}
 	r.mu.RUnlock()
 
-	for _, address := range order {
-		entry, ok := entries[address]
-		if !ok {
+	for _, entry := range order {
+		if entry == nil {
 			continue
 		}
 		if !fn(entry) {
@@ -155,16 +262,58 @@ func (r *DeviceRegistry) Iterate(fn func(DeviceEntry) bool) {
 	}
 }
 
+func (r *DeviceRegistry) detachAddressLocked(entry *deviceEntry, address byte) {
+	if entry == nil {
+		return
+	}
+	delete(r.entries, address)
+	if !containsAddress(entry.addresses, address) {
+		return
+	}
+
+	entry.addresses = removeAddress(entry.addresses, address)
+	if len(entry.addresses) == 0 {
+		if entry.identityKey != "" {
+			delete(r.identity, entry.identityKey)
+		}
+		r.order = removeEntry(r.order, entry)
+		return
+	}
+	if entry.primaryAddress == address {
+		entry.primaryAddress = entry.addresses[0]
+		entry.info.Address = entry.primaryAddress
+	}
+}
+
 type deviceEntry struct {
-	info        DeviceInfo
-	planes      []Plane
-	projections []Projection
-	index       CanonicalIndex
-	indexErr    error
+	primaryAddress byte
+	addresses      []byte
+	physical       physicalIdentity
+	identityKey    string
+	info           DeviceInfo
+	planes         []Plane
+	projections    []Projection
+	index          CanonicalIndex
+	indexErr       error
 }
 
 func (d *deviceEntry) Address() byte {
+	if d.primaryAddress != 0 {
+		return d.primaryAddress
+	}
 	return d.info.Address
+}
+
+func (d *deviceEntry) Addresses() []byte {
+	if len(d.addresses) == 0 {
+		if d.info.Address == 0 {
+			return nil
+		}
+		return []byte{d.info.Address}
+	}
+	out := make([]byte, len(d.addresses))
+	copy(out, d.addresses)
+	return out
 }
 
 func (d *deviceEntry) Manufacturer() string {
@@ -207,4 +356,33 @@ func CanonicalIndexForEntry(entry DeviceEntry) (CanonicalIndex, error) {
 		return internal.index, internal.indexErr
 	}
 	return BuildCanonicalIndex(entry.Projections())
+}
+
+func containsAddress(addresses []byte, address byte) bool {
+	for _, existing := range addresses {
+		if existing == address {
+			return true
+		}
+	}
+	return false
+}
+
+func removeAddress(addresses []byte, address byte) []byte {
+	for index, existing := range addresses {
+		if existing != address {
+			continue
+		}
+		return append(addresses[:index], addresses[index+1:]...)
+	}
+	return addresses
+}
+
+func removeEntry(entries []*deviceEntry, entry *deviceEntry) []*deviceEntry {
+	for index, existing := range entries {
+		if existing != entry {
+			continue
+		}
+		return append(entries[:index], entries[index+1:]...)
+	}
+	return entries
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -104,6 +104,9 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	if entry == nil {
 		entry = existingByAddress
 	}
+	if entry == existingByAddress && existingByIdentity == nil && existingByAddress != nil && (!canMergeIdentity(info, existingByAddress.info) || hasConflictingModelSignature(info, existingByAddress.info)) {
+		entry = nil
+	}
 	if entry == nil {
 		if fallback, ok := r.lookupCompatibleBySignatureLocked(info); ok {
 			entry = fallback
@@ -125,6 +128,24 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	}
 
 	storedInfo := info
+	if storedInfo.Manufacturer == "" {
+		storedInfo.Manufacturer = entry.info.Manufacturer
+	}
+	if storedInfo.DeviceID == "" {
+		storedInfo.DeviceID = entry.info.DeviceID
+	}
+	if storedInfo.SoftwareVersion == "" {
+		storedInfo.SoftwareVersion = entry.info.SoftwareVersion
+	}
+	if storedInfo.HardwareVersion == "" {
+		storedInfo.HardwareVersion = entry.info.HardwareVersion
+	}
+	if storedInfo.SerialNumber == "" {
+		storedInfo.SerialNumber = entry.info.SerialNumber
+	}
+	if storedInfo.MacAddress == "" {
+		storedInfo.MacAddress = entry.info.MacAddress
+	}
 	storedInfo.Address = entry.primaryAddress
 	if info.SerialNumber == "" && info.MacAddress == "" && entry.identityKey != "" {
 		identityKey = entry.identityKey
@@ -234,6 +255,21 @@ func canMergeIdentity(incoming DeviceInfo, existing DeviceInfo) bool {
 		return false
 	}
 	return true
+}
+
+func hasConflictingModelSignature(incoming DeviceInfo, existing DeviceInfo) bool {
+	incomingDeviceID := normalizeIdentityPart(incoming.DeviceID)
+	existingDeviceID := normalizeIdentityPart(existing.DeviceID)
+	incomingSoftware := normalizeIdentityPart(incoming.SoftwareVersion)
+	existingSoftware := normalizeIdentityPart(existing.SoftwareVersion)
+	incomingHardware := normalizeIdentityPart(incoming.HardwareVersion)
+	existingHardware := normalizeIdentityPart(existing.HardwareVersion)
+
+	if incomingDeviceID == "" || existingDeviceID == "" || incomingSoftware == "" || existingSoftware == "" || incomingHardware == "" || existingHardware == "" {
+		return false
+	}
+
+	return incomingDeviceID != existingDeviceID || incomingSoftware != existingSoftware || incomingHardware != existingHardware
 }
 
 func (r *DeviceRegistry) Lookup(address byte) (DeviceEntry, bool) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/d3vi1/helianthus-ebusreg/schema"
@@ -301,5 +302,92 @@ func TestDeviceRegistry_ProviderMatching(t *testing.T) {
 	}
 	if providerA.createCalls != 1 || providerB.createCalls != 0 || providerC.createCalls != 1 {
 		t.Fatalf("unexpected create call counts: A=%d B=%d C=%d", providerA.createCalls, providerB.createCalls, providerC.createCalls)
+	}
+}
+
+func TestDeviceRegistry_AliasAddressesShareCanonicalEntry(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0704",
+		HardwareVersion: "7603",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x09,
+		Manufacturer:    "vaillant",
+		DeviceID:        "bai00",
+		SoftwareVersion: "0704",
+		HardwareVersion: "7603",
+	})
+
+	entry08, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected alias primary address lookup")
+	}
+	entry09, ok := registry.Lookup(0x09)
+	if !ok {
+		t.Fatalf("expected alias secondary address lookup")
+	}
+	if entry08 != entry09 {
+		t.Fatalf("expected aliases to resolve to the same device entry")
+	}
+	if entry08.Address() != 0x08 {
+		t.Fatalf("canonical address = %02x; want 08", entry08.Address())
+	}
+	if !slices.Equal(entry08.Addresses(), []byte{0x08, 0x09}) {
+		t.Fatalf("addresses = %v; want [8 9]", entry08.Addresses())
+	}
+
+	addresses := make([]byte, 0)
+	registry.Iterate(func(entry DeviceEntry) bool {
+		addresses = append(addresses, entry.Address())
+		return true
+	})
+	if !slices.Equal(addresses, []byte{0x08}) {
+		t.Fatalf("iterate canonical addresses = %v; want [8]", addresses)
+	}
+}
+
+func TestDeviceRegistry_DoesNotMergeDifferentSerials(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "VR92",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+		SerialNumber:    "SN-1",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x09,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "VR92",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+		SerialNumber:    "SN-2",
+	})
+
+	entry08, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected address 0x08 to exist")
+	}
+	entry09, ok := registry.Lookup(0x09)
+	if !ok {
+		t.Fatalf("expected address 0x09 to exist")
+	}
+	if entry08 == entry09 {
+		t.Fatalf("different serial numbers must not merge")
+	}
+	if !slices.Equal(entry08.Addresses(), []byte{0x08}) {
+		t.Fatalf("entry08 addresses = %v; want [8]", entry08.Addresses())
+	}
+	if !slices.Equal(entry09.Addresses(), []byte{0x09}) {
+		t.Fatalf("entry09 addresses = %v; want [9]", entry09.Addresses())
 	}
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -391,3 +391,90 @@ func TestDeviceRegistry_DoesNotMergeDifferentSerials(t *testing.T) {
 		t.Fatalf("entry09 addresses = %v; want [9]", entry09.Addresses())
 	}
 }
+
+func TestDeviceRegistry_SplitsAliasWhenConflictingSerialArrives(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "VR92",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x09,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "VR92",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x09,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "VR92",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+		SerialNumber:    "SN-B",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "VR92",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+		SerialNumber:    "SN-A",
+	})
+
+	entry08, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected address 0x08 to exist")
+	}
+	entry09, ok := registry.Lookup(0x09)
+	if !ok {
+		t.Fatalf("expected address 0x09 to exist")
+	}
+	if entry08 == entry09 {
+		t.Fatalf("conflicting serial numbers must split aliases")
+	}
+	if entry08.SerialNumber() != "SN-A" {
+		t.Fatalf("entry08 serial = %q; want SN-A", entry08.SerialNumber())
+	}
+	if entry09.SerialNumber() != "SN-B" {
+		t.Fatalf("entry09 serial = %q; want SN-B", entry09.SerialNumber())
+	}
+}
+
+func TestDeviceRegistry_PreservesKnownIdentityOnSparseUpdate(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+		SerialNumber:    "SN-KEEP",
+		MacAddress:      "AA:BB:CC:DD:EE:FF",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+	})
+
+	entry, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected address 0x08 to exist")
+	}
+	if entry.SerialNumber() != "SN-KEEP" {
+		t.Fatalf("serial = %q; want SN-KEEP", entry.SerialNumber())
+	}
+	if entry.MacAddress() != "AA:BB:CC:DD:EE:FF" {
+		t.Fatalf("mac = %q; want preserved MAC", entry.MacAddress())
+	}
+}

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -46,6 +46,7 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 
 	entries := make([]DeviceEntry, 0)
 	found := make(map[byte]struct{})
+	registered := make(map[byte]struct{})
 	pending := dedupeScanTargets(targets)
 	for pass := 0; pass <= scanCollisionMaxPasses && len(pending) > 0; pass++ {
 		collisions := make([]byte, 0)
@@ -129,11 +130,16 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 				}
 			}
 			if info.SerialNumber == "" && info.Manufacturer == "Vaillant" {
-				if existing, ok := registry.Lookup(info.Address); ok && shouldReuseSerial(info, existing) {
+				if existing, ok := registry.lookupByIdentity(info); ok && shouldReuseSerial(info, existing) {
 					info.SerialNumber = existing.SerialNumber()
 				}
 			}
-			entries = append(entries, registry.Register(info))
+			entry := registry.Register(info)
+			canonicalAddress := entry.Address()
+			if _, ok := registered[canonicalAddress]; !ok {
+				registered[canonicalAddress] = struct{}{}
+				entries = append(entries, entry)
+			}
 			found[address] = struct{}{}
 		}
 

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -252,6 +253,24 @@ func (bus *vaillantScanIDTimeoutBus) Send(ctx context.Context, frame protocol.Fr
 	return nil, ebuserrors.ErrNoSuchDevice
 }
 
+type vaillantScanIDAliasTimeoutBus struct{}
+
+func (bus *vaillantScanIDAliasTimeoutBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	if frame.Primary == scanPrimary && frame.Secondary == scanSecondary {
+		return &protocol.Frame{
+			Source:    0x31,
+			Target:    frame.Source,
+			Primary:   scanPrimary,
+			Secondary: scanSecondary,
+			Data:      []byte{0xB5, 'D', 'E', 'V', '3', '0', 0x05, 0x14, 0x12, 0x04},
+		}, nil
+	}
+	if frame.Primary == vaillantPrimary && frame.Secondary == vaillantScanIDSecondary {
+		return nil, context.DeadlineExceeded
+	}
+	return nil, ebuserrors.ErrNoSuchDevice
+}
+
 func TestScanUsesDiscoveredAddressForVaillantScanID(t *testing.T) {
 	t.Parallel()
 
@@ -346,6 +365,46 @@ func TestScanPreservesKnownSerialWhenScanIDFails(t *testing.T) {
 	}
 }
 
+func TestScanReusesSerialAcrossAliasAddressesByIdentity(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x30,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "DEV30",
+		SerialNumber:    "21-22-09-0020184848-0082-005409-N4",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+	})
+	bus := &vaillantScanIDAliasTimeoutBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x20})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Address() != 0x30 {
+		t.Fatalf("canonical address = %02x; want 30", entries[0].Address())
+	}
+	if !slices.Equal(entries[0].Addresses(), []byte{0x30, 0x31}) {
+		t.Fatalf("addresses = %v; want [48 49]", entries[0].Addresses())
+	}
+
+	entry, ok := registry.Lookup(0x31)
+	if !ok {
+		t.Fatalf("expected alias 0x31 to be registered")
+	}
+	if entry.Address() != 0x30 {
+		t.Fatalf("lookup canonical address = %02x; want 30", entry.Address())
+	}
+	if entry.SerialNumber() != "21-22-09-0020184848-0082-005409-N4" {
+		t.Fatalf("serial number = %q; want preserved value", entry.SerialNumber())
+	}
+}
+
 func TestScanDoesNotReuseSerialForDifferentDeviceIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -376,6 +435,52 @@ func TestScanDoesNotReuseSerialForDifferentDeviceIdentity(t *testing.T) {
 	}
 	if entry.SerialNumber() != "" {
 		t.Fatalf("serial number = %q; want empty for identity mismatch", entry.SerialNumber())
+	}
+}
+
+func TestScanDeduplicatesAliasAddressesIntoSingleEntry(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{
+		responses: map[byte]*protocol.Frame{
+			0x08: {
+				Source:    0x08,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0xB5, 'B', 'A', 'I', '0', '0', 0x07, 0x04, 0x76, 0x03},
+			},
+			0x09: {
+				Source:    0x09,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0xB5, 'B', 'A', 'I', '0', '0', 0x07, 0x04, 0x76, 0x03},
+			},
+		},
+	}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x08, 0x09})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 canonical entry, got %d", len(entries))
+	}
+	if entries[0].Address() != 0x08 {
+		t.Fatalf("canonical address = %02x; want 08", entries[0].Address())
+	}
+	if !slices.Equal(entries[0].Addresses(), []byte{0x08, 0x09}) {
+		t.Fatalf("addresses = %v; want [8 9]", entries[0].Addresses())
+	}
+
+	entry, ok := registry.Lookup(0x09)
+	if !ok {
+		t.Fatalf("expected alias address 0x09 lookup")
+	}
+	if entry.Address() != 0x08 {
+		t.Fatalf("lookup canonical address = %02x; want 08", entry.Address())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add canonical physical identity handling so one registry entry can own multiple eBUS addresses
- add alias address exposure via `DeviceEntry.Addresses()` while keeping deterministic primary `Address()`
- make scan serial reuse and scan result dedup operate on canonical identity, not only raw source address
- add regression tests for alias merge, serial mismatch separation, and canonical scan dedup

## Validation
- `go test ./registry -count=1`
- `./scripts/ci_local.sh`

Closes #80