### PR TITLE
Export ReadVaillantScanID for gateway B5.09 enrichment

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -191,6 +191,14 @@ func parseDeviceInfo(address byte, payload []byte) (DeviceInfo, error) {
 	}, nil
 }
 
+// ReadVaillantScanID sends B5.09 identity reads (chunks 0x24..0x27) and
+// returns the formatted Vaillant serial number.  It is the exported twin of
+// the internal readVaillantScanID so that callers outside this package (e.g.
+// the gateway's ebusd-tcp preload enrichment) can invoke it.
+func ReadVaillantScanID(ctx context.Context, bus ScanBus, source byte, target byte) (string, bool, error) {
+	return readVaillantScanID(ctx, bus, source, target)
+}
+
 func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target byte) (string, bool, error) {
 	if bus == nil {
 		return "", false, nil


### PR DESCRIPTION
## Summary
- Export `readVaillantScanID` as `ReadVaillantScanID` — a thin 3-line wrapper
- Needed by d3vi1/helianthus-ebusgateway#223 (post-preload B5.09 identity enrichment for ebusd-tcp transport)
- No behavior change to existing code

## Test plan
- [x] `go test ./...` passes (registry package tests cover scan logic)
- [x] No new behavior — purely an export of existing function

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)