### PR TITLE
Scan: keep queried alias faces when response source repeats (#81)

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -45,7 +45,6 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 	}
 
 	entries := make([]DeviceEntry, 0)
-	found := make(map[byte]struct{})
 	registered := make(map[byte]struct{})
 	pending := dedupeScanTargets(targets)
 	for pass := 0; pass <= scanCollisionMaxPasses && len(pending) > 0; pass++ {
@@ -104,9 +103,6 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 			if address == 0 {
 				address = target
 			}
-			if _, ok := found[address]; ok {
-				continue
-			}
 
 			info, err := parseDeviceInfo(address, response.Data)
 			if err != nil {
@@ -135,12 +131,16 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 				}
 			}
 			entry := registry.Register(info)
+			if address != target {
+				alias := info
+				alias.Address = target
+				entry = registry.Register(alias)
+			}
 			canonicalAddress := entry.Address()
 			if _, ok := registered[canonicalAddress]; !ok {
 				registered[canonicalAddress] = struct{}{}
 				entries = append(entries, entry)
 			}
-			found[address] = struct{}{}
 		}
 
 		if len(collisions) == 0 && len(retries) == 0 {

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -389,8 +389,8 @@ func TestScanReusesSerialAcrossAliasAddressesByIdentity(t *testing.T) {
 	if entries[0].Address() != 0x30 {
 		t.Fatalf("canonical address = %02x; want 30", entries[0].Address())
 	}
-	if !slices.Equal(entries[0].Addresses(), []byte{0x30, 0x31}) {
-		t.Fatalf("addresses = %v; want [48 49]", entries[0].Addresses())
+	if !slices.Equal(entries[0].Addresses(), []byte{0x30, 0x31, 0x20}) {
+		t.Fatalf("addresses = %v; want [48 49 32]", entries[0].Addresses())
 	}
 
 	entry, ok := registry.Lookup(0x31)
@@ -481,6 +481,52 @@ func TestScanDeduplicatesAliasAddressesIntoSingleEntry(t *testing.T) {
 	}
 	if entry.Address() != 0x08 {
 		t.Fatalf("lookup canonical address = %02x; want 08", entry.Address())
+	}
+}
+
+func TestScanRegistersQueriedAliasWhenResponseSourceRepeats(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{
+		responses: map[byte]*protocol.Frame{
+			0x15: {
+				Source:    0x15,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0xB5, 'B', 'A', 'S', 'V', '2', 0x05, 0x07, 0x17, 0x04},
+			},
+			0xEC: {
+				Source:    0x15,
+				Target:    0x10,
+				Primary:   scanPrimary,
+				Secondary: scanSecondary,
+				Data:      []byte{0xB5, 'B', 'A', 'S', 'V', '2', 0x05, 0x07, 0x17, 0x04},
+			},
+		},
+	}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x10, []byte{0x15, 0xEC})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 canonical entry, got %d", len(entries))
+	}
+	if entries[0].Address() != 0x15 {
+		t.Fatalf("canonical address = %02x; want 15", entries[0].Address())
+	}
+	if !slices.Equal(entries[0].Addresses(), []byte{0x15, 0xEC}) {
+		t.Fatalf("addresses = %v; want [21 236]", entries[0].Addresses())
+	}
+
+	entry, ok := registry.Lookup(0xEC)
+	if !ok {
+		t.Fatalf("expected alias address 0xEC lookup")
+	}
+	if entry.Address() != 0x15 {
+		t.Fatalf("lookup canonical address = %02x; want 15", entry.Address())
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop dropping scan replies only because `response.Source` was already seen on another target
- when source address differs from queried target, register the queried target as an alias face of the same physical entry
- add regression test reproducing the SOL00-style miss (`0xEC` target returning already-seen source)

## Validation
- `go test ./registry -count=1`
- `./scripts/ci_local.sh`

Closes #81