### PR TITLE
B555 timer/schedule plane provider

### DIFF
--- a/providers/vaillant/providers.go
+++ b/providers/vaillant/providers.go
@@ -2,6 +2,7 @@ package vaillant
 
 import (
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/b555"
 	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/dhw"
 	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/heating"
 	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/solar"
@@ -24,11 +25,16 @@ func Solar() registry.PlaneProvider {
 	return solar.NewProvider()
 }
 
+func Timer() registry.PlaneProvider {
+	return b555.NewProvider()
+}
+
 func Default() []registry.PlaneProvider {
 	return []registry.PlaneProvider{
 		System(),
 		Heating(),
 		DHW(),
 		Solar(),
+		Timer(),
 	}
 }

--- a/vaillant/b555/b555.go
+++ b/vaillant/b555/b555.go
@@ -1,0 +1,98 @@
+package b555
+
+import (
+	"strings"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"github.com/Project-Helianthus/helianthus-ebusreg/router"
+	"github.com/Project-Helianthus/helianthus-ebusreg/schema"
+)
+
+const (
+	methodReadTimerConfig = "read_timer_config"
+	methodReadTimerSlots  = "read_timer_slots"
+	methodReadTimer       = "read_timer"
+	methodWriteTimer      = "write_timer"
+)
+
+// Provider creates B555 timer/schedule planes for Vaillant controllers.
+type Provider struct{}
+
+func NewProvider() Provider {
+	return Provider{}
+}
+
+func (Provider) Name() string {
+	return "vaillant_b555"
+}
+
+func (Provider) Match(info registry.DeviceInfo) bool {
+	manufacturer := strings.TrimSpace(info.Manufacturer)
+	if manufacturer == "" {
+		return false
+	}
+	normalized := strings.ToLower(manufacturer)
+	return strings.Contains(normalized, "vaillant") ||
+		strings.Contains(normalized, "saunier") ||
+		strings.Contains(normalized, "awb")
+}
+
+func (Provider) CreatePlanes(info registry.DeviceInfo) []registry.Plane {
+	return []registry.Plane{
+		newTimerPlane(info),
+	}
+}
+
+type plane struct {
+	name    string
+	address byte
+	methods []registry.Method
+}
+
+func newTimerPlane(info registry.DeviceInfo) *plane {
+	return &plane{
+		name:    "timer",
+		address: info.Address,
+		methods: []registry.Method{
+			method{name: methodReadTimerConfig, readOnly: true, template: configReadTemplate{primary: 0xB5, secondary: 0x55}, response: schema.SchemaSelector{}},
+			method{name: methodReadTimerSlots, readOnly: true, template: slotsReadTemplate{primary: 0xB5, secondary: 0x55}, response: schema.SchemaSelector{}},
+			method{name: methodReadTimer, readOnly: true, template: timerReadTemplate{primary: 0xB5, secondary: 0x55}, response: schema.SchemaSelector{}},
+			method{name: methodWriteTimer, readOnly: false, template: timerWriteTemplate{primary: 0xB5, secondary: 0x55}, response: schema.SchemaSelector{}},
+		},
+	}
+}
+
+func (p *plane) Name() string {
+	return p.name
+}
+
+func (p *plane) Methods() []registry.Method {
+	return p.methods
+}
+
+func (p *plane) Subscriptions() []router.Subscription {
+	return nil
+}
+
+type method struct {
+	name     string
+	readOnly bool
+	template registry.FrameTemplate
+	response schema.SchemaSelector
+}
+
+func (m method) Name() string {
+	return m.name
+}
+
+func (m method) ReadOnly() bool {
+	return m.readOnly
+}
+
+func (m method) Template() registry.FrameTemplate {
+	return m.template
+}
+
+func (m method) ResponseSchema() schema.SchemaSelector {
+	return m.response
+}

--- a/vaillant/b555/b555_test.go
+++ b/vaillant/b555/b555_test.go
@@ -1,0 +1,502 @@
+package b555
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/types"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+func TestProvider_MatchesVaillant(t *testing.T) {
+	p := NewProvider()
+	tests := []struct {
+		manufacturer string
+		match        bool
+	}{
+		{"Vaillant", true},
+		{"vaillant", true},
+		{"VAILLANT", true},
+		{"Saunier Duval", true},
+		{"saunier", true},
+		{"AWB", true},
+		{"awb", true},
+		{"Bosch", false},
+		{"", false},
+		{"  ", false},
+	}
+	for _, tt := range tests {
+		got := p.Match(registry.DeviceInfo{Manufacturer: tt.manufacturer})
+		if got != tt.match {
+			t.Errorf("Match(%q) = %v, want %v", tt.manufacturer, got, tt.match)
+		}
+	}
+}
+
+func TestProvider_CreatesPlanesWithTimerMethods(t *testing.T) {
+	p := NewProvider()
+	planes := p.CreatePlanes(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	if len(planes) != 1 {
+		t.Fatalf("expected 1 plane, got %d", len(planes))
+	}
+	if planes[0].Name() != "timer" {
+		t.Errorf("plane name = %q, want %q", planes[0].Name(), "timer")
+	}
+	methods := planes[0].Methods()
+	if len(methods) != 4 {
+		t.Fatalf("expected 4 methods, got %d", len(methods))
+	}
+
+	wantMethods := []struct {
+		name     string
+		readOnly bool
+	}{
+		{"read_timer_config", true},
+		{"read_timer_slots", true},
+		{"read_timer", true},
+		{"write_timer", false},
+	}
+	for i, want := range wantMethods {
+		if methods[i].Name() != want.name {
+			t.Errorf("method[%d].Name() = %q, want %q", i, methods[i].Name(), want.name)
+		}
+		if methods[i].ReadOnly() != want.readOnly {
+			t.Errorf("method[%d].ReadOnly() = %v, want %v", i, methods[i].ReadOnly(), want.readOnly)
+		}
+	}
+}
+
+// --- Template Build tests ---
+
+func TestConfigReadTemplate_Build(t *testing.T) {
+	tmpl := configReadTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{"zone": 0, "hc": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) != 3 {
+		t.Fatalf("payload len = %d, want 3", len(payload))
+	}
+	if payload[0] != 0xA3 || payload[1] != 0x00 || payload[2] != 0x00 {
+		t.Errorf("payload = %X, want A30000", payload)
+	}
+}
+
+func TestConfigReadTemplate_Build_Zone2DHW(t *testing.T) {
+	tmpl := configReadTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{"zone": 0xFF, "hc": 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload[0] != 0xA3 || payload[1] != 0xFF || payload[2] != 0x02 {
+		t.Errorf("payload = %X, want A3FF02", payload)
+	}
+}
+
+func TestConfigReadTemplate_RejectsHCOver4(t *testing.T) {
+	tmpl := configReadTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{"zone": 0, "hc": 5})
+	if err == nil {
+		t.Fatal("expected error for hc=5")
+	}
+}
+
+func TestSlotsReadTemplate_Build(t *testing.T) {
+	tmpl := slotsReadTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{"zone": 1, "hc": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload[0] != 0xA4 || payload[1] != 0x01 || payload[2] != 0x00 {
+		t.Errorf("payload = %X, want A40100", payload)
+	}
+}
+
+func TestTimerReadTemplate_Build(t *testing.T) {
+	tmpl := timerReadTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{"zone": 0, "hc": 0, "weekday": 6, "slot": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) != 5 {
+		t.Fatalf("payload len = %d, want 5", len(payload))
+	}
+	// A5 00 00 06 00
+	if payload[0] != 0xA5 || payload[1] != 0x00 || payload[2] != 0x00 || payload[3] != 0x06 || payload[4] != 0x00 {
+		t.Errorf("payload = %X, want A500000600", payload)
+	}
+}
+
+func TestTimerReadTemplate_RejectsWeekdayOver6(t *testing.T) {
+	tmpl := timerReadTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{"zone": 0, "hc": 0, "weekday": 7, "slot": 0})
+	if err == nil {
+		t.Fatal("expected error for weekday=7")
+	}
+}
+
+func TestTimerReadTemplate_RejectsMissingParams(t *testing.T) {
+	tmpl := timerReadTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(nil)
+	if err == nil {
+		t.Fatal("expected error for nil params")
+	}
+	_, err = tmpl.Build(map[string]any{"zone": 0, "hc": 0, "weekday": 0})
+	if err == nil {
+		t.Fatal("expected error for missing slot")
+	}
+}
+
+func TestTimerWriteTemplate_Build(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{
+		"zone":         0,
+		"hc":           0,
+		"weekday":      0,
+		"slot":         0,
+		"slot_count":   1,
+		"start_hour":   0,
+		"start_minute": 0,
+		"end_hour":     24,
+		"end_minute":   0,
+		"temperature":  225, // 22.5°C
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) != 12 {
+		t.Fatalf("payload len = %d, want 12", len(payload))
+	}
+	// A6 00 00 00 00 01 00 00 18 00 E1 00
+	expected := []byte{0xA6, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x18, 0x00, 0xE1, 0x00}
+	for i := range expected {
+		if payload[i] != expected[i] {
+			t.Errorf("payload[%d] = 0x%02X, want 0x%02X", i, payload[i], expected[i])
+		}
+	}
+}
+
+func TestTimerWriteTemplate_DHWTemp(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{
+		"zone":         0xFF,
+		"hc":           2,
+		"weekday":      0,
+		"slot":         0,
+		"slot_count":   1,
+		"start_hour":   0,
+		"start_minute": 0,
+		"end_hour":     24,
+		"end_minute":   0,
+		"temperature":  0xFFFF, // no-op sentinel
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Temperature bytes: 0xFF, 0xFF (LE)
+	if payload[10] != 0xFF || payload[11] != 0xFF {
+		t.Errorf("temp bytes = [%02X %02X], want [FF FF]", payload[10], payload[11])
+	}
+}
+
+func TestTimerWriteTemplate_RejectsHourOver24(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{
+		"zone": 0, "hc": 0, "weekday": 0, "slot": 0, "slot_count": 1,
+		"start_hour": 25, "start_minute": 0, "end_hour": 24, "end_minute": 0,
+		"temperature": 225,
+	})
+	if err == nil {
+		t.Fatal("expected error for start_hour=25")
+	}
+}
+
+func TestTimerWriteTemplate_RejectsMinuteOver59(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{
+		"zone": 0, "hc": 0, "weekday": 0, "slot": 0, "slot_count": 1,
+		"start_hour": 0, "start_minute": 60, "end_hour": 24, "end_minute": 0,
+		"temperature": 225,
+	})
+	if err == nil {
+		t.Fatal("expected error for start_minute=60")
+	}
+}
+
+func TestTimerWriteTemplate_RejectsZeroSlotCount(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{
+		"zone": 0, "hc": 0, "weekday": 0, "slot": 0, "slot_count": 0,
+		"start_hour": 0, "start_minute": 0, "end_hour": 24, "end_minute": 0,
+		"temperature": 225,
+	})
+	if err == nil {
+		t.Fatal("expected error for slot_count=0")
+	}
+}
+
+// --- Decode tests ---
+
+func TestDecodeConfigResponse_Z1Heating(t *testing.T) {
+	// Real response from live hardware: status=0, max_slots=12, time_res=10,
+	// min_dur=5, has_temp=1, temp_slots=12, min=5, max=30, pad=0
+	payload := []byte{0x00, 0x0C, 0x0A, 0x05, 0x01, 0x0C, 0x05, 0x1E, 0x00}
+	values := decodeConfigResponse(0x00, 0x00, payload)
+
+	assertValue(t, values, "status", byte(0x00))
+	assertValue(t, values, "available", true)
+	assertValue(t, values, "max_slots", byte(12))
+	assertValue(t, values, "time_resolution", byte(10))
+	assertValue(t, values, "min_duration", byte(5))
+	assertValue(t, values, "has_temperature", true)
+	assertValue(t, values, "temp_slots", byte(12))
+	assertValue(t, values, "min_temp_c", float64(5))
+	assertValue(t, values, "max_temp_c", float64(30))
+}
+
+func TestDecodeConfigResponse_CC(t *testing.T) {
+	// CC: status=0, max_slots=3, time_res=10, min_dur=0, has_temp=0, temp_slots=0, min=FF, max=FF
+	payload := []byte{0x00, 0x03, 0x0A, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00}
+	values := decodeConfigResponse(0x00, 0x03, payload)
+
+	assertValue(t, values, "available", true)
+	assertValue(t, values, "max_slots", byte(3))
+	assertValue(t, values, "has_temperature", false)
+	assertValue(t, values, "temp_slots", byte(0))
+	assertNotValid(t, values, "min_temp_c")
+	assertNotValid(t, values, "max_temp_c")
+}
+
+func TestDecodeConfigResponse_Unavailable(t *testing.T) {
+	// Cooling: status=0x03 (unavailable)
+	payload := []byte{0x03, 0x01, 0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00}
+	values := decodeConfigResponse(0x00, 0x01, payload)
+
+	assertValue(t, values, "status", byte(0x03))
+	assertValue(t, values, "available", false)
+}
+
+func TestDecodeConfigResponse_ShortPayload(t *testing.T) {
+	values := decodeConfigResponse(0x00, 0x00, []byte{0x00, 0x0C})
+	assertNotValid(t, values, "status")
+}
+
+func TestDecodeSlotsResponse_Z1Heating(t *testing.T) {
+	// status=0, all days have 1 slot
+	payload := []byte{0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00}
+	values := decodeSlotsResponse(0x00, 0x00, payload)
+
+	assertValue(t, values, "available", true)
+	slotsVal, ok := values["slots_per_day"]
+	if !ok || !slotsVal.Valid {
+		t.Fatal("slots_per_day missing or invalid")
+	}
+	slots, ok := slotsVal.Value.([]int)
+	if !ok {
+		t.Fatalf("slots_per_day type = %T, want []int", slotsVal.Value)
+	}
+	for i, s := range slots {
+		if s != 1 {
+			t.Errorf("slots_per_day[%d] = %d, want 1", i, s)
+		}
+	}
+}
+
+func TestDecodeTimerReadResponse_Z1HeatingMonday(t *testing.T) {
+	// status=0, 00:00-24:00 @ 22.5°C
+	payload := []byte{0x00, 0x00, 0x00, 0x18, 0x00, 0xE1, 0x00}
+	values := decodeTimerReadResponse(0x00, 0x00, 0x00, 0x00, payload)
+
+	assertValue(t, values, "available", true)
+	assertValue(t, values, "start_hour", byte(0))
+	assertValue(t, values, "start_minute", byte(0))
+	assertValue(t, values, "end_hour", byte(24))
+	assertValue(t, values, "end_minute", byte(0))
+	assertValue(t, values, "temperature_raw", uint16(225))
+	assertValue(t, values, "temperature_c", float64(22.5))
+}
+
+func TestDecodeTimerReadResponse_DHW(t *testing.T) {
+	// DHW: 00:00-24:00 @ 61.0°C (raw=610=0x0262)
+	payload := []byte{0x00, 0x00, 0x00, 0x18, 0x00, 0x62, 0x02}
+	values := decodeTimerReadResponse(0x00, 0x02, 0x00, 0x00, payload)
+
+	assertValue(t, values, "temperature_raw", uint16(610))
+	assertValue(t, values, "temperature_c", float64(61.0))
+}
+
+func TestDecodeTimerReadResponse_CCNoTemp(t *testing.T) {
+	// CC: 00:00-24:00, temp=0xFFFF (no temperature)
+	payload := []byte{0x00, 0x00, 0x00, 0x18, 0x00, 0xFF, 0xFF}
+	values := decodeTimerReadResponse(0x00, 0x03, 0x00, 0x00, payload)
+
+	assertValue(t, values, "temperature_raw", uint16(0xFFFF))
+	assertNotValid(t, values, "temperature_c")
+}
+
+func TestDecodeTimerReadResponse_ShortPayload(t *testing.T) {
+	values := decodeTimerReadResponse(0x00, 0x00, 0x00, 0x00, []byte{0x00})
+	assertNotValid(t, values, "status")
+}
+
+func TestDecodeTimerWriteResponse_ACK(t *testing.T) {
+	values := decodeTimerWriteResponse(0x00, 0x00, 0x00, 0x00, []byte{0x00})
+	assertValue(t, values, "error_code", byte(0x00))
+	assertValue(t, values, "accepted", true)
+}
+
+func TestDecodeTimerWriteResponse_ParamOutOfRange(t *testing.T) {
+	values := decodeTimerWriteResponse(0x00, 0x00, 0x00, 0x00, []byte{0x01})
+	assertValue(t, values, "error_code", byte(0x01))
+	assertValue(t, values, "accepted", false)
+}
+
+func TestDecodeTimerWriteResponse_Unavailable(t *testing.T) {
+	values := decodeTimerWriteResponse(0x00, 0x01, 0x00, 0x00, []byte{0x03})
+	assertValue(t, values, "error_code", byte(0x03))
+	assertValue(t, values, "accepted", false)
+}
+
+func TestDecodeTimerWriteResponse_ValidationFailure(t *testing.T) {
+	values := decodeTimerWriteResponse(0x00, 0x02, 0x00, 0x00, []byte{0x06})
+	assertValue(t, values, "error_code", byte(0x06))
+	assertValue(t, values, "accepted", false)
+}
+
+func TestDecodeTimerWriteResponse_EmptyPayload(t *testing.T) {
+	values := decodeTimerWriteResponse(0x00, 0x00, 0x00, 0x00, nil)
+	assertNotValid(t, values, "error_code")
+	assertValue(t, values, "accepted", false)
+}
+
+// --- Router plane tests ---
+
+func TestBuildRequest_ConfigRead(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	frame, err := pl.BuildRequest(methods[0], map[string]any{
+		"source": 0x71,
+		"zone":   0,
+		"hc":     0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if frame.Source != 0x71 {
+		t.Errorf("Source = 0x%02X, want 0x71", frame.Source)
+	}
+	if frame.Target != 0x15 {
+		t.Errorf("Target = 0x%02X, want 0x15", frame.Target)
+	}
+	if frame.Primary != 0xB5 || frame.Secondary != 0x55 {
+		t.Errorf("PB/SB = %02X/%02X, want B5/55", frame.Primary, frame.Secondary)
+	}
+	if len(frame.Data) != 3 || frame.Data[0] != 0xA3 {
+		t.Errorf("Data = %X, want A3...", frame.Data)
+	}
+}
+
+func TestBuildRequest_TimerWrite(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	frame, err := pl.BuildRequest(methods[3], map[string]any{
+		"source":       0x71,
+		"zone":         0,
+		"hc":           0,
+		"weekday":      0,
+		"slot":         0,
+		"slot_count":   1,
+		"start_hour":   0,
+		"start_minute": 0,
+		"end_hour":     24,
+		"end_minute":   0,
+		"temperature":  225,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frame.Data) != 12 {
+		t.Fatalf("Data len = %d, want 12", len(frame.Data))
+	}
+	if frame.Data[0] != 0xA6 {
+		t.Errorf("opcode = 0x%02X, want 0xA6", frame.Data[0])
+	}
+}
+
+func TestDecodeResponse_ConfigRead(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	result, err := pl.DecodeResponse(methods[0], protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x55,
+		Data:      []byte{0x00, 0x0C, 0x0A, 0x05, 0x01, 0x0C, 0x05, 0x1E, 0x00},
+	}, map[string]any{"zone": 0, "hc": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, ok := result.(map[string]types.Value)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]types.Value", result)
+	}
+	assertValue(t, values, "max_slots", byte(12))
+}
+
+func TestDecodeResponse_TimerRead(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	result, err := pl.DecodeResponse(methods[2], protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x55,
+		Data:      []byte{0x00, 0x00, 0x00, 0x18, 0x00, 0xE1, 0x00},
+	}, map[string]any{"zone": 0, "hc": 0, "weekday": 0, "slot": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, ok := result.(map[string]types.Value)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]types.Value", result)
+	}
+	assertValue(t, values, "temperature_c", float64(22.5))
+}
+
+func TestDecodeResponse_RejectsWrongSecondary(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	_, err := pl.DecodeResponse(methods[0], protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x24, // wrong — B524, not B555
+		Data:      []byte{0x00},
+	}, map[string]any{"zone": 0, "hc": 0})
+	if err == nil {
+		t.Fatal("expected error for wrong secondary byte")
+	}
+}
+
+// --- Helpers ---
+
+func assertValue(t *testing.T, values map[string]types.Value, key string, want any) {
+	t.Helper()
+	v, ok := values[key]
+	if !ok {
+		t.Errorf("key %q missing", key)
+		return
+	}
+	if !v.Valid {
+		t.Errorf("key %q not valid", key)
+		return
+	}
+	if v.Value != want {
+		t.Errorf("key %q = %v (%T), want %v (%T)", key, v.Value, v.Value, want, want)
+	}
+}
+
+func assertNotValid(t *testing.T, values map[string]types.Value, key string) {
+	t.Helper()
+	v, ok := values[key]
+	if !ok {
+		return // missing is acceptable for "not valid"
+	}
+	if v.Valid {
+		t.Errorf("key %q should not be valid, got %v", key, v.Value)
+	}
+}

--- a/vaillant/b555/b555_test.go
+++ b/vaillant/b555/b555_test.go
@@ -459,6 +459,94 @@ func TestDecodeResponse_TimerRead(t *testing.T) {
 	assertValue(t, values, "temperature_c", float64(22.5))
 }
 
+func TestDecodeResponse_SlotsRead(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	result, err := pl.DecodeResponse(methods[1], protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x55,
+		Data:      []byte{0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00},
+	}, map[string]any{"zone": 0, "hc": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, ok := result.(map[string]types.Value)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]types.Value", result)
+	}
+	assertValue(t, values, "available", true)
+}
+
+func TestDecodeResponse_TimerWrite(t *testing.T) {
+	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
+	methods := pl.Methods()
+	result, err := pl.DecodeResponse(methods[3], protocol.Frame{
+		Primary:   0xB5,
+		Secondary: 0x55,
+		Data:      []byte{0x00},
+	}, map[string]any{"zone": 0, "hc": 0, "weekday": 0, "slot": 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, ok := result.(map[string]types.Value)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]types.Value", result)
+	}
+	assertValue(t, values, "accepted", true)
+}
+
+func TestConfigReadTemplate_AcceptsHC4(t *testing.T) {
+	tmpl := configReadTemplate{primary: 0xB5, secondary: 0x55}
+	payload, err := tmpl.Build(map[string]any{"zone": 0, "hc": 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload[2] != 0x04 {
+		t.Errorf("hc = %d, want 4", payload[2])
+	}
+}
+
+func TestTimerWriteTemplate_AcceptsMinute59(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{
+		"zone": 0, "hc": 0, "weekday": 0, "slot": 0, "slot_count": 1,
+		"start_hour": 0, "start_minute": 59, "end_hour": 24, "end_minute": 59,
+		"temperature": 225,
+	})
+	if err != nil {
+		t.Fatalf("expected no error for minute=59, got %v", err)
+	}
+}
+
+func TestTimerWriteTemplate_RejectsEndHourOver24(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{
+		"zone": 0, "hc": 0, "weekday": 0, "slot": 0, "slot_count": 1,
+		"start_hour": 0, "start_minute": 0, "end_hour": 25, "end_minute": 0,
+		"temperature": 225,
+	})
+	if err == nil {
+		t.Fatal("expected error for end_hour=25")
+	}
+}
+
+func TestTimerWriteTemplate_RejectsEndMinuteOver59(t *testing.T) {
+	tmpl := timerWriteTemplate{primary: 0xB5, secondary: 0x55}
+	_, err := tmpl.Build(map[string]any{
+		"zone": 0, "hc": 0, "weekday": 0, "slot": 0, "slot_count": 1,
+		"start_hour": 0, "start_minute": 0, "end_hour": 24, "end_minute": 60,
+		"temperature": 225,
+	})
+	if err == nil {
+		t.Fatal("expected error for end_minute=60")
+	}
+}
+
+func TestDecodeSlotsResponse_ShortPayload(t *testing.T) {
+	values := decodeSlotsResponse(0x00, 0x00, []byte{0x00, 0x01})
+	assertNotValid(t, values, "status")
+}
+
 func TestDecodeResponse_RejectsWrongSecondary(t *testing.T) {
 	pl := newTimerPlane(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant"})
 	methods := pl.Methods()

--- a/vaillant/b555/decode.go
+++ b/vaillant/b555/decode.go
@@ -1,0 +1,152 @@
+package b555
+
+import (
+	"github.com/Project-Helianthus/helianthus-ebusgo/types"
+)
+
+// decodeConfigResponse decodes an A3 CONFIG_READ response (9 bytes).
+//
+// Response format:
+//
+//	[status] [max_slots] [time_res] [min_dur] [has_temp] [temp_slots] [min_temp] [max_temp] [pad]
+func decodeConfigResponse(zone, hc byte, payload []byte) map[string]types.Value {
+	values := map[string]types.Value{
+		"opcode":  {Value: opcodeConfigRead, Valid: true},
+		"zone":    {Value: zone, Valid: true},
+		"hc":      {Value: hc, Valid: true},
+		"payload": {Value: append([]byte(nil), payload...), Valid: true},
+	}
+
+	if len(payload) < 9 {
+		values["status"] = types.Value{Valid: false}
+		return values
+	}
+
+	status := payload[0]
+	values["status"] = types.Value{Value: status, Valid: true}
+	values["max_slots"] = types.Value{Value: payload[1], Valid: true}
+	values["time_resolution"] = types.Value{Value: payload[2], Valid: true}
+	values["min_duration"] = types.Value{Value: payload[3], Valid: true}
+	values["has_temperature"] = types.Value{Value: payload[4] == 0x01, Valid: true}
+	values["temp_slots"] = types.Value{Value: payload[5], Valid: true}
+
+	if payload[6] == 0xFF {
+		values["min_temp_c"] = types.Value{Valid: false}
+	} else {
+		values["min_temp_c"] = types.Value{Value: float64(payload[6]), Valid: true}
+	}
+
+	if payload[7] == 0xFF {
+		values["max_temp_c"] = types.Value{Valid: false}
+	} else {
+		values["max_temp_c"] = types.Value{Value: float64(payload[7]), Valid: true}
+	}
+
+	// status 0x03 = unavailable
+	values["available"] = types.Value{Value: status == 0x00, Valid: true}
+
+	return values
+}
+
+// decodeSlotsResponse decodes an A4 SLOTS_READ response (9 bytes).
+//
+// Response format:
+//
+//	[status] [Mon] [Tue] [Wed] [Thu] [Fri] [Sat] [Sun] [pad]
+func decodeSlotsResponse(zone, hc byte, payload []byte) map[string]types.Value {
+	values := map[string]types.Value{
+		"opcode":  {Value: opcodeSlotsRead, Valid: true},
+		"zone":    {Value: zone, Valid: true},
+		"hc":      {Value: hc, Valid: true},
+		"payload": {Value: append([]byte(nil), payload...), Valid: true},
+	}
+
+	if len(payload) < 9 {
+		values["status"] = types.Value{Valid: false}
+		return values
+	}
+
+	status := payload[0]
+	values["status"] = types.Value{Value: status, Valid: true}
+	values["available"] = types.Value{Value: status == 0x00, Valid: true}
+
+	// Slot counts per weekday: Mon=0x00..Sun=0x06
+	days := make([]int, 7)
+	for i := 0; i < 7; i++ {
+		days[i] = int(payload[1+i])
+	}
+	values["slots_per_day"] = types.Value{Value: days, Valid: true}
+
+	return values
+}
+
+// decodeTimerReadResponse decodes an A5 TIMER_READ response (7 bytes).
+//
+// Response format:
+//
+//	[status] [Sh] [Sm] [Eh] [Em] [Tlo] [Thi]
+func decodeTimerReadResponse(zone, hc, weekday, slot byte, payload []byte) map[string]types.Value {
+	values := map[string]types.Value{
+		"opcode":  {Value: opcodeTimerRead, Valid: true},
+		"zone":    {Value: zone, Valid: true},
+		"hc":      {Value: hc, Valid: true},
+		"weekday": {Value: weekday, Valid: true},
+		"slot":    {Value: slot, Valid: true},
+		"payload": {Value: append([]byte(nil), payload...), Valid: true},
+	}
+
+	if len(payload) < 7 {
+		values["status"] = types.Value{Valid: false}
+		return values
+	}
+
+	status := payload[0]
+	values["status"] = types.Value{Value: status, Valid: true}
+	values["available"] = types.Value{Value: status == 0x00, Valid: true}
+	values["start_hour"] = types.Value{Value: payload[1], Valid: true}
+	values["start_minute"] = types.Value{Value: payload[2], Valid: true}
+	values["end_hour"] = types.Value{Value: payload[3], Valid: true}
+	values["end_minute"] = types.Value{Value: payload[4], Valid: true}
+
+	tempRaw := uint16(payload[5]) | uint16(payload[6])<<8
+	if tempRaw == 0xFFFF {
+		values["temperature_raw"] = types.Value{Value: uint16(0xFFFF), Valid: true}
+		values["temperature_c"] = types.Value{Valid: false}
+	} else {
+		values["temperature_raw"] = types.Value{Value: tempRaw, Valid: true}
+		values["temperature_c"] = types.Value{Value: float64(tempRaw) / 10.0, Valid: true}
+	}
+
+	return values
+}
+
+// decodeTimerWriteResponse decodes an A6 TIMER_WRITE response (1 byte).
+//
+// Response format:
+//
+//	[error_code]
+//
+// Error codes: 0x00=ACK, 0x01=parameter out of range, 0x03=timer unavailable,
+// 0x06=validation failure.
+func decodeTimerWriteResponse(zone, hc, weekday, slot byte, payload []byte) map[string]types.Value {
+	values := map[string]types.Value{
+		"opcode":  {Value: opcodeTimerWrite, Valid: true},
+		"zone":    {Value: zone, Valid: true},
+		"hc":      {Value: hc, Valid: true},
+		"weekday": {Value: weekday, Valid: true},
+		"slot":    {Value: slot, Valid: true},
+		"payload": {Value: append([]byte(nil), payload...), Valid: true},
+	}
+
+	if len(payload) == 0 {
+		values["error_code"] = types.Value{Valid: false}
+		values["accepted"] = types.Value{Value: false, Valid: true}
+		return values
+	}
+
+	errorCode := payload[0]
+	values["error_code"] = types.Value{Value: errorCode, Valid: true}
+	values["accepted"] = types.Value{Value: errorCode == 0x00, Valid: true}
+
+	return values
+}

--- a/vaillant/b555/params.go
+++ b/vaillant/b555/params.go
@@ -1,0 +1,120 @@
+package b555
+
+import (
+	"encoding/json"
+	"math"
+)
+
+func uint8Param(params map[string]any, key string) (byte, bool) {
+	value, ok := params[key]
+	if !ok {
+		return 0, false
+	}
+	return toByte(value)
+}
+
+func toByte(value any) (byte, bool) {
+	parsed, ok := parseUint(value, 0xFF)
+	if !ok {
+		return 0, false
+	}
+	return byte(parsed), true
+}
+
+func uint16Param(params map[string]any, key string) (uint16, bool) {
+	value, ok := params[key]
+	if !ok {
+		return 0, false
+	}
+	parsed, ok := parseUint(value, 0xFFFF)
+	if !ok {
+		return 0, false
+	}
+	return uint16(parsed), true
+}
+
+func parseUint(value any, max uint64) (uint64, bool) {
+	switch typed := value.(type) {
+	case int:
+		if typed < 0 || uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case int8:
+		if typed < 0 || uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case int16:
+		if typed < 0 || uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case int32:
+		if typed < 0 || uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case int64:
+		if typed < 0 || uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case uint:
+		if uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case uint8:
+		if uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case uint16:
+		if uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case uint32:
+		if uint64(typed) > max {
+			return 0, false
+		}
+		return uint64(typed), true
+	case uint64:
+		if typed > max {
+			return 0, false
+		}
+		return typed, true
+	case float32:
+		return parseFloatUint(float64(typed), max)
+	case float64:
+		return parseFloatUint(typed, max)
+	case json.Number:
+		if parsed, err := typed.Int64(); err == nil {
+			if parsed < 0 || uint64(parsed) > max {
+				return 0, false
+			}
+			return uint64(parsed), true
+		}
+		floatParsed, err := typed.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return parseFloatUint(floatParsed, max)
+	default:
+		return 0, false
+	}
+}
+
+func parseFloatUint(value float64, max uint64) (uint64, bool) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, false
+	}
+	if value < 0 || value > float64(max) {
+		return 0, false
+	}
+	if math.Trunc(value) != value {
+		return 0, false
+	}
+	return uint64(value), true
+}

--- a/vaillant/b555/router_plane.go
+++ b/vaillant/b555/router_plane.go
@@ -1,0 +1,138 @@
+package b555
+
+import (
+	"fmt"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+func (p *plane) OnBroadcast(frame protocol.Frame) error {
+	return nil
+}
+
+func (p *plane) BuildRequest(method registry.Method, params map[string]any) (protocol.Frame, error) {
+	if method == nil {
+		return protocol.Frame{}, fmt.Errorf("b555 BuildRequest missing method: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if params == nil {
+		return protocol.Frame{}, fmt.Errorf("b555 BuildRequest missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	source, ok := uint8Param(params, "source")
+	if !ok {
+		return protocol.Frame{}, fmt.Errorf("b555 BuildRequest source: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	target := p.address
+	if target == 0 {
+		targetParam, ok := uint8Param(params, "target")
+		if !ok {
+			return protocol.Frame{}, fmt.Errorf("b555 BuildRequest target: %w", ebuserrors.ErrInvalidPayload)
+		}
+		target = targetParam
+	}
+
+	template := method.Template()
+	if template == nil {
+		return protocol.Frame{}, fmt.Errorf("b555 BuildRequest missing template: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	var payload []byte
+	if builder, ok := template.(interface {
+		Build(params map[string]any) ([]byte, error)
+	}); ok {
+		value, err := builder.Build(params)
+		if err != nil {
+			return protocol.Frame{}, fmt.Errorf("b555 BuildRequest build payload: %w", err)
+		}
+		payload = value
+	}
+
+	return protocol.Frame{
+		Source:    source,
+		Target:    target,
+		Primary:   template.Primary(),
+		Secondary: template.Secondary(),
+		Data:      payload,
+	}, nil
+}
+
+func (p *plane) DecodeResponse(method registry.Method, response protocol.Frame, params map[string]any) (any, error) {
+	if method == nil {
+		return nil, fmt.Errorf("b555 DecodeResponse missing method: %w", ebuserrors.ErrInvalidPayload)
+	}
+	template := method.Template()
+	if template == nil {
+		return nil, fmt.Errorf("b555 DecodeResponse missing template: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if response.Primary != template.Primary() || response.Secondary != template.Secondary() {
+		return nil, fmt.Errorf("b555 DecodeResponse unexpected response type: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	switch method.Name() {
+	case methodReadTimerConfig:
+		zone, ok := uint8Param(params, "zone")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse zone: %w", ebuserrors.ErrInvalidPayload)
+		}
+		hc, ok := uint8Param(params, "hc")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse hc: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeConfigResponse(zone, hc, response.Data), nil
+
+	case methodReadTimerSlots:
+		zone, ok := uint8Param(params, "zone")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse zone: %w", ebuserrors.ErrInvalidPayload)
+		}
+		hc, ok := uint8Param(params, "hc")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse hc: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeSlotsResponse(zone, hc, response.Data), nil
+
+	case methodReadTimer:
+		zone, ok := uint8Param(params, "zone")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse zone: %w", ebuserrors.ErrInvalidPayload)
+		}
+		hc, ok := uint8Param(params, "hc")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse hc: %w", ebuserrors.ErrInvalidPayload)
+		}
+		weekday, ok := uint8Param(params, "weekday")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse weekday: %w", ebuserrors.ErrInvalidPayload)
+		}
+		slot, ok := uint8Param(params, "slot")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse slot: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeTimerReadResponse(zone, hc, weekday, slot, response.Data), nil
+
+	case methodWriteTimer:
+		zone, ok := uint8Param(params, "zone")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse zone: %w", ebuserrors.ErrInvalidPayload)
+		}
+		hc, ok := uint8Param(params, "hc")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse hc: %w", ebuserrors.ErrInvalidPayload)
+		}
+		weekday, ok := uint8Param(params, "weekday")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse weekday: %w", ebuserrors.ErrInvalidPayload)
+		}
+		slot, ok := uint8Param(params, "slot")
+		if !ok {
+			return nil, fmt.Errorf("b555 DecodeResponse slot: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return decodeTimerWriteResponse(zone, hc, weekday, slot, response.Data), nil
+
+	default:
+		return nil, fmt.Errorf("b555 DecodeResponse unknown method %q: %w", method.Name(), ebuserrors.ErrInvalidPayload)
+	}
+}

--- a/vaillant/b555/templates.go
+++ b/vaillant/b555/templates.go
@@ -1,0 +1,198 @@
+package b555
+
+import (
+	"fmt"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+)
+
+const (
+	opcodeConfigRead = byte(0xA3)
+	opcodeSlotsRead  = byte(0xA4)
+	opcodeTimerRead  = byte(0xA5)
+	opcodeTimerWrite = byte(0xA6)
+)
+
+// configReadTemplate builds a B555 CONFIG_READ (A3) request.
+//
+// Wire format: [A3, ZONE, HC]
+type configReadTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (t configReadTemplate) Primary() byte   { return t.primary }
+func (t configReadTemplate) Secondary() byte { return t.secondary }
+
+func (t configReadTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("b555 config read missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+	zone, ok := uint8Param(params, "zone")
+	if !ok {
+		return nil, fmt.Errorf("b555 config read zone: %w", ebuserrors.ErrInvalidPayload)
+	}
+	hc, ok := uint8Param(params, "hc")
+	if !ok {
+		return nil, fmt.Errorf("b555 config read hc: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if hc > 0x04 {
+		return nil, fmt.Errorf("b555 config read hc %d > 4: %w", hc, ebuserrors.ErrInvalidPayload)
+	}
+	return []byte{opcodeConfigRead, zone, hc}, nil
+}
+
+// slotsReadTemplate builds a B555 SLOTS_READ (A4) request.
+//
+// Wire format: [A4, ZONE, HC]
+type slotsReadTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (t slotsReadTemplate) Primary() byte   { return t.primary }
+func (t slotsReadTemplate) Secondary() byte { return t.secondary }
+
+func (t slotsReadTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("b555 slots read missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+	zone, ok := uint8Param(params, "zone")
+	if !ok {
+		return nil, fmt.Errorf("b555 slots read zone: %w", ebuserrors.ErrInvalidPayload)
+	}
+	hc, ok := uint8Param(params, "hc")
+	if !ok {
+		return nil, fmt.Errorf("b555 slots read hc: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if hc > 0x04 {
+		return nil, fmt.Errorf("b555 slots read hc %d > 4: %w", hc, ebuserrors.ErrInvalidPayload)
+	}
+	return []byte{opcodeSlotsRead, zone, hc}, nil
+}
+
+// timerReadTemplate builds a B555 TIMER_READ (A5) request.
+//
+// Wire format: [A5, ZONE, HC, DD, SS]
+type timerReadTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (t timerReadTemplate) Primary() byte   { return t.primary }
+func (t timerReadTemplate) Secondary() byte { return t.secondary }
+
+func (t timerReadTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("b555 timer read missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+	zone, ok := uint8Param(params, "zone")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer read zone: %w", ebuserrors.ErrInvalidPayload)
+	}
+	hc, ok := uint8Param(params, "hc")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer read hc: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if hc > 0x04 {
+		return nil, fmt.Errorf("b555 timer read hc %d > 4: %w", hc, ebuserrors.ErrInvalidPayload)
+	}
+	dd, ok := uint8Param(params, "weekday")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer read weekday: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if dd > 0x06 {
+		return nil, fmt.Errorf("b555 timer read weekday %d > 6: %w", dd, ebuserrors.ErrInvalidPayload)
+	}
+	ss, ok := uint8Param(params, "slot")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer read slot: %w", ebuserrors.ErrInvalidPayload)
+	}
+	return []byte{opcodeTimerRead, zone, hc, dd, ss}, nil
+}
+
+// timerWriteTemplate builds a B555 TIMER_WRITE (A6) request.
+//
+// Wire format: [A6, ZONE, HC, DD, SI, SC, Sh, Sm, Eh, Em, Tlo, Thi]
+type timerWriteTemplate struct {
+	primary   byte
+	secondary byte
+}
+
+func (t timerWriteTemplate) Primary() byte   { return t.primary }
+func (t timerWriteTemplate) Secondary() byte { return t.secondary }
+
+func (t timerWriteTemplate) Build(params map[string]any) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("b555 timer write missing params: %w", ebuserrors.ErrInvalidPayload)
+	}
+	zone, ok := uint8Param(params, "zone")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write zone: %w", ebuserrors.ErrInvalidPayload)
+	}
+	hc, ok := uint8Param(params, "hc")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write hc: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if hc > 0x04 {
+		return nil, fmt.Errorf("b555 timer write hc %d > 4: %w", hc, ebuserrors.ErrInvalidPayload)
+	}
+	dd, ok := uint8Param(params, "weekday")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write weekday: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if dd > 0x06 {
+		return nil, fmt.Errorf("b555 timer write weekday %d > 6: %w", dd, ebuserrors.ErrInvalidPayload)
+	}
+	si, ok := uint8Param(params, "slot")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write slot: %w", ebuserrors.ErrInvalidPayload)
+	}
+	sc, ok := uint8Param(params, "slot_count")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write slot_count: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if sc == 0 {
+		return nil, fmt.Errorf("b555 timer write slot_count must be > 0: %w", ebuserrors.ErrInvalidPayload)
+	}
+	startHour, ok := uint8Param(params, "start_hour")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write start_hour: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if startHour > 24 {
+		return nil, fmt.Errorf("b555 timer write start_hour %d > 24: %w", startHour, ebuserrors.ErrInvalidPayload)
+	}
+	startMinute, ok := uint8Param(params, "start_minute")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write start_minute: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if startMinute > 59 {
+		return nil, fmt.Errorf("b555 timer write start_minute %d > 59: %w", startMinute, ebuserrors.ErrInvalidPayload)
+	}
+	endHour, ok := uint8Param(params, "end_hour")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write end_hour: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if endHour > 24 {
+		return nil, fmt.Errorf("b555 timer write end_hour %d > 24: %w", endHour, ebuserrors.ErrInvalidPayload)
+	}
+	endMinute, ok := uint8Param(params, "end_minute")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write end_minute: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if endMinute > 59 {
+		return nil, fmt.Errorf("b555 timer write end_minute %d > 59: %w", endMinute, ebuserrors.ErrInvalidPayload)
+	}
+	temp, ok := uint16Param(params, "temperature")
+	if !ok {
+		return nil, fmt.Errorf("b555 timer write temperature: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	return []byte{
+		opcodeTimerWrite,
+		zone, hc, dd, si, sc,
+		startHour, startMinute,
+		endHour, endMinute,
+		byte(temp), byte(temp >> 8),
+	}, nil
+}


### PR DESCRIPTION
## Summary
- New `vaillant/b555/` plane provider for B555 timer protocol (PB=0xB5, SB=0x55)
- 4 methods: `read_timer_config` (A3), `read_timer_slots` (A4), `read_timer` (A5), `write_timer` (A6)
- Full router.Plane implementation (BuildRequest, DecodeResponse)
- Registered in `providers/vaillant/providers.go` as `Timer()`

## Test plan
- 33 tests: template encoding, response decoding, validation, router integration
- All tests pass with `-race`
- Lint: 0 issues
- Build: clean

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)