### PR TITLE
Surface router broadcast overflow for GW-02

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -3,6 +3,8 @@ package router
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"expvar"
 	"fmt"
 	"strings"
 	"sync"
@@ -18,6 +20,10 @@ type Subscription struct {
 	Primary   byte
 	Secondary byte
 }
+
+var ErrBroadcastEventOverflow = errors.New("router broadcast event queue full")
+
+var routerBroadcastEventOverflowTotal = expvar.NewInt("router_broadcast_event_overflow_total")
 
 type BroadcastEvent struct {
 	Plane  string
@@ -147,10 +153,10 @@ func (router *BusEventRouter) HandleBroadcast(frame protocol.Frame) []error {
 		return nil
 	}
 
-	errors := make([]error, 0)
+	errs := make([]error, 0)
 	for _, plane := range planes {
 		if err := plane.OnBroadcast(frame); err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		}
 
 		decoder, ok := plane.(BroadcastDecoder)
@@ -159,7 +165,7 @@ func (router *BusEventRouter) HandleBroadcast(frame protocol.Frame) []error {
 		}
 		decoded, handled, err := decoder.DecodeBroadcast(frame)
 		if err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 			continue
 		}
 		if !handled {
@@ -174,9 +180,11 @@ func (router *BusEventRouter) HandleBroadcast(frame protocol.Frame) []error {
 		select {
 		case router.events <- event:
 		default:
+			routerBroadcastEventOverflowTotal.Add(1)
+			errs = append(errs, fmt.Errorf("router.HandleBroadcast plane=%s: %w", plane.Name(), ErrBroadcastEventOverflow))
 		}
 	}
-	return errors
+	return errs
 }
 
 func (router *BusEventRouter) Invoke(ctx context.Context, plane Plane, methodName string, params map[string]any) (any, error) {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -291,6 +291,96 @@ func TestBusEventRouter_EmitsDecodedBroadcastEvents(t *testing.T) {
 	}
 }
 
+func TestBusEventRouter_SurfacesBroadcastEventOverflow(t *testing.T) {
+	t.Parallel()
+
+	before := routerBroadcastEventOverflowTotal.Value()
+	router := NewBusEventRouter(&mockBus{})
+	plane := &decodingPlane{
+		mockPlane: &mockPlane{
+			name: "A",
+			subscriptions: []Subscription{
+				{Primary: 0xB5, Secondary: 0x16},
+			},
+		},
+		decoded: map[string]types.Value{
+			"foo": {Value: uint8(1), Valid: true},
+		},
+		handled: true,
+	}
+	router.SetPlanes([]Plane{plane})
+
+	for i := 0; i < cap(router.events); i++ {
+		router.events <- BroadcastEvent{Plane: "seed"}
+	}
+
+	errs := router.HandleBroadcast(protocol.Frame{Primary: 0xB5, Secondary: 0x16})
+	if len(errs) != 1 {
+		t.Fatalf("errors = %d; want 1", len(errs))
+	}
+	if !errors.Is(errs[0], ErrBroadcastEventOverflow) {
+		t.Fatalf("error = %v; want ErrBroadcastEventOverflow", errs[0])
+	}
+	if plane.broadcastCalls != 1 {
+		t.Fatalf("broadcast calls = %d; want 1", plane.broadcastCalls)
+	}
+	if got := routerBroadcastEventOverflowTotal.Value(); got != before+1 {
+		t.Fatalf("routerBroadcastEventOverflowTotal = %d; want %d", got, before+1)
+	}
+}
+
+func TestBusEventRouter_SurfacesBroadcastEventOverflowPerPlane(t *testing.T) {
+	t.Parallel()
+
+	before := routerBroadcastEventOverflowTotal.Value()
+	router := NewBusEventRouter(&mockBus{})
+	planeA := &decodingPlane{
+		mockPlane: &mockPlane{
+			name: "A",
+			subscriptions: []Subscription{
+				{Primary: 0xB5, Secondary: 0x16},
+			},
+		},
+		decoded: map[string]types.Value{
+			"foo": {Value: uint8(1), Valid: true},
+		},
+		handled: true,
+	}
+	planeB := &decodingPlane{
+		mockPlane: &mockPlane{
+			name: "B",
+			subscriptions: []Subscription{
+				{Primary: 0xB5, Secondary: 0x16},
+			},
+		},
+		decoded: map[string]types.Value{
+			"bar": {Value: uint8(2), Valid: true},
+		},
+		handled: true,
+	}
+	router.SetPlanes([]Plane{planeA, planeB})
+
+	for i := 0; i < cap(router.events); i++ {
+		router.events <- BroadcastEvent{Plane: "seed"}
+	}
+
+	errs := router.HandleBroadcast(protocol.Frame{Primary: 0xB5, Secondary: 0x16})
+	if len(errs) != 2 {
+		t.Fatalf("errors = %d; want 2", len(errs))
+	}
+	for _, err := range errs {
+		if !errors.Is(err, ErrBroadcastEventOverflow) {
+			t.Fatalf("error = %v; want ErrBroadcastEventOverflow", err)
+		}
+	}
+	if planeA.broadcastCalls != 1 || planeB.broadcastCalls != 1 {
+		t.Fatalf("broadcast calls = (%d, %d); want (1, 1)", planeA.broadcastCalls, planeB.broadcastCalls)
+	}
+	if got := routerBroadcastEventOverflowTotal.Value(); got != before+2 {
+		t.Fatalf("routerBroadcastEventOverflowTotal = %d; want %d", got, before+2)
+	}
+}
+
 func TestBusEventRouter_InvokeCoalescesConcurrentReadOnlyCalls(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
Surface `BusEventRouter` broadcast queue overflow instead of silently dropping decoded broadcast events.

## Why
`GW-02` requires correctness-critical broadcast downstream delivery to stop failing silently. The router must emit an explicit error and observability signal when its event queue is full so the gateway can degrade explicitly instead of losing passive-side evidence.

## Acceptance Criteria
- [x] `HandleBroadcast` returns a wrapped sentinel when the broadcast event queue is full.
- [x] Overflow increments an expvar counter for observability.
- [x] Tests cover single-plane and multi-plane overflow behavior.
- [x] Unit tests cover the implemented code.
- [x] CI green.
- [ ] Smoke test required: NO

## Validation
- `gofmt -w router/router.go router/router_test.go`
- `go test ./... -count=1`

## Dependencies
- Part of `GW-02`; gateway follow-up will pin this commit and surface degraded behavior.
- Closes #111