### PR TITLE
MCP-10-102: shared registry projection helpers for MCP/GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Backward-compatible defaults for legacy `registry.Method` implementations:
 Methods can override defaults by implementing optional interfaces in `registry`:
 `MethodMutabilityProvider`, `MethodDangerProvider`, and `MethodRoutableProvider`.
 
+## Shared Service Projections
+
+For MCP and GraphQL service-layer reuse, `registry` exposes projection helpers:
+
+- `ProjectRegistryDevices(iter EntryIterator)`
+- `ProjectDeviceEntry(entry DeviceEntry)`
+- `ProjectPlane(plane Plane)`
+- `ProjectMethod(method Method)`
+
+Projected method data includes frame template bytes plus normalized method metadata (`mutability`, `danger`, `routable`) through `ResolveMethodMetadata`.
+
 ## Quickstart (copy/paste)
 
 ### 1) Clone and baseline checks

--- a/registry/service_projection.go
+++ b/registry/service_projection.go
@@ -1,0 +1,154 @@
+package registry
+
+import (
+	"fmt"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+	"github.com/d3vi1/helianthus-ebusreg/schema"
+)
+
+// EntryIterator is the minimal registry surface required by projection helpers.
+type EntryIterator interface {
+	Iterate(func(DeviceEntry) bool)
+}
+
+// ServiceDeviceView is a normalized device projection for shared service-layer use.
+type ServiceDeviceView struct {
+	Address         byte
+	Addresses       []byte
+	Manufacturer    string
+	DeviceID        string
+	SerialNumber    string
+	MacAddress      string
+	SoftwareVersion string
+	HardwareVersion string
+	Planes          []ServicePlaneView
+}
+
+// ServicePlaneView is a normalized plane projection for shared service-layer use.
+type ServicePlaneView struct {
+	Name    string
+	Methods []ServiceMethodView
+}
+
+// ServiceMethodView is a normalized method projection for shared service-layer use.
+type ServiceMethodView struct {
+	Name             string
+	ReadOnly         bool
+	Primary          byte
+	Secondary        byte
+	Metadata         MethodMetadata
+	ResponseSelector schema.SchemaSelector
+}
+
+func ProjectRegistryDevices(iter EntryIterator) ([]ServiceDeviceView, error) {
+	if iter == nil {
+		return nil, fmt.Errorf("project registry devices: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	out := make([]ServiceDeviceView, 0)
+	var projectionErr error
+	iter.Iterate(func(entry DeviceEntry) bool {
+		projected, err := ProjectDeviceEntry(entry)
+		if err != nil {
+			projectionErr = err
+			return false
+		}
+		out = append(out, projected)
+		return true
+	})
+	if projectionErr != nil {
+		return nil, projectionErr
+	}
+	return out, nil
+}
+
+func ProjectDeviceEntry(entry DeviceEntry) (ServiceDeviceView, error) {
+	if entry == nil {
+		return ServiceDeviceView{}, fmt.Errorf("project device entry: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	planes := entry.Planes()
+	projectedPlanes := make([]ServicePlaneView, 0, len(planes))
+	for index, plane := range planes {
+		projected, err := ProjectPlane(plane)
+		if err != nil {
+			return ServiceDeviceView{}, fmt.Errorf("project device plane %d: %w", index, err)
+		}
+		projectedPlanes = append(projectedPlanes, projected)
+	}
+
+	return ServiceDeviceView{
+		Address:         entry.Address(),
+		Addresses:       normalizeProjectedAddresses(entry.Address(), entry.Addresses()),
+		Manufacturer:    entry.Manufacturer(),
+		DeviceID:        entry.DeviceID(),
+		SerialNumber:    entry.SerialNumber(),
+		MacAddress:      entry.MacAddress(),
+		SoftwareVersion: entry.SoftwareVersion(),
+		HardwareVersion: entry.HardwareVersion(),
+		Planes:          projectedPlanes,
+	}, nil
+}
+
+func ProjectPlane(plane Plane) (ServicePlaneView, error) {
+	if plane == nil {
+		return ServicePlaneView{}, fmt.Errorf("project plane: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	methods := plane.Methods()
+	projectedMethods := make([]ServiceMethodView, 0, len(methods))
+	for index, method := range methods {
+		projected, err := ProjectMethod(method)
+		if err != nil {
+			return ServicePlaneView{}, fmt.Errorf("project method %d: %w", index, err)
+		}
+		projectedMethods = append(projectedMethods, projected)
+	}
+
+	return ServicePlaneView{
+		Name:    plane.Name(),
+		Methods: projectedMethods,
+	}, nil
+}
+
+func ProjectMethod(method Method) (ServiceMethodView, error) {
+	if method == nil {
+		return ServiceMethodView{}, fmt.Errorf("project method: %w", ebuserrors.ErrInvalidPayload)
+	}
+	template := method.Template()
+	if template == nil {
+		return ServiceMethodView{}, fmt.Errorf("project method %q missing template: %w", method.Name(), ebuserrors.ErrInvalidPayload)
+	}
+
+	return ServiceMethodView{
+		Name:             method.Name(),
+		ReadOnly:         method.ReadOnly(),
+		Primary:          template.Primary(),
+		Secondary:        template.Secondary(),
+		Metadata:         ResolveMethodMetadata(method),
+		ResponseSelector: method.ResponseSchema(),
+	}, nil
+}
+
+func normalizeProjectedAddresses(primary byte, aliases []byte) []byte {
+	out := make([]byte, 0, len(aliases)+1)
+	appendUniqueAddress := func(address byte) {
+		for _, existing := range out {
+			if existing == address {
+				return
+			}
+		}
+		out = append(out, address)
+	}
+
+	appendUniqueAddress(primary)
+	for _, address := range aliases {
+		appendUniqueAddress(address)
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/registry/service_projection_test.go
+++ b/registry/service_projection_test.go
@@ -1,0 +1,258 @@
+package registry
+
+import (
+	stderrors "errors"
+	"reflect"
+	"testing"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+	"github.com/d3vi1/helianthus-ebusreg/schema"
+)
+
+type projectionTestTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template projectionTestTemplate) Primary() byte   { return template.primary }
+func (template projectionTestTemplate) Secondary() byte { return template.secondary }
+
+type projectionTestMethod struct {
+	name       string
+	readOnly   bool
+	template   FrameTemplate
+	selector   schema.SchemaSelector
+	mutability MethodMutability
+	danger     MethodDanger
+	routable   bool
+}
+
+func (method projectionTestMethod) Name() string                          { return method.name }
+func (method projectionTestMethod) ReadOnly() bool                        { return method.readOnly }
+func (method projectionTestMethod) Template() FrameTemplate               { return method.template }
+func (method projectionTestMethod) ResponseSchema() schema.SchemaSelector { return method.selector }
+func (method projectionTestMethod) Mutability() MethodMutability          { return method.mutability }
+func (method projectionTestMethod) Danger() MethodDanger                  { return method.danger }
+func (method projectionTestMethod) Routable() bool                        { return method.routable }
+
+type projectionTestPlane struct {
+	name    string
+	methods []Method
+}
+
+func (plane projectionTestPlane) Name() string      { return plane.name }
+func (plane projectionTestPlane) Methods() []Method { return plane.methods }
+
+type projectionTestEntry struct {
+	address         byte
+	addresses       []byte
+	manufacturer    string
+	deviceID        string
+	serialNumber    string
+	macAddress      string
+	softwareVersion string
+	hardwareVersion string
+	planes          []Plane
+	projections     []Projection
+}
+
+func (entry projectionTestEntry) Address() byte             { return entry.address }
+func (entry projectionTestEntry) Addresses() []byte         { return append([]byte(nil), entry.addresses...) }
+func (entry projectionTestEntry) Manufacturer() string      { return entry.manufacturer }
+func (entry projectionTestEntry) DeviceID() string          { return entry.deviceID }
+func (entry projectionTestEntry) SerialNumber() string      { return entry.serialNumber }
+func (entry projectionTestEntry) MacAddress() string        { return entry.macAddress }
+func (entry projectionTestEntry) SoftwareVersion() string   { return entry.softwareVersion }
+func (entry projectionTestEntry) HardwareVersion() string   { return entry.hardwareVersion }
+func (entry projectionTestEntry) Planes() []Plane           { return entry.planes }
+func (entry projectionTestEntry) Projections() []Projection { return entry.projections }
+
+type projectionTestIterator struct {
+	entries []DeviceEntry
+}
+
+func (iterator projectionTestIterator) Iterate(fn func(DeviceEntry) bool) {
+	for _, entry := range iterator.entries {
+		if !fn(entry) {
+			return
+		}
+	}
+}
+
+func TestProjectMethod(t *testing.T) {
+	t.Parallel()
+
+	selector := schema.SchemaSelector{
+		Default: schema.Schema{Fields: []schema.SchemaField{{Name: "temp_c", Type: types.DATA2b{}}}},
+	}
+	method := projectionTestMethod{
+		name:     "set_target",
+		readOnly: false,
+		template: projectionTestTemplate{primary: 0xB5, secondary: 0x05},
+		selector: selector,
+		// Explicit metadata provider values take priority over ReadOnly fallback.
+		mutability: MethodMutabilityUnknown,
+		danger:     MethodDangerDangerous,
+		routable:   false,
+	}
+
+	projected, err := ProjectMethod(method)
+	if err != nil {
+		t.Fatalf("ProjectMethod error = %v", err)
+	}
+	if projected.Name != "set_target" {
+		t.Fatalf("Name = %q; want set_target", projected.Name)
+	}
+	if projected.ReadOnly {
+		t.Fatalf("ReadOnly = true; want false")
+	}
+	if projected.Primary != 0xB5 || projected.Secondary != 0x05 {
+		t.Fatalf("template = (%02x,%02x); want (b5,05)", projected.Primary, projected.Secondary)
+	}
+	if !reflect.DeepEqual(projected.ResponseSelector, selector) {
+		t.Fatalf("ResponseSelector = %#v; want %#v", projected.ResponseSelector, selector)
+	}
+	if projected.Metadata.Mutability != MethodMutabilityUnknown {
+		t.Fatalf("Mutability = %q; want unknown", projected.Metadata.Mutability)
+	}
+	if projected.Metadata.Danger != MethodDangerDangerous {
+		t.Fatalf("Danger = %q; want dangerous", projected.Metadata.Danger)
+	}
+	if projected.Metadata.Routable {
+		t.Fatalf("Routable = true; want false")
+	}
+}
+
+func TestProjectMethodErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ProjectMethod(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectMethod(nil) error = %v; want ErrInvalidPayload", err)
+	}
+
+	invalidMethod := projectionTestMethod{name: "broken", template: nil}
+	if _, err := ProjectMethod(invalidMethod); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectMethod(missing template) error = %v; want ErrInvalidPayload", err)
+	}
+}
+
+func TestProjectDeviceEntryAndPlane(t *testing.T) {
+	t.Parallel()
+
+	readMethod := projectionTestMethod{
+		name:       "get_status",
+		readOnly:   true,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x04},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityReadOnly,
+		danger:     MethodDangerSafe,
+		routable:   true,
+	}
+	writeMethod := projectionTestMethod{
+		name:       "set_target",
+		readOnly:   false,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x05},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityMutating,
+		danger:     MethodDangerDangerous,
+		routable:   true,
+	}
+	plane := projectionTestPlane{name: "Heating", methods: []Method{readMethod, writeMethod}}
+	entry := projectionTestEntry{
+		address:         0x08,
+		addresses:       []byte{0x10, 0x08, 0x10},
+		manufacturer:    "Vaillant",
+		deviceID:        "BAI00",
+		serialNumber:    "ABC",
+		macAddress:      "DEF",
+		softwareVersion: "123",
+		hardwareVersion: "456",
+		planes:          []Plane{plane},
+	}
+
+	projected, err := ProjectDeviceEntry(entry)
+	if err != nil {
+		t.Fatalf("ProjectDeviceEntry error = %v", err)
+	}
+	if projected.Address != 0x08 {
+		t.Fatalf("Address = %02x; want 08", projected.Address)
+	}
+	if !reflect.DeepEqual(projected.Addresses, []byte{0x08, 0x10}) {
+		t.Fatalf("Addresses = %v; want [8 16]", projected.Addresses)
+	}
+	if projected.Manufacturer != "Vaillant" || projected.DeviceID != "BAI00" {
+		t.Fatalf("identity projection mismatch: %#v", projected)
+	}
+	if len(projected.Planes) != 1 {
+		t.Fatalf("Planes len = %d; want 1", len(projected.Planes))
+	}
+	if projected.Planes[0].Name != "Heating" {
+		t.Fatalf("Plane name = %q; want Heating", projected.Planes[0].Name)
+	}
+	if len(projected.Planes[0].Methods) != 2 {
+		t.Fatalf("Methods len = %d; want 2", len(projected.Planes[0].Methods))
+	}
+
+	projected.Addresses[0] = 0xFF
+	again, err := ProjectDeviceEntry(entry)
+	if err != nil {
+		t.Fatalf("ProjectDeviceEntry(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(again.Addresses, []byte{0x08, 0x10}) {
+		t.Fatalf("Addresses leaked mutation: %v", again.Addresses)
+	}
+}
+
+func TestProjectRegistryDevices(t *testing.T) {
+	t.Parallel()
+
+	entryA := projectionTestEntry{
+		address:   0x08,
+		addresses: []byte{0x08},
+		planes:    []Plane{projectionTestPlane{name: "System", methods: []Method{projectionTestMethod{name: "a", template: projectionTestTemplate{primary: 0xB5, secondary: 0x04}, selector: schema.SchemaSelector{}, mutability: MethodMutabilityReadOnly, danger: MethodDangerSafe, routable: true, readOnly: true}}}},
+	}
+	entryB := projectionTestEntry{
+		address:   0x10,
+		addresses: []byte{0x10},
+		planes:    []Plane{projectionTestPlane{name: "Heating", methods: []Method{projectionTestMethod{name: "b", template: projectionTestTemplate{primary: 0xB5, secondary: 0x05}, selector: schema.SchemaSelector{}, mutability: MethodMutabilityMutating, danger: MethodDangerDangerous, routable: true, readOnly: false}}}},
+	}
+	iterator := projectionTestIterator{entries: []DeviceEntry{entryA, entryB}}
+
+	projected, err := ProjectRegistryDevices(iterator)
+	if err != nil {
+		t.Fatalf("ProjectRegistryDevices error = %v", err)
+	}
+	if len(projected) != 2 {
+		t.Fatalf("len = %d; want 2", len(projected))
+	}
+	if projected[0].Address != 0x08 || projected[1].Address != 0x10 {
+		t.Fatalf("order mismatch: %02x %02x", projected[0].Address, projected[1].Address)
+	}
+
+	if _, err := ProjectRegistryDevices(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectRegistryDevices(nil) error = %v; want ErrInvalidPayload", err)
+	}
+
+	badIterator := projectionTestIterator{entries: []DeviceEntry{entryA, nil, entryB}}
+	if _, err := ProjectRegistryDevices(badIterator); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectRegistryDevices(bad iterator) error = %v; want ErrInvalidPayload", err)
+	}
+}
+
+func TestProjectPlaneErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ProjectPlane(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectPlane(nil) error = %v; want ErrInvalidPayload", err)
+	}
+
+	badPlane := projectionTestPlane{name: "Bad", methods: []Method{projectionTestMethod{name: "broken", template: nil}}}
+	if _, err := ProjectPlane(badPlane); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectPlane(bad method) error = %v; want ErrInvalidPayload", err)
+	}
+
+	if _, err := ProjectDeviceEntry(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectDeviceEntry(nil) error = %v; want ErrInvalidPayload", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add shared registry service projection helpers for higher-layer MCP/GraphQL consumers:
  - `ProjectRegistryDevices`
  - `ProjectDeviceEntry`
  - `ProjectPlane`
  - `ProjectMethod`
- project method frame template bytes and normalized method metadata (`mutability`, `danger`, `routable`)
- add focused tests for device/plane/method projection behavior and invalid-payload paths
- document helper surface in README

## Validation
- `GOWORK=off go test ./registry -count=1`
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off ./scripts/ci_local.sh`

Fixes #85
