### PR TITLE
MCP-10-103: deterministic ordering guarantees for registry views

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ For MCP and GraphQL service-layer reuse, `registry` exposes projection helpers:
 
 Projected method data includes frame template bytes plus normalized method metadata (`mutability`, `danger`, `routable`) through `ResolveMethodMetadata`.
 
+Deterministic ordering guarantees for projected views:
+
+- devices: `address` ascending, then manufacturer/device/hardware/serial (case-insensitive)
+- planes: name ascending (case-insensitive)
+- methods: name ascending (case-insensitive), then template `(primary, secondary)`
+
 ## Quickstart (copy/paste)
 
 ### 1) Clone and baseline checks

--- a/registry/service_projection.go
+++ b/registry/service_projection.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusreg/schema"
@@ -60,6 +62,7 @@ func ProjectRegistryDevices(iter EntryIterator) ([]ServiceDeviceView, error) {
 	if projectionErr != nil {
 		return nil, projectionErr
 	}
+	sortServiceDevices(out)
 	return out, nil
 }
 
@@ -77,6 +80,7 @@ func ProjectDeviceEntry(entry DeviceEntry) (ServiceDeviceView, error) {
 		}
 		projectedPlanes = append(projectedPlanes, projected)
 	}
+	sortServicePlanes(projectedPlanes)
 
 	return ServiceDeviceView{
 		Address:         entry.Address(),
@@ -105,6 +109,7 @@ func ProjectPlane(plane Plane) (ServicePlaneView, error) {
 		}
 		projectedMethods = append(projectedMethods, projected)
 	}
+	sortServiceMethods(projectedMethods)
 
 	return ServicePlaneView{
 		Name:    plane.Name(),
@@ -143,7 +148,11 @@ func normalizeProjectedAddresses(primary byte, aliases []byte) []byte {
 	}
 
 	appendUniqueAddress(primary)
-	for _, address := range aliases {
+	aliasesCopy := append([]byte(nil), aliases...)
+	sort.Slice(aliasesCopy, func(i, j int) bool {
+		return aliasesCopy[i] < aliasesCopy[j]
+	})
+	for _, address := range aliasesCopy {
 		appendUniqueAddress(address)
 	}
 
@@ -151,4 +160,66 @@ func normalizeProjectedAddresses(primary byte, aliases []byte) []byte {
 		return nil
 	}
 	return out
+}
+
+func sortServiceDevices(devices []ServiceDeviceView) {
+	sort.Slice(devices, func(i, j int) bool {
+		left := devices[i]
+		right := devices[j]
+		if left.Address != right.Address {
+			return left.Address < right.Address
+		}
+		if compareFolded(left.Manufacturer, right.Manufacturer) != 0 {
+			return compareFolded(left.Manufacturer, right.Manufacturer) < 0
+		}
+		if compareFolded(left.DeviceID, right.DeviceID) != 0 {
+			return compareFolded(left.DeviceID, right.DeviceID) < 0
+		}
+		if compareFolded(left.HardwareVersion, right.HardwareVersion) != 0 {
+			return compareFolded(left.HardwareVersion, right.HardwareVersion) < 0
+		}
+		return compareFolded(left.SerialNumber, right.SerialNumber) < 0
+	})
+	for index := range devices {
+		sortServicePlanes(devices[index].Planes)
+	}
+}
+
+func sortServicePlanes(planes []ServicePlaneView) {
+	sort.Slice(planes, func(i, j int) bool {
+		if compareFolded(planes[i].Name, planes[j].Name) != 0 {
+			return compareFolded(planes[i].Name, planes[j].Name) < 0
+		}
+		return planes[i].Name < planes[j].Name
+	})
+	for index := range planes {
+		sortServiceMethods(planes[index].Methods)
+	}
+}
+
+func sortServiceMethods(methods []ServiceMethodView) {
+	sort.Slice(methods, func(i, j int) bool {
+		if compareFolded(methods[i].Name, methods[j].Name) != 0 {
+			return compareFolded(methods[i].Name, methods[j].Name) < 0
+		}
+		if methods[i].Name != methods[j].Name {
+			return methods[i].Name < methods[j].Name
+		}
+		if methods[i].Primary != methods[j].Primary {
+			return methods[i].Primary < methods[j].Primary
+		}
+		return methods[i].Secondary < methods[j].Secondary
+	})
+}
+
+func compareFolded(left string, right string) int {
+	leftFolded := strings.ToLower(strings.TrimSpace(left))
+	rightFolded := strings.ToLower(strings.TrimSpace(right))
+	if leftFolded < rightFolded {
+		return -1
+	}
+	if leftFolded > rightFolded {
+		return 1
+	}
+	return 0
 }

--- a/registry/service_projection_test.go
+++ b/registry/service_projection_test.go
@@ -240,6 +240,84 @@ func TestProjectRegistryDevices(t *testing.T) {
 	}
 }
 
+func TestProjectRegistryDevicesDeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	methodZ := projectionTestMethod{
+		name:       "zeta",
+		readOnly:   true,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x09},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityReadOnly,
+		danger:     MethodDangerSafe,
+		routable:   true,
+	}
+	methodA := projectionTestMethod{
+		name:       "alpha",
+		readOnly:   true,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x01},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityReadOnly,
+		danger:     MethodDangerSafe,
+		routable:   true,
+	}
+
+	entryB := projectionTestEntry{
+		address:         0x10,
+		addresses:       []byte{0x15, 0x10, 0x12},
+		manufacturer:    "vaillant",
+		deviceID:        "B",
+		hardwareVersion: "2",
+		serialNumber:    "2",
+		planes: []Plane{
+			projectionTestPlane{name: "zPlane", methods: []Method{methodZ, methodA}},
+			projectionTestPlane{name: "APlane", methods: []Method{methodZ}},
+		},
+	}
+	entryA := projectionTestEntry{
+		address:         0x08,
+		addresses:       []byte{0x09, 0x08, 0x0A},
+		manufacturer:    "Vaillant",
+		deviceID:        "A",
+		hardwareVersion: "1",
+		serialNumber:    "1",
+		planes: []Plane{
+			projectionTestPlane{name: "System", methods: []Method{methodZ, methodA}},
+		},
+	}
+
+	projected, err := ProjectRegistryDevices(projectionTestIterator{entries: []DeviceEntry{entryB, entryA}})
+	if err != nil {
+		t.Fatalf("ProjectRegistryDevices error = %v", err)
+	}
+
+	if len(projected) != 2 {
+		t.Fatalf("devices len = %d; want 2", len(projected))
+	}
+	if projected[0].Address != 0x08 || projected[1].Address != 0x10 {
+		t.Fatalf("device order = [%02x,%02x]; want [08,10]", projected[0].Address, projected[1].Address)
+	}
+	if !reflect.DeepEqual(projected[1].Addresses, []byte{0x10, 0x12, 0x15}) {
+		t.Fatalf("addresses order = %v; want [16 18 21]", projected[1].Addresses)
+	}
+	if len(projected[1].Planes) != 2 {
+		t.Fatalf("plane len = %d; want 2", len(projected[1].Planes))
+	}
+	if projected[1].Planes[0].Name != "APlane" || projected[1].Planes[1].Name != "zPlane" {
+		t.Fatalf("plane order = [%s,%s]; want [APlane,zPlane]", projected[1].Planes[0].Name, projected[1].Planes[1].Name)
+	}
+	if len(projected[1].Planes[1].Methods) != 2 {
+		t.Fatalf("method len = %d; want 2", len(projected[1].Planes[1].Methods))
+	}
+	if projected[1].Planes[1].Methods[0].Name != "alpha" || projected[1].Planes[1].Methods[1].Name != "zeta" {
+		t.Fatalf(
+			"method order = [%s,%s]; want [alpha,zeta]",
+			projected[1].Planes[1].Methods[0].Name,
+			projected[1].Planes[1].Methods[1].Name,
+		)
+	}
+}
+
 func TestProjectPlaneErrors(t *testing.T) {
 	t.Parallel()
 
@@ -254,5 +332,41 @@ func TestProjectPlaneErrors(t *testing.T) {
 
 	if _, err := ProjectDeviceEntry(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
 		t.Fatalf("ProjectDeviceEntry(nil) error = %v; want ErrInvalidPayload", err)
+	}
+}
+
+func TestProjectPlaneDeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	methods := []Method{
+		projectionTestMethod{
+			name:       "zeta",
+			readOnly:   true,
+			template:   projectionTestTemplate{primary: 0xB5, secondary: 0x02},
+			selector:   schema.SchemaSelector{},
+			mutability: MethodMutabilityReadOnly,
+			danger:     MethodDangerSafe,
+			routable:   true,
+		},
+		projectionTestMethod{
+			name:       "alpha",
+			readOnly:   true,
+			template:   projectionTestTemplate{primary: 0xB5, secondary: 0x01},
+			selector:   schema.SchemaSelector{},
+			mutability: MethodMutabilityReadOnly,
+			danger:     MethodDangerSafe,
+			routable:   true,
+		},
+	}
+
+	projected, err := ProjectPlane(projectionTestPlane{name: "Heating", methods: methods})
+	if err != nil {
+		t.Fatalf("ProjectPlane error = %v", err)
+	}
+	if len(projected.Methods) != 2 {
+		t.Fatalf("methods len = %d; want 2", len(projected.Methods))
+	}
+	if projected.Methods[0].Name != "alpha" || projected.Methods[1].Name != "zeta" {
+		t.Fatalf("method order = [%s,%s]; want [alpha,zeta]", projected.Methods[0].Name, projected.Methods[1].Name)
 	}
 }


### PR DESCRIPTION
## Summary
- enforce deterministic ordering in shared registry projection helpers
  - devices sorted by address then identity tie-breakers
  - planes sorted by name
  - methods sorted by name then template bytes
- stabilize projected device alias ordering (primary first, aliases ascending)
- add ordering-focused tests for registry/device/plane projection behavior
- document ordering rules in README

## Validation
- GOWORK=off go test ./registry -count=1
- GOWORK=off go test ./... -count=1
- GOWORK=off ./scripts/ci_local.sh

Fixes #86
