### PR TITLE
B524 profile register max updates per D9

### DIFF
--- a/vaillant/system/b524_profile.go
+++ b/vaillant/system/b524_profile.go
@@ -12,10 +12,31 @@ const (
 	B524OpcodeRemote = byte(0x06)
 )
 
+// B524DiscoveryProfiles defines the maximum exploration bounds for B524
+// register discovery per group. Dual-namespace groups (0x08, 0x09, 0x0A)
+// have separate profiles for local (OP=0x02) and remote (OP=0x06) opcodes.
+//
+// Over-estimate policy: where existing profile max exceeds scan-observed max
+// (GG=0x0A Remote: profile 0x003F > scan 0x0035, GG=0x0C Remote: profile
+// 0x003F > scan 0x002F), existing higher values are kept conservatively as
+// the scan may miss optional registers.
 var B524DiscoveryProfiles = []B524GroupProfile{
-	{Group: 0x02, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x0021},
-	{Group: 0x03, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x002F},
-	{Group: 0x09, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x002F},
-	{Group: 0x0A, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x003F},
-	{Group: 0x0C, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x003F},
+	// Singleton groups (II_max=0x00)
+	{Group: 0x00, Opcode: B524OpcodeLocal, InstanceMax: 0x00, RegisterMax: 0x00FF}, // Regulator Parameters
+	{Group: 0x01, Opcode: B524OpcodeLocal, InstanceMax: 0x00, RegisterMax: 0x0013}, // DHW
+
+	// Multi-instance local groups
+	{Group: 0x02, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x0025}, // Heating Circuits
+	{Group: 0x03, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x002F}, // Zones
+
+	// Dual-namespace groups: local (OP=0x02) config + remote (OP=0x06) live data
+	{Group: 0x08, Opcode: B524OpcodeLocal, InstanceMax: 0x00, RegisterMax: 0x0007},  // Buffer/Solar Cylinder 2 (singleton)
+	{Group: 0x08, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x0004}, // Buffer/Solar Cylinder 2 (remote)
+	{Group: 0x09, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x000F},  // Room Sensors (local config)
+	{Group: 0x09, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x002F}, // Room Sensors (remote live)
+	{Group: 0x0A, Opcode: B524OpcodeLocal, InstanceMax: 0x0A, RegisterMax: 0x004D},  // Room State (local config)
+	{Group: 0x0A, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x003F}, // Room State (remote live)
+
+	// Remote-only groups
+	{Group: 0x0C, Opcode: B524OpcodeRemote, InstanceMax: 0x0A, RegisterMax: 0x003F}, // Unrecognized
 }

--- a/vaillant/system/b524_profile_test.go
+++ b/vaillant/system/b524_profile_test.go
@@ -2,35 +2,104 @@ package system
 
 import "testing"
 
+type profileKey struct {
+	Group  byte
+	Opcode byte
+}
+
 func TestB524DiscoveryProfiles(t *testing.T) {
 	t.Parallel()
 
-	profiles := map[byte]B524GroupProfile{}
+	profiles := map[profileKey]B524GroupProfile{}
 	for _, profile := range B524DiscoveryProfiles {
-		profiles[profile.Group] = profile
+		key := profileKey{Group: profile.Group, Opcode: profile.Opcode}
+		if _, exists := profiles[key]; exists {
+			t.Fatalf("duplicate profile for group 0x%02X opcode 0x%02X", profile.Group, profile.Opcode)
+		}
+		profiles[key] = profile
 	}
 
-	assertProfile(t, profiles, 0x02, B524OpcodeLocal, 0x0A, 0x0021)
+	// Singleton groups
+	assertProfile(t, profiles, 0x00, B524OpcodeLocal, 0x00, 0x00FF)
+	assertProfile(t, profiles, 0x01, B524OpcodeLocal, 0x00, 0x0013)
+
+	// Multi-instance local groups
+	assertProfile(t, profiles, 0x02, B524OpcodeLocal, 0x0A, 0x0025)
 	assertProfile(t, profiles, 0x03, B524OpcodeLocal, 0x0A, 0x002F)
+
+	// Dual-namespace groups
+	assertProfile(t, profiles, 0x08, B524OpcodeLocal, 0x00, 0x0007)
+	assertProfile(t, profiles, 0x08, B524OpcodeRemote, 0x0A, 0x0004)
+	assertProfile(t, profiles, 0x09, B524OpcodeLocal, 0x0A, 0x000F)
 	assertProfile(t, profiles, 0x09, B524OpcodeRemote, 0x0A, 0x002F)
+	assertProfile(t, profiles, 0x0A, B524OpcodeLocal, 0x0A, 0x004D)
 	assertProfile(t, profiles, 0x0A, B524OpcodeRemote, 0x0A, 0x003F)
+
+	// Remote-only groups
 	assertProfile(t, profiles, 0x0C, B524OpcodeRemote, 0x0A, 0x003F)
 }
 
-func assertProfile(t *testing.T, profiles map[byte]B524GroupProfile, group, opcode, instanceMax byte, registerMax uint16) {
+func TestB524Profile_RegistersDualNamespaceEntries(t *testing.T) {
+	t.Parallel()
+
+	type dualEntry struct {
+		group                byte
+		localInstanceMax     byte
+		localRegisterMax     uint16
+		remoteInstanceMax    byte
+		remoteRegisterMax    uint16
+	}
+
+	dualGroups := []dualEntry{
+		{group: 0x08, localInstanceMax: 0x00, localRegisterMax: 0x0007, remoteInstanceMax: 0x0A, remoteRegisterMax: 0x0004},
+		{group: 0x09, localInstanceMax: 0x0A, localRegisterMax: 0x000F, remoteInstanceMax: 0x0A, remoteRegisterMax: 0x002F},
+		{group: 0x0A, localInstanceMax: 0x0A, localRegisterMax: 0x004D, remoteInstanceMax: 0x0A, remoteRegisterMax: 0x003F},
+	}
+
+	profiles := map[profileKey]B524GroupProfile{}
+	for _, p := range B524DiscoveryProfiles {
+		profiles[profileKey{Group: p.Group, Opcode: p.Opcode}] = p
+	}
+
+	for _, de := range dualGroups {
+		localKey := profileKey{Group: de.group, Opcode: B524OpcodeLocal}
+		local, ok := profiles[localKey]
+		if !ok {
+			t.Fatalf("missing local profile for dual-namespace group 0x%02X", de.group)
+		}
+		if local.InstanceMax != de.localInstanceMax {
+			t.Fatalf("group 0x%02X local instance max = 0x%02X, want 0x%02X", de.group, local.InstanceMax, de.localInstanceMax)
+		}
+		if local.RegisterMax != de.localRegisterMax {
+			t.Fatalf("group 0x%02X local register max = 0x%04X, want 0x%04X", de.group, local.RegisterMax, de.localRegisterMax)
+		}
+
+		remoteKey := profileKey{Group: de.group, Opcode: B524OpcodeRemote}
+		remote, ok := profiles[remoteKey]
+		if !ok {
+			t.Fatalf("missing remote profile for dual-namespace group 0x%02X", de.group)
+		}
+		if remote.InstanceMax != de.remoteInstanceMax {
+			t.Fatalf("group 0x%02X remote instance max = 0x%02X, want 0x%02X", de.group, remote.InstanceMax, de.remoteInstanceMax)
+		}
+		if remote.RegisterMax != de.remoteRegisterMax {
+			t.Fatalf("group 0x%02X remote register max = 0x%04X, want 0x%04X", de.group, remote.RegisterMax, de.remoteRegisterMax)
+		}
+	}
+}
+
+func assertProfile(t *testing.T, profiles map[profileKey]B524GroupProfile, group, opcode, instanceMax byte, registerMax uint16) {
 	t.Helper()
 
-	profile, ok := profiles[group]
+	key := profileKey{Group: group, Opcode: opcode}
+	profile, ok := profiles[key]
 	if !ok {
-		t.Fatalf("missing profile for group 0x%02X", group)
-	}
-	if profile.Opcode != opcode {
-		t.Fatalf("group 0x%02X opcode = 0x%02X, want 0x%02X", group, profile.Opcode, opcode)
+		t.Fatalf("missing profile for group 0x%02X opcode 0x%02X", group, opcode)
 	}
 	if profile.InstanceMax != instanceMax {
-		t.Fatalf("group 0x%02X instance max = 0x%02X, want 0x%02X", group, profile.InstanceMax, instanceMax)
+		t.Fatalf("group 0x%02X opcode 0x%02X instance max = 0x%02X, want 0x%02X", group, opcode, profile.InstanceMax, instanceMax)
 	}
 	if profile.RegisterMax != registerMax {
-		t.Fatalf("group 0x%02X register max = 0x%04X, want 0x%04X", group, profile.RegisterMax, registerMax)
+		t.Fatalf("group 0x%02X opcode 0x%02X register max = 0x%04X, want 0x%04X", group, opcode, profile.RegisterMax, registerMax)
 	}
 }


### PR DESCRIPTION
## Summary
- Add GG=0x00 (Regulator) and GG=0x01 (DHW) singleton profiles
- Update GG=0x02 (HeatingCircuits) RR_max: 0x0021 → 0x0025
- Add 4 new dual-namespace profiles (GG=0x08 L+R, GG=0x09 L, GG=0x0A L)
- GG=0x03 unchanged (already correct at 0x002F)
- Over-estimate policy: GG=0x0A Remote and GG=0x0C Remote kept at 0x003F

## Test plan
- [x] `TestB524DiscoveryProfiles` — restructured for dual-namespace (composite key)
- [x] `TestB524Profile_RegistersDualNamespaceEntries` — table-driven validation of all 4 new dual-namespace entries
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` all pass
- [x] `golangci-lint run ./...` 0 issues
- [ ] TinyGo: SKIPPED — TinyGo 0.40.1 requires Go ≤1.25, system has Go 1.26 (infrastructure-level, not code-level)

META-22 W1-I01. Closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)