### PR TITLE
Fix projection BuildCanonicalIndex failure

### DIFF
--- a/vaillant/system/projections.go
+++ b/vaillant/system/projections.go
@@ -54,6 +54,10 @@ func (Provider) CreateProjections(info registry.DeviceInfo, planes []registry.Pl
 		Plane:    registry.ServicePlane,
 		Segments: appendSegment(base, methodSegment(methodGetRegister)),
 	}
+	registerService, ok := newNode(registry.ServicePlane, registerCanonical.Segments, registerCanonical)
+	if !ok {
+		return nil
+	}
 	registerDebug, ok := newNode(projectionPlaneDebug, appendSegment(base, registry.PathSegment{Name: "register@b509"}), registerCanonical)
 	if !ok {
 		return nil
@@ -63,6 +67,10 @@ func (Provider) CreateProjections(info registry.DeviceInfo, planes []registry.Pl
 		Plane:    registry.ServicePlane,
 		Segments: appendSegment(base, methodSegment(methodGetExtRegister)),
 	}
+	extRegisterService, ok := newNode(registry.ServicePlane, extRegisterCanonical.Segments, extRegisterCanonical)
+	if !ok {
+		return nil
+	}
 	extRegisterDebug, ok := newNode(projectionPlaneDebug, appendSegment(base, registry.PathSegment{Name: "register@b524"}), extRegisterCanonical)
 	if !ok {
 		return nil
@@ -70,11 +78,17 @@ func (Provider) CreateProjections(info registry.DeviceInfo, planes []registry.Pl
 
 	projections := make([]registry.Projection, 0, 7)
 
-	serviceEdges := make([]registry.Edge, 0, 1)
+	serviceEdges := make([]registry.Edge, 0, 3)
 	if edge, err := registry.NewEdge(registry.ServicePlane, rootService.ID, operationalService.ID); err == nil {
 		serviceEdges = append(serviceEdges, edge)
 	}
-	if projection, err := registry.NewProjection(registry.ServicePlane, []registry.Node{rootService, operationalService}, serviceEdges); err == nil {
+	if edge, err := registry.NewEdge(registry.ServicePlane, rootService.ID, registerService.ID); err == nil {
+		serviceEdges = append(serviceEdges, edge)
+	}
+	if edge, err := registry.NewEdge(registry.ServicePlane, rootService.ID, extRegisterService.ID); err == nil {
+		serviceEdges = append(serviceEdges, edge)
+	}
+	if projection, err := registry.NewProjection(registry.ServicePlane, []registry.Node{rootService, operationalService, registerService, extRegisterService}, serviceEdges); err == nil {
 		projections = append(projections, projection)
 	}
 

--- a/vaillant/system/projections_test.go
+++ b/vaillant/system/projections_test.go
@@ -20,6 +20,12 @@ func TestCreateProjections_BASV2(t *testing.T) {
 	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@10/device@BASV2/method@get_operational_data") {
 		t.Fatalf("missing Service operational node")
 	}
+	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@10/device@BASV2/method@get_register") {
+		t.Fatalf("missing Service register node")
+	}
+	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@10/device@BASV2/method@get_ext_register") {
+		t.Fatalf("missing Service ext_register node")
+	}
 	if !hasNodePath(projections, "Observability", "Observability:/ebus/addr@10/device@BASV2/method@get_operational_data") {
 		t.Fatalf("missing Observability operational node")
 	}
@@ -44,6 +50,12 @@ func TestCreateProjections_BAI00(t *testing.T) {
 
 	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@08/device@BAI00/method@get_operational_data") {
 		t.Fatalf("missing Service operational node")
+	}
+	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@08/device@BAI00/method@get_register") {
+		t.Fatalf("missing Service register node")
+	}
+	if !hasNodePath(projections, registry.ServicePlane, "Service:/ebus/addr@08/device@BAI00/method@get_ext_register") {
+		t.Fatalf("missing Service ext_register node")
 	}
 	if !hasNodePath(projections, "Observability", "Observability:/ebus/addr@08/device@BAI00/method@get_operational_data") {
 		t.Fatalf("missing Observability operational node")
@@ -102,6 +114,28 @@ func TestCreateProjections_NoPlanes(t *testing.T) {
 	projections = NewProvider().CreateProjections(info, []registry.Plane{nil, nil})
 	if projections != nil {
 		t.Fatalf("expected nil projections for nil-element planes, got %d", len(projections))
+	}
+}
+
+func TestCreateProjections_BuildCanonicalIndex(t *testing.T) {
+	t.Parallel()
+
+	devices := []registry.DeviceInfo{
+		{Manufacturer: "Vaillant", DeviceID: "BAI00", Address: 0x08},
+		{Manufacturer: "Vaillant", DeviceID: "BASV2", Address: 0x15},
+		{Manufacturer: "Vaillant", DeviceID: "VRC720", Address: 0x10},
+	}
+	provider := NewProvider()
+	for _, info := range devices {
+		planes := provider.CreatePlanes(info)
+		projections := provider.CreateProjections(info, planes)
+		if len(projections) == 0 {
+			t.Fatalf("expected projections for %s", info.DeviceID)
+		}
+		_, err := registry.BuildCanonicalIndex(projections)
+		if err != nil {
+			t.Fatalf("BuildCanonicalIndex failed for %s: %v", info.DeviceID, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add missing Service plane nodes (`registerService`, `extRegisterService`) that Debug projection canonicals reference
- Wire new nodes into Service projection with edges from root
- Add `BuildCanonicalIndex` integration test as regression guard for BAI00, BASV2, and VRC720

## Root Cause
Debug nodes `registerDebug` and `extRegisterDebug` had canonical paths pointing to `Service:/.../method@get_register` and `Service:/.../method@get_ext_register`, but no Service plane nodes existed for those methods. `BuildCanonicalIndex` validation failed → `projections = nil` for all devices.

## Test plan
- [x] All 5 `TestCreateProjections_*` tests pass
- [x] New `TestCreateProjections_BuildCanonicalIndex` validates the index builds without error for BAI00, BASV2, VRC720
- [x] `go test ./... && go vet ./...` — all green
- [ ] Live: portal projection panel shows graphs for all devices after gateway picks up new ebusreg

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)