### PR TITLE
Fix router overflow test parallelism

### DIFF
--- a/router/router_test.go
+++ b/router/router_test.go
@@ -292,8 +292,6 @@ func TestBusEventRouter_EmitsDecodedBroadcastEvents(t *testing.T) {
 }
 
 func TestBusEventRouter_SurfacesBroadcastEventOverflow(t *testing.T) {
-	t.Parallel()
-
 	before := routerBroadcastEventOverflowTotal.Value()
 	router := NewBusEventRouter(&mockBus{})
 	plane := &decodingPlane{
@@ -330,8 +328,6 @@ func TestBusEventRouter_SurfacesBroadcastEventOverflow(t *testing.T) {
 }
 
 func TestBusEventRouter_SurfacesBroadcastEventOverflowPerPlane(t *testing.T) {
-	t.Parallel()
-
 	before := routerBroadcastEventOverflowTotal.Value()
 	router := NewBusEventRouter(&mockBus{})
 	planeA := &decodingPlane{

--- a/vaillant/system/b524_profile_test.go
+++ b/vaillant/system/b524_profile_test.go
@@ -43,11 +43,11 @@ func TestB524Profile_RegistersDualNamespaceEntries(t *testing.T) {
 	t.Parallel()
 
 	type dualEntry struct {
-		group                byte
-		localInstanceMax     byte
-		localRegisterMax     uint16
-		remoteInstanceMax    byte
-		remoteRegisterMax    uint16
+		group             byte
+		localInstanceMax  byte
+		localRegisterMax  uint16
+		remoteInstanceMax byte
+		remoteRegisterMax uint16
 	}
 
 	dualGroups := []dualEntry{


### PR DESCRIPTION
## What
Remove `t.Parallel()` from the broadcast overflow tests that assert package-global expvar deltas.

## Why
Codex review on #112 correctly identified that `routerBroadcastEventOverflowTotal` is shared process-wide, so the before/after assertions become nondeterministic when those tests run in parallel with the rest of the package.

## Acceptance Criteria
- [x] Overflow tests that assert `routerBroadcastEventOverflowTotal` no longer run in parallel against other package tests
- [x] Existing overflow behavior assertions remain intact
- [x] Unit tests cover the implemented code
- [x] CI green
- [x] Smoke test required: NO

## Dependencies
- Depends on #113
