### PR TITLE
Remove projection device_id whitelist

### DIFF
--- a/vaillant/system/projections.go
+++ b/vaillant/system/projections.go
@@ -138,18 +138,7 @@ func planeNameSet(planes []registry.Plane) map[string]struct{} {
 }
 
 func shouldCreateProjections(planes []registry.Plane) bool {
-	return len(planes) > 0
-}
-
-func normalizeDeviceID(id string) string {
-	if strings.TrimSpace(id) == "" {
-		return ""
-	}
-	normalized := strings.ToUpper(strings.TrimSpace(id))
-	normalized = strings.ReplaceAll(normalized, "_", "")
-	normalized = strings.ReplaceAll(normalized, " ", "")
-	normalized = strings.ReplaceAll(normalized, "-", "")
-	return normalized
+	return len(planeNameSet(planes)) > 0
 }
 
 func projectionBaseSegments(info registry.DeviceInfo) []registry.PathSegment {

--- a/vaillant/system/projections.go
+++ b/vaillant/system/projections.go
@@ -17,7 +17,7 @@ const (
 )
 
 func (Provider) CreateProjections(info registry.DeviceInfo, planes []registry.Plane) []registry.Projection {
-	if !shouldCreateProjections(info) {
+	if !shouldCreateProjections(planes) {
 		return nil
 	}
 
@@ -137,14 +137,8 @@ func planeNameSet(planes []registry.Plane) map[string]struct{} {
 	return out
 }
 
-func shouldCreateProjections(info registry.DeviceInfo) bool {
-	normalized := normalizeDeviceID(info.DeviceID)
-	switch normalized {
-	case "BASV2", "BAI00", "VR71":
-		return true
-	default:
-		return false
-	}
+func shouldCreateProjections(planes []registry.Plane) bool {
+	return len(planes) > 0
 }
 
 func normalizeDeviceID(id string) string {

--- a/vaillant/system/projections_test.go
+++ b/vaillant/system/projections_test.go
@@ -99,6 +99,10 @@ func TestCreateProjections_NoPlanes(t *testing.T) {
 	if projections != nil {
 		t.Fatalf("expected nil projections for zero-length planes, got %d", len(projections))
 	}
+	projections = NewProvider().CreateProjections(info, []registry.Plane{nil, nil})
+	if projections != nil {
+		t.Fatalf("expected nil projections for nil-element planes, got %d", len(projections))
+	}
 }
 
 func hasNodePath(projections []registry.Projection, plane string, path string) bool {

--- a/vaillant/system/projections_test.go
+++ b/vaillant/system/projections_test.go
@@ -66,14 +66,38 @@ func TestCreateProjections_DeviceFilter(t *testing.T) {
 	}
 	planes := NewProvider().CreatePlanes(info)
 	projections := NewProvider().CreateProjections(info, planes)
-	if len(projections) != 0 {
-		t.Fatalf("expected no projections, got %d", len(projections))
+	if len(projections) == 0 {
+		t.Fatalf("expected projections for VRC720, got 0")
+	}
+	if !hasNodePath(projections, "Service", "Service:/ebus/addr@10/device@VRC720/method@get_operational_data") {
+		t.Fatalf("missing Service operational node for VRC720")
+	}
+	if !hasNodePath(projections, "Debug", "Debug:/ebus/addr@10/device@VRC720/register@b509") {
+		t.Fatalf("missing Debug b509 node for VRC720")
 	}
 
 	info.DeviceID = "VR_71"
 	projections = NewProvider().CreateProjections(info, planes)
 	if len(projections) == 0 {
 		t.Fatalf("expected projections for VR_71")
+	}
+}
+
+func TestCreateProjections_NoPlanes(t *testing.T) {
+	t.Parallel()
+
+	info := registry.DeviceInfo{
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		Address:      0x10,
+	}
+	projections := NewProvider().CreateProjections(info, nil)
+	if projections != nil {
+		t.Fatalf("expected nil projections for empty planes, got %d", len(projections))
+	}
+	projections = NewProvider().CreateProjections(info, []registry.Plane{})
+	if projections != nil {
+		t.Fatalf("expected nil projections for zero-length planes, got %d", len(projections))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove hardcoded `shouldCreateProjections()` whitelist that restricted projections to BASV2/BAI00/VR71
- Gate on `len(planes) > 0` instead — any Vaillant device with registered planes gets Service, Observability, and Debug projections
- VRC720 regulator (the most important device) now gets projections in the portal

## Test Updates

- `TestCreateProjections_DeviceFilter`: Flipped — VRC720 now gets projections, verified Service + Debug nodes
- `TestCreateProjections_NoPlanes`: New test — verifies nil/empty planes returns nil projections
- Existing BASV2/BAI00 tests unchanged and passing

## Test plan

- [x] `go test ./vaillant/system/ -count=1 -run TestCreateProjections` — all 4 tests pass
- [x] `go test ./... -count=1` — full suite green
- [x] `go vet ./...` — clean
- [ ] Codex code review
- [ ] Live portal validation after gateway rebuild

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)