### PR TITLE
Integrate MCP-first cruise-control into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ For MCP and GraphQL service-layer reuse, `registry` exposes projection helpers:
 
 Projected method data includes frame template bytes plus normalized method metadata (`mutability`, `danger`, `routable`) through `ResolveMethodMetadata`.
 
+Deterministic ordering guarantees for projected views:
+
+- devices: `address` ascending, then manufacturer/device/hardware/serial (case-insensitive)
+- planes: name ascending (case-insensitive)
+- methods: name ascending (case-insensitive), then template `(primary, secondary)`
+
 ## Quickstart (copy/paste)
 
 ### 1) Clone and baseline checks

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ Backward-compatible defaults for legacy `registry.Method` implementations:
 Methods can override defaults by implementing optional interfaces in `registry`:
 `MethodMutabilityProvider`, `MethodDangerProvider`, and `MethodRoutableProvider`.
 
+### Method Contract Semantics
+
+Normalization semantics are stable and test-backed:
+
+| Input | Result |
+|---|---|
+| no mutability provider + `ReadOnly()==true` | `mutability=read_only` |
+| no mutability provider + `ReadOnly()==false` | `mutability=mutating` |
+| explicit mutability provider (`unknown/read_only/mutating`) | provider value is preserved |
+| invalid mutability provider value | fallback to `ReadOnly()` inference |
+| no danger provider | derived from mutability (`read_only -> safe`, otherwise `dangerous`) |
+| explicit danger provider (`safe/dangerous`) | provider value is preserved |
+| danger provider returns `unknown` or invalid | fallback to derived danger |
+| no routable provider | `routable=true` |
+| explicit routable provider | provider value is preserved |
+
 ## Shared Service Projections
 
 For MCP and GraphQL service-layer reuse, `registry` exposes projection helpers:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Backward-compatible defaults for legacy `registry.Method` implementations:
 Methods can override defaults by implementing optional interfaces in `registry`:
 `MethodMutabilityProvider`, `MethodDangerProvider`, and `MethodRoutableProvider`.
 
+## Shared Service Projections
+
+For MCP and GraphQL service-layer reuse, `registry` exposes projection helpers:
+
+- `ProjectRegistryDevices(iter EntryIterator)`
+- `ProjectDeviceEntry(entry DeviceEntry)`
+- `ProjectPlane(plane Plane)`
+- `ProjectMethod(method Method)`
+
+Projected method data includes frame template bytes plus normalized method metadata (`mutability`, `danger`, `routable`) through `ResolveMethodMetadata`.
+
 ## Quickstart (copy/paste)
 
 ### 1) Clone and baseline checks

--- a/registry/method_metadata_test.go
+++ b/registry/method_metadata_test.go
@@ -65,6 +65,33 @@ func (m noMetadataMethod) ResponseSchema() schema.SchemaSelector {
 	return schema.SchemaSelector{}
 }
 
+type mutabilityOnlyMethod struct {
+	noMetadataMethod
+	mutability MethodMutability
+}
+
+func (m mutabilityOnlyMethod) Mutability() MethodMutability {
+	return m.mutability
+}
+
+type dangerOnlyMethod struct {
+	noMetadataMethod
+	danger MethodDanger
+}
+
+func (m dangerOnlyMethod) Danger() MethodDanger {
+	return m.danger
+}
+
+type routableOnlyMethod struct {
+	noMetadataMethod
+	routable bool
+}
+
+func (m routableOnlyMethod) Routable() bool {
+	return m.routable
+}
+
 func TestResolveMethodMetadata_DefaultsFromReadOnly(t *testing.T) {
 	t.Parallel()
 
@@ -183,4 +210,111 @@ func TestResolveMethodMetadata_NilMethodDefaults(t *testing.T) {
 	if metadata.Routable {
 		t.Fatalf("routable = true; want false")
 	}
+}
+
+func TestResolveMethodMetadata_PartialProviders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mutability provider influences danger fallback", func(t *testing.T) {
+		t.Parallel()
+
+		method := mutabilityOnlyMethod{
+			noMetadataMethod: noMetadataMethod{
+				name:     "custom",
+				readOnly: false,
+				template: mockTemplate{primary: 0xB5, secondary: 0x04},
+			},
+			mutability: MethodMutabilityReadOnly,
+		}
+		metadata := ResolveMethodMetadata(method)
+		if metadata.Mutability != MethodMutabilityReadOnly {
+			t.Fatalf("mutability = %q; want %q", metadata.Mutability, MethodMutabilityReadOnly)
+		}
+		if metadata.Danger != MethodDangerSafe {
+			t.Fatalf("danger = %q; want %q", metadata.Danger, MethodDangerSafe)
+		}
+		if !metadata.Routable {
+			t.Fatalf("routable = false; want true")
+		}
+	})
+
+	t.Run("unknown mutability remains dangerous without explicit danger", func(t *testing.T) {
+		t.Parallel()
+
+		method := mutabilityOnlyMethod{
+			noMetadataMethod: noMetadataMethod{
+				name:     "custom_unknown",
+				readOnly: true,
+				template: mockTemplate{primary: 0xB5, secondary: 0x04},
+			},
+			mutability: MethodMutabilityUnknown,
+		}
+		metadata := ResolveMethodMetadata(method)
+		if metadata.Mutability != MethodMutabilityUnknown {
+			t.Fatalf("mutability = %q; want %q", metadata.Mutability, MethodMutabilityUnknown)
+		}
+		if metadata.Danger != MethodDangerDangerous {
+			t.Fatalf("danger = %q; want %q", metadata.Danger, MethodDangerDangerous)
+		}
+	})
+
+	t.Run("danger provider override respected", func(t *testing.T) {
+		t.Parallel()
+
+		method := dangerOnlyMethod{
+			noMetadataMethod: noMetadataMethod{
+				name:     "danger_override",
+				readOnly: false,
+				template: mockTemplate{primary: 0xB5, secondary: 0x05},
+			},
+			danger: MethodDangerSafe,
+		}
+		metadata := ResolveMethodMetadata(method)
+		if metadata.Mutability != MethodMutabilityMutating {
+			t.Fatalf("mutability = %q; want %q", metadata.Mutability, MethodMutabilityMutating)
+		}
+		if metadata.Danger != MethodDangerSafe {
+			t.Fatalf("danger = %q; want %q", metadata.Danger, MethodDangerSafe)
+		}
+	})
+
+	t.Run("unknown danger falls back to derived value", func(t *testing.T) {
+		t.Parallel()
+
+		method := dangerOnlyMethod{
+			noMetadataMethod: noMetadataMethod{
+				name:     "danger_unknown",
+				readOnly: true,
+				template: mockTemplate{primary: 0xB5, secondary: 0x04},
+			},
+			danger: MethodDangerUnknown,
+		}
+		metadata := ResolveMethodMetadata(method)
+		if metadata.Danger != MethodDangerSafe {
+			t.Fatalf("danger = %q; want %q", metadata.Danger, MethodDangerSafe)
+		}
+	})
+
+	t.Run("routable provider only affects routable", func(t *testing.T) {
+		t.Parallel()
+
+		method := routableOnlyMethod{
+			noMetadataMethod: noMetadataMethod{
+				name:     "non_routable",
+				readOnly: true,
+				template: mockTemplate{primary: 0xB5, secondary: 0x04},
+			},
+			routable: false,
+		}
+		metadata := ResolveMethodMetadata(method)
+		if metadata.Mutability != MethodMutabilityReadOnly {
+			t.Fatalf("mutability = %q; want %q", metadata.Mutability, MethodMutabilityReadOnly)
+		}
+		if metadata.Danger != MethodDangerSafe {
+			t.Fatalf("danger = %q; want %q", metadata.Danger, MethodDangerSafe)
+		}
+		if metadata.Routable {
+			t.Fatalf("routable = true; want false")
+		}
+	})
 }

--- a/registry/service_projection.go
+++ b/registry/service_projection.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusreg/schema"
@@ -60,6 +62,7 @@ func ProjectRegistryDevices(iter EntryIterator) ([]ServiceDeviceView, error) {
 	if projectionErr != nil {
 		return nil, projectionErr
 	}
+	sortServiceDevices(out)
 	return out, nil
 }
 
@@ -77,6 +80,7 @@ func ProjectDeviceEntry(entry DeviceEntry) (ServiceDeviceView, error) {
 		}
 		projectedPlanes = append(projectedPlanes, projected)
 	}
+	sortServicePlanes(projectedPlanes)
 
 	return ServiceDeviceView{
 		Address:         entry.Address(),
@@ -105,6 +109,7 @@ func ProjectPlane(plane Plane) (ServicePlaneView, error) {
 		}
 		projectedMethods = append(projectedMethods, projected)
 	}
+	sortServiceMethods(projectedMethods)
 
 	return ServicePlaneView{
 		Name:    plane.Name(),
@@ -143,7 +148,11 @@ func normalizeProjectedAddresses(primary byte, aliases []byte) []byte {
 	}
 
 	appendUniqueAddress(primary)
-	for _, address := range aliases {
+	aliasesCopy := append([]byte(nil), aliases...)
+	sort.Slice(aliasesCopy, func(i, j int) bool {
+		return aliasesCopy[i] < aliasesCopy[j]
+	})
+	for _, address := range aliasesCopy {
 		appendUniqueAddress(address)
 	}
 
@@ -151,4 +160,66 @@ func normalizeProjectedAddresses(primary byte, aliases []byte) []byte {
 		return nil
 	}
 	return out
+}
+
+func sortServiceDevices(devices []ServiceDeviceView) {
+	sort.Slice(devices, func(i, j int) bool {
+		left := devices[i]
+		right := devices[j]
+		if left.Address != right.Address {
+			return left.Address < right.Address
+		}
+		if compareFolded(left.Manufacturer, right.Manufacturer) != 0 {
+			return compareFolded(left.Manufacturer, right.Manufacturer) < 0
+		}
+		if compareFolded(left.DeviceID, right.DeviceID) != 0 {
+			return compareFolded(left.DeviceID, right.DeviceID) < 0
+		}
+		if compareFolded(left.HardwareVersion, right.HardwareVersion) != 0 {
+			return compareFolded(left.HardwareVersion, right.HardwareVersion) < 0
+		}
+		return compareFolded(left.SerialNumber, right.SerialNumber) < 0
+	})
+	for index := range devices {
+		sortServicePlanes(devices[index].Planes)
+	}
+}
+
+func sortServicePlanes(planes []ServicePlaneView) {
+	sort.Slice(planes, func(i, j int) bool {
+		if compareFolded(planes[i].Name, planes[j].Name) != 0 {
+			return compareFolded(planes[i].Name, planes[j].Name) < 0
+		}
+		return planes[i].Name < planes[j].Name
+	})
+	for index := range planes {
+		sortServiceMethods(planes[index].Methods)
+	}
+}
+
+func sortServiceMethods(methods []ServiceMethodView) {
+	sort.Slice(methods, func(i, j int) bool {
+		if compareFolded(methods[i].Name, methods[j].Name) != 0 {
+			return compareFolded(methods[i].Name, methods[j].Name) < 0
+		}
+		if methods[i].Name != methods[j].Name {
+			return methods[i].Name < methods[j].Name
+		}
+		if methods[i].Primary != methods[j].Primary {
+			return methods[i].Primary < methods[j].Primary
+		}
+		return methods[i].Secondary < methods[j].Secondary
+	})
+}
+
+func compareFolded(left string, right string) int {
+	leftFolded := strings.ToLower(strings.TrimSpace(left))
+	rightFolded := strings.ToLower(strings.TrimSpace(right))
+	if leftFolded < rightFolded {
+		return -1
+	}
+	if leftFolded > rightFolded {
+		return 1
+	}
+	return 0
 }

--- a/registry/service_projection.go
+++ b/registry/service_projection.go
@@ -1,0 +1,154 @@
+package registry
+
+import (
+	"fmt"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+	"github.com/d3vi1/helianthus-ebusreg/schema"
+)
+
+// EntryIterator is the minimal registry surface required by projection helpers.
+type EntryIterator interface {
+	Iterate(func(DeviceEntry) bool)
+}
+
+// ServiceDeviceView is a normalized device projection for shared service-layer use.
+type ServiceDeviceView struct {
+	Address         byte
+	Addresses       []byte
+	Manufacturer    string
+	DeviceID        string
+	SerialNumber    string
+	MacAddress      string
+	SoftwareVersion string
+	HardwareVersion string
+	Planes          []ServicePlaneView
+}
+
+// ServicePlaneView is a normalized plane projection for shared service-layer use.
+type ServicePlaneView struct {
+	Name    string
+	Methods []ServiceMethodView
+}
+
+// ServiceMethodView is a normalized method projection for shared service-layer use.
+type ServiceMethodView struct {
+	Name             string
+	ReadOnly         bool
+	Primary          byte
+	Secondary        byte
+	Metadata         MethodMetadata
+	ResponseSelector schema.SchemaSelector
+}
+
+func ProjectRegistryDevices(iter EntryIterator) ([]ServiceDeviceView, error) {
+	if iter == nil {
+		return nil, fmt.Errorf("project registry devices: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	out := make([]ServiceDeviceView, 0)
+	var projectionErr error
+	iter.Iterate(func(entry DeviceEntry) bool {
+		projected, err := ProjectDeviceEntry(entry)
+		if err != nil {
+			projectionErr = err
+			return false
+		}
+		out = append(out, projected)
+		return true
+	})
+	if projectionErr != nil {
+		return nil, projectionErr
+	}
+	return out, nil
+}
+
+func ProjectDeviceEntry(entry DeviceEntry) (ServiceDeviceView, error) {
+	if entry == nil {
+		return ServiceDeviceView{}, fmt.Errorf("project device entry: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	planes := entry.Planes()
+	projectedPlanes := make([]ServicePlaneView, 0, len(planes))
+	for index, plane := range planes {
+		projected, err := ProjectPlane(plane)
+		if err != nil {
+			return ServiceDeviceView{}, fmt.Errorf("project device plane %d: %w", index, err)
+		}
+		projectedPlanes = append(projectedPlanes, projected)
+	}
+
+	return ServiceDeviceView{
+		Address:         entry.Address(),
+		Addresses:       normalizeProjectedAddresses(entry.Address(), entry.Addresses()),
+		Manufacturer:    entry.Manufacturer(),
+		DeviceID:        entry.DeviceID(),
+		SerialNumber:    entry.SerialNumber(),
+		MacAddress:      entry.MacAddress(),
+		SoftwareVersion: entry.SoftwareVersion(),
+		HardwareVersion: entry.HardwareVersion(),
+		Planes:          projectedPlanes,
+	}, nil
+}
+
+func ProjectPlane(plane Plane) (ServicePlaneView, error) {
+	if plane == nil {
+		return ServicePlaneView{}, fmt.Errorf("project plane: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	methods := plane.Methods()
+	projectedMethods := make([]ServiceMethodView, 0, len(methods))
+	for index, method := range methods {
+		projected, err := ProjectMethod(method)
+		if err != nil {
+			return ServicePlaneView{}, fmt.Errorf("project method %d: %w", index, err)
+		}
+		projectedMethods = append(projectedMethods, projected)
+	}
+
+	return ServicePlaneView{
+		Name:    plane.Name(),
+		Methods: projectedMethods,
+	}, nil
+}
+
+func ProjectMethod(method Method) (ServiceMethodView, error) {
+	if method == nil {
+		return ServiceMethodView{}, fmt.Errorf("project method: %w", ebuserrors.ErrInvalidPayload)
+	}
+	template := method.Template()
+	if template == nil {
+		return ServiceMethodView{}, fmt.Errorf("project method %q missing template: %w", method.Name(), ebuserrors.ErrInvalidPayload)
+	}
+
+	return ServiceMethodView{
+		Name:             method.Name(),
+		ReadOnly:         method.ReadOnly(),
+		Primary:          template.Primary(),
+		Secondary:        template.Secondary(),
+		Metadata:         ResolveMethodMetadata(method),
+		ResponseSelector: method.ResponseSchema(),
+	}, nil
+}
+
+func normalizeProjectedAddresses(primary byte, aliases []byte) []byte {
+	out := make([]byte, 0, len(aliases)+1)
+	appendUniqueAddress := func(address byte) {
+		for _, existing := range out {
+			if existing == address {
+				return
+			}
+		}
+		out = append(out, address)
+	}
+
+	appendUniqueAddress(primary)
+	for _, address := range aliases {
+		appendUniqueAddress(address)
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/registry/service_projection_test.go
+++ b/registry/service_projection_test.go
@@ -240,6 +240,84 @@ func TestProjectRegistryDevices(t *testing.T) {
 	}
 }
 
+func TestProjectRegistryDevicesDeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	methodZ := projectionTestMethod{
+		name:       "zeta",
+		readOnly:   true,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x09},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityReadOnly,
+		danger:     MethodDangerSafe,
+		routable:   true,
+	}
+	methodA := projectionTestMethod{
+		name:       "alpha",
+		readOnly:   true,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x01},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityReadOnly,
+		danger:     MethodDangerSafe,
+		routable:   true,
+	}
+
+	entryB := projectionTestEntry{
+		address:         0x10,
+		addresses:       []byte{0x15, 0x10, 0x12},
+		manufacturer:    "vaillant",
+		deviceID:        "B",
+		hardwareVersion: "2",
+		serialNumber:    "2",
+		planes: []Plane{
+			projectionTestPlane{name: "zPlane", methods: []Method{methodZ, methodA}},
+			projectionTestPlane{name: "APlane", methods: []Method{methodZ}},
+		},
+	}
+	entryA := projectionTestEntry{
+		address:         0x08,
+		addresses:       []byte{0x09, 0x08, 0x0A},
+		manufacturer:    "Vaillant",
+		deviceID:        "A",
+		hardwareVersion: "1",
+		serialNumber:    "1",
+		planes: []Plane{
+			projectionTestPlane{name: "System", methods: []Method{methodZ, methodA}},
+		},
+	}
+
+	projected, err := ProjectRegistryDevices(projectionTestIterator{entries: []DeviceEntry{entryB, entryA}})
+	if err != nil {
+		t.Fatalf("ProjectRegistryDevices error = %v", err)
+	}
+
+	if len(projected) != 2 {
+		t.Fatalf("devices len = %d; want 2", len(projected))
+	}
+	if projected[0].Address != 0x08 || projected[1].Address != 0x10 {
+		t.Fatalf("device order = [%02x,%02x]; want [08,10]", projected[0].Address, projected[1].Address)
+	}
+	if !reflect.DeepEqual(projected[1].Addresses, []byte{0x10, 0x12, 0x15}) {
+		t.Fatalf("addresses order = %v; want [16 18 21]", projected[1].Addresses)
+	}
+	if len(projected[1].Planes) != 2 {
+		t.Fatalf("plane len = %d; want 2", len(projected[1].Planes))
+	}
+	if projected[1].Planes[0].Name != "APlane" || projected[1].Planes[1].Name != "zPlane" {
+		t.Fatalf("plane order = [%s,%s]; want [APlane,zPlane]", projected[1].Planes[0].Name, projected[1].Planes[1].Name)
+	}
+	if len(projected[1].Planes[1].Methods) != 2 {
+		t.Fatalf("method len = %d; want 2", len(projected[1].Planes[1].Methods))
+	}
+	if projected[1].Planes[1].Methods[0].Name != "alpha" || projected[1].Planes[1].Methods[1].Name != "zeta" {
+		t.Fatalf(
+			"method order = [%s,%s]; want [alpha,zeta]",
+			projected[1].Planes[1].Methods[0].Name,
+			projected[1].Planes[1].Methods[1].Name,
+		)
+	}
+}
+
 func TestProjectPlaneErrors(t *testing.T) {
 	t.Parallel()
 
@@ -254,5 +332,41 @@ func TestProjectPlaneErrors(t *testing.T) {
 
 	if _, err := ProjectDeviceEntry(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
 		t.Fatalf("ProjectDeviceEntry(nil) error = %v; want ErrInvalidPayload", err)
+	}
+}
+
+func TestProjectPlaneDeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	methods := []Method{
+		projectionTestMethod{
+			name:       "zeta",
+			readOnly:   true,
+			template:   projectionTestTemplate{primary: 0xB5, secondary: 0x02},
+			selector:   schema.SchemaSelector{},
+			mutability: MethodMutabilityReadOnly,
+			danger:     MethodDangerSafe,
+			routable:   true,
+		},
+		projectionTestMethod{
+			name:       "alpha",
+			readOnly:   true,
+			template:   projectionTestTemplate{primary: 0xB5, secondary: 0x01},
+			selector:   schema.SchemaSelector{},
+			mutability: MethodMutabilityReadOnly,
+			danger:     MethodDangerSafe,
+			routable:   true,
+		},
+	}
+
+	projected, err := ProjectPlane(projectionTestPlane{name: "Heating", methods: methods})
+	if err != nil {
+		t.Fatalf("ProjectPlane error = %v", err)
+	}
+	if len(projected.Methods) != 2 {
+		t.Fatalf("methods len = %d; want 2", len(projected.Methods))
+	}
+	if projected.Methods[0].Name != "alpha" || projected.Methods[1].Name != "zeta" {
+		t.Fatalf("method order = [%s,%s]; want [alpha,zeta]", projected.Methods[0].Name, projected.Methods[1].Name)
 	}
 }

--- a/registry/service_projection_test.go
+++ b/registry/service_projection_test.go
@@ -1,0 +1,258 @@
+package registry
+
+import (
+	stderrors "errors"
+	"reflect"
+	"testing"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+	"github.com/d3vi1/helianthus-ebusgo/types"
+	"github.com/d3vi1/helianthus-ebusreg/schema"
+)
+
+type projectionTestTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (template projectionTestTemplate) Primary() byte   { return template.primary }
+func (template projectionTestTemplate) Secondary() byte { return template.secondary }
+
+type projectionTestMethod struct {
+	name       string
+	readOnly   bool
+	template   FrameTemplate
+	selector   schema.SchemaSelector
+	mutability MethodMutability
+	danger     MethodDanger
+	routable   bool
+}
+
+func (method projectionTestMethod) Name() string                          { return method.name }
+func (method projectionTestMethod) ReadOnly() bool                        { return method.readOnly }
+func (method projectionTestMethod) Template() FrameTemplate               { return method.template }
+func (method projectionTestMethod) ResponseSchema() schema.SchemaSelector { return method.selector }
+func (method projectionTestMethod) Mutability() MethodMutability          { return method.mutability }
+func (method projectionTestMethod) Danger() MethodDanger                  { return method.danger }
+func (method projectionTestMethod) Routable() bool                        { return method.routable }
+
+type projectionTestPlane struct {
+	name    string
+	methods []Method
+}
+
+func (plane projectionTestPlane) Name() string      { return plane.name }
+func (plane projectionTestPlane) Methods() []Method { return plane.methods }
+
+type projectionTestEntry struct {
+	address         byte
+	addresses       []byte
+	manufacturer    string
+	deviceID        string
+	serialNumber    string
+	macAddress      string
+	softwareVersion string
+	hardwareVersion string
+	planes          []Plane
+	projections     []Projection
+}
+
+func (entry projectionTestEntry) Address() byte             { return entry.address }
+func (entry projectionTestEntry) Addresses() []byte         { return append([]byte(nil), entry.addresses...) }
+func (entry projectionTestEntry) Manufacturer() string      { return entry.manufacturer }
+func (entry projectionTestEntry) DeviceID() string          { return entry.deviceID }
+func (entry projectionTestEntry) SerialNumber() string      { return entry.serialNumber }
+func (entry projectionTestEntry) MacAddress() string        { return entry.macAddress }
+func (entry projectionTestEntry) SoftwareVersion() string   { return entry.softwareVersion }
+func (entry projectionTestEntry) HardwareVersion() string   { return entry.hardwareVersion }
+func (entry projectionTestEntry) Planes() []Plane           { return entry.planes }
+func (entry projectionTestEntry) Projections() []Projection { return entry.projections }
+
+type projectionTestIterator struct {
+	entries []DeviceEntry
+}
+
+func (iterator projectionTestIterator) Iterate(fn func(DeviceEntry) bool) {
+	for _, entry := range iterator.entries {
+		if !fn(entry) {
+			return
+		}
+	}
+}
+
+func TestProjectMethod(t *testing.T) {
+	t.Parallel()
+
+	selector := schema.SchemaSelector{
+		Default: schema.Schema{Fields: []schema.SchemaField{{Name: "temp_c", Type: types.DATA2b{}}}},
+	}
+	method := projectionTestMethod{
+		name:     "set_target",
+		readOnly: false,
+		template: projectionTestTemplate{primary: 0xB5, secondary: 0x05},
+		selector: selector,
+		// Explicit metadata provider values take priority over ReadOnly fallback.
+		mutability: MethodMutabilityUnknown,
+		danger:     MethodDangerDangerous,
+		routable:   false,
+	}
+
+	projected, err := ProjectMethod(method)
+	if err != nil {
+		t.Fatalf("ProjectMethod error = %v", err)
+	}
+	if projected.Name != "set_target" {
+		t.Fatalf("Name = %q; want set_target", projected.Name)
+	}
+	if projected.ReadOnly {
+		t.Fatalf("ReadOnly = true; want false")
+	}
+	if projected.Primary != 0xB5 || projected.Secondary != 0x05 {
+		t.Fatalf("template = (%02x,%02x); want (b5,05)", projected.Primary, projected.Secondary)
+	}
+	if !reflect.DeepEqual(projected.ResponseSelector, selector) {
+		t.Fatalf("ResponseSelector = %#v; want %#v", projected.ResponseSelector, selector)
+	}
+	if projected.Metadata.Mutability != MethodMutabilityUnknown {
+		t.Fatalf("Mutability = %q; want unknown", projected.Metadata.Mutability)
+	}
+	if projected.Metadata.Danger != MethodDangerDangerous {
+		t.Fatalf("Danger = %q; want dangerous", projected.Metadata.Danger)
+	}
+	if projected.Metadata.Routable {
+		t.Fatalf("Routable = true; want false")
+	}
+}
+
+func TestProjectMethodErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ProjectMethod(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectMethod(nil) error = %v; want ErrInvalidPayload", err)
+	}
+
+	invalidMethod := projectionTestMethod{name: "broken", template: nil}
+	if _, err := ProjectMethod(invalidMethod); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectMethod(missing template) error = %v; want ErrInvalidPayload", err)
+	}
+}
+
+func TestProjectDeviceEntryAndPlane(t *testing.T) {
+	t.Parallel()
+
+	readMethod := projectionTestMethod{
+		name:       "get_status",
+		readOnly:   true,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x04},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityReadOnly,
+		danger:     MethodDangerSafe,
+		routable:   true,
+	}
+	writeMethod := projectionTestMethod{
+		name:       "set_target",
+		readOnly:   false,
+		template:   projectionTestTemplate{primary: 0xB5, secondary: 0x05},
+		selector:   schema.SchemaSelector{},
+		mutability: MethodMutabilityMutating,
+		danger:     MethodDangerDangerous,
+		routable:   true,
+	}
+	plane := projectionTestPlane{name: "Heating", methods: []Method{readMethod, writeMethod}}
+	entry := projectionTestEntry{
+		address:         0x08,
+		addresses:       []byte{0x10, 0x08, 0x10},
+		manufacturer:    "Vaillant",
+		deviceID:        "BAI00",
+		serialNumber:    "ABC",
+		macAddress:      "DEF",
+		softwareVersion: "123",
+		hardwareVersion: "456",
+		planes:          []Plane{plane},
+	}
+
+	projected, err := ProjectDeviceEntry(entry)
+	if err != nil {
+		t.Fatalf("ProjectDeviceEntry error = %v", err)
+	}
+	if projected.Address != 0x08 {
+		t.Fatalf("Address = %02x; want 08", projected.Address)
+	}
+	if !reflect.DeepEqual(projected.Addresses, []byte{0x08, 0x10}) {
+		t.Fatalf("Addresses = %v; want [8 16]", projected.Addresses)
+	}
+	if projected.Manufacturer != "Vaillant" || projected.DeviceID != "BAI00" {
+		t.Fatalf("identity projection mismatch: %#v", projected)
+	}
+	if len(projected.Planes) != 1 {
+		t.Fatalf("Planes len = %d; want 1", len(projected.Planes))
+	}
+	if projected.Planes[0].Name != "Heating" {
+		t.Fatalf("Plane name = %q; want Heating", projected.Planes[0].Name)
+	}
+	if len(projected.Planes[0].Methods) != 2 {
+		t.Fatalf("Methods len = %d; want 2", len(projected.Planes[0].Methods))
+	}
+
+	projected.Addresses[0] = 0xFF
+	again, err := ProjectDeviceEntry(entry)
+	if err != nil {
+		t.Fatalf("ProjectDeviceEntry(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(again.Addresses, []byte{0x08, 0x10}) {
+		t.Fatalf("Addresses leaked mutation: %v", again.Addresses)
+	}
+}
+
+func TestProjectRegistryDevices(t *testing.T) {
+	t.Parallel()
+
+	entryA := projectionTestEntry{
+		address:   0x08,
+		addresses: []byte{0x08},
+		planes:    []Plane{projectionTestPlane{name: "System", methods: []Method{projectionTestMethod{name: "a", template: projectionTestTemplate{primary: 0xB5, secondary: 0x04}, selector: schema.SchemaSelector{}, mutability: MethodMutabilityReadOnly, danger: MethodDangerSafe, routable: true, readOnly: true}}}},
+	}
+	entryB := projectionTestEntry{
+		address:   0x10,
+		addresses: []byte{0x10},
+		planes:    []Plane{projectionTestPlane{name: "Heating", methods: []Method{projectionTestMethod{name: "b", template: projectionTestTemplate{primary: 0xB5, secondary: 0x05}, selector: schema.SchemaSelector{}, mutability: MethodMutabilityMutating, danger: MethodDangerDangerous, routable: true, readOnly: false}}}},
+	}
+	iterator := projectionTestIterator{entries: []DeviceEntry{entryA, entryB}}
+
+	projected, err := ProjectRegistryDevices(iterator)
+	if err != nil {
+		t.Fatalf("ProjectRegistryDevices error = %v", err)
+	}
+	if len(projected) != 2 {
+		t.Fatalf("len = %d; want 2", len(projected))
+	}
+	if projected[0].Address != 0x08 || projected[1].Address != 0x10 {
+		t.Fatalf("order mismatch: %02x %02x", projected[0].Address, projected[1].Address)
+	}
+
+	if _, err := ProjectRegistryDevices(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectRegistryDevices(nil) error = %v; want ErrInvalidPayload", err)
+	}
+
+	badIterator := projectionTestIterator{entries: []DeviceEntry{entryA, nil, entryB}}
+	if _, err := ProjectRegistryDevices(badIterator); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectRegistryDevices(bad iterator) error = %v; want ErrInvalidPayload", err)
+	}
+}
+
+func TestProjectPlaneErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ProjectPlane(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectPlane(nil) error = %v; want ErrInvalidPayload", err)
+	}
+
+	badPlane := projectionTestPlane{name: "Bad", methods: []Method{projectionTestMethod{name: "broken", template: nil}}}
+	if _, err := ProjectPlane(badPlane); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectPlane(bad method) error = %v; want ErrInvalidPayload", err)
+	}
+
+	if _, err := ProjectDeviceEntry(nil); !stderrors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Fatalf("ProjectDeviceEntry(nil) error = %v; want ErrInvalidPayload", err)
+	}
+}


### PR DESCRIPTION
Integration PR to merge MCP-first program work from mcpfirst-cruise-control into main.\n\nScope included:\n- MCP-10-101..104 (method safety metadata contract, shared registry projections, deterministic ordering, semantics tests/docs)\n- local validation executed in branch workflow (GOWORK=off ./scripts/ci_local.sh)\n\nPart of final MCP-first integration wave.