### PR TITLE
issue-97: ControllerCapability tri-state contract

### DIFF
--- a/vaillant/productids/catalog.go
+++ b/vaillant/productids/catalog.go
@@ -112,7 +112,7 @@ func (c ControllerCapability) String() string {
 }
 
 func (c Catalog) ControllerCapability(partNumber string) ControllerCapability {
-	record, found := c.ByPartNumber[partNumber]
+	record, found := c.ByPartNumber[strings.TrimSpace(partNumber)]
 	if !found {
 		return ControllerUnknown
 	}

--- a/vaillant/productids/catalog.go
+++ b/vaillant/productids/catalog.go
@@ -89,3 +89,35 @@ func valueAt(row []string, idx int) string {
 	}
 	return row[idx]
 }
+
+type ControllerCapability int
+
+const (
+	ControllerUnknown ControllerCapability = iota
+	ControllerNone
+	ControllerPresent
+)
+
+func (c ControllerCapability) String() string {
+	switch c {
+	case ControllerUnknown:
+		return "ControllerUnknown"
+	case ControllerNone:
+		return "ControllerNone"
+	case ControllerPresent:
+		return "ControllerPresent"
+	default:
+		return "ControllerCapability(invalid)"
+	}
+}
+
+func (c Catalog) ControllerCapability(partNumber string) ControllerCapability {
+	record, found := c.ByPartNumber[partNumber]
+	if !found {
+		return ControllerUnknown
+	}
+	if strings.EqualFold(record.Role, "Regulator") {
+		return ControllerPresent
+	}
+	return ControllerNone
+}

--- a/vaillant/productids/catalog_test.go
+++ b/vaillant/productids/catalog_test.go
@@ -97,6 +97,32 @@ func TestControllerCapabilityString(t *testing.T) {
 	}
 }
 
+func TestControllerCapabilityCaseInsensitive(t *testing.T) {
+	catalog := Catalog{
+		ByPartNumber: map[string]Record{
+			"PN_REG": {PartNumber: "PN_REG", Role: "regulator"},
+		},
+	}
+
+	got := catalog.ControllerCapability("PN_REG")
+	if got != ControllerPresent {
+		t.Fatalf("expected ControllerPresent for lowercase role, got %v", got)
+	}
+}
+
+func TestControllerCapabilityTrimSpace(t *testing.T) {
+	catalog := Catalog{
+		ByPartNumber: map[string]Record{
+			"PN_REG": {PartNumber: "PN_REG", Role: "Regulator"},
+		},
+	}
+
+	got := catalog.ControllerCapability("  PN_REG  ")
+	if got != ControllerPresent {
+		t.Fatalf("expected ControllerPresent for padded part number, got %v", got)
+	}
+}
+
 func TestControllerCapabilityRealCatalog(t *testing.T) {
 	catalog, err := LoadCatalog()
 	if err != nil {

--- a/vaillant/productids/catalog_test.go
+++ b/vaillant/productids/catalog_test.go
@@ -39,3 +39,74 @@ func TestParseCatalogMissingColumns(t *testing.T) {
 		t.Fatalf("expected ErrMissingColumns, got %v", err)
 	}
 }
+
+func TestControllerCapabilityPresent(t *testing.T) {
+	catalog := Catalog{
+		ByPartNumber: map[string]Record{
+			"PN_REG": {PartNumber: "PN_REG", Role: "Regulator"},
+		},
+	}
+
+	got := catalog.ControllerCapability("PN_REG")
+	if got != ControllerPresent {
+		t.Fatalf("expected ControllerPresent, got %v", got)
+	}
+}
+
+func TestControllerCapabilityNone(t *testing.T) {
+	catalog := Catalog{
+		ByPartNumber: map[string]Record{
+			"PN_BOIL": {PartNumber: "PN_BOIL", Role: "Boiler"},
+		},
+	}
+
+	got := catalog.ControllerCapability("PN_BOIL")
+	if got != ControllerNone {
+		t.Fatalf("expected ControllerNone, got %v", got)
+	}
+}
+
+func TestControllerCapabilityUnknown(t *testing.T) {
+	catalog := Catalog{
+		ByPartNumber: map[string]Record{
+			"PN_REG": {PartNumber: "PN_REG", Role: "Regulator"},
+		},
+	}
+
+	got := catalog.ControllerCapability("PN_UNKNOWN")
+	if got != ControllerUnknown {
+		t.Fatalf("expected ControllerUnknown, got %v", got)
+	}
+}
+
+func TestControllerCapabilityString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   ControllerCapability
+		want string
+	}{
+		{name: "unknown", in: ControllerUnknown, want: "ControllerUnknown"},
+		{name: "none", in: ControllerNone, want: "ControllerNone"},
+		{name: "present", in: ControllerPresent, want: "ControllerPresent"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.in.String(); got != tt.want {
+			t.Fatalf("%s: expected %q, got %q", tt.name, tt.want, got)
+		}
+	}
+}
+
+func TestControllerCapabilityRealCatalog(t *testing.T) {
+	catalog, err := LoadCatalog()
+	if err != nil {
+		t.Fatalf("LoadCatalog error: %v", err)
+	}
+
+	if got := catalog.ControllerCapability("0020171314"); got != ControllerPresent {
+		t.Fatalf("expected 0020171314 to be ControllerPresent, got %v", got)
+	}
+	if got := catalog.ControllerCapability("0010016292"); got != ControllerNone {
+		t.Fatalf("expected 0010016292 to be ControllerNone, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ControllerCapability` tri-state enum: `ControllerUnknown` / `ControllerNone` / `ControllerPresent`
- Adds `Catalog.ControllerCapability(partNumber)` lookup method with case-insensitive role comparison
- Protocol-agnostic contract — no transport or eBUS specifics

Prerequisite for ebusgateway#193 (regulator detection from product_ids).

Closes #97

## Test plan
- [x] Unit tests for all three states (Present, None, Unknown)
- [x] String() method test
- [x] Real catalog validation (VRC 700/2 → Present, GeniaAir → None)
- [x] `ci_local.sh` green (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)