### PR TITLE
fix: accept mixed Vaillant scanid chunk layouts

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -207,7 +207,7 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 		ctx = context.Background()
 	}
 
-	raw := make([]byte, 0, 32)
+	chunks := make([][]byte, 0, 4)
 	for qq := byte(0x24); qq <= byte(0x27); qq++ {
 		request := protocol.Frame{
 			Source:    source,
@@ -232,13 +232,37 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 		if response == nil {
 			return "", false, nil
 		}
-		if len(response.Data) != 9 || response.Data[0] != 0x00 {
+		if len(response.Data) == 0 {
 			return "", false, nil
 		}
-		raw = append(raw, response.Data[1:]...)
+		chunks = append(chunks, append([]byte(nil), response.Data...))
 	}
 
-	trimmed := trimScanIDBytes(raw)
+	statusRaw := make([]byte, 0, 32)
+	statusOK := true
+	for _, chunk := range chunks {
+		if len(chunk) != 9 || chunk[0] != 0x00 {
+			statusOK = false
+			break
+		}
+		statusRaw = append(statusRaw, chunk[1:]...)
+	}
+	if statusOK {
+		trimmed := trimScanIDBytes(statusRaw)
+		if len(trimmed) > 0 {
+			formatted := formatVaillantSerial(string(trimmed))
+			if formatted != "" {
+				return formatted, true, nil
+			}
+		}
+	}
+
+	fullRaw := make([]byte, 0, 36)
+	for _, chunk := range chunks {
+		fullRaw = append(fullRaw, chunk...)
+	}
+
+	trimmed := trimScanIDBytes(fullRaw)
 	if len(trimmed) == 0 {
 		return "", false, nil
 	}
@@ -251,8 +275,18 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 }
 
 func trimScanIDBytes(data []byte) []byte {
+	start := 0
+	for start < len(data) {
+		first := data[start]
+		if first == 0x00 || first == 0x20 || first == 0xFF {
+			start++
+			continue
+		}
+		break
+	}
+
 	end := len(data)
-	for end > 0 {
+	for end > start {
 		last := data[end-1]
 		if last == 0x00 || last == 0x20 || last == 0xFF {
 			end--
@@ -260,7 +294,7 @@ func trimScanIDBytes(data []byte) []byte {
 		}
 		break
 	}
-	return data[:end]
+	return data[start:end]
 }
 
 func formatVaillantSerial(raw string) string {

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -213,6 +213,57 @@ func (bus *vaillantScanIDBus) Send(ctx context.Context, frame protocol.Frame) (*
 	return nil, ebuserrors.ErrNoSuchDevice
 }
 
+type vaillantScanIDMixedChunkBus struct {
+	calls []protocol.Frame
+}
+
+func (bus *vaillantScanIDMixedChunkBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	bus.calls = append(bus.calls, frame)
+
+	if frame.Primary == scanPrimary && frame.Secondary == scanSecondary {
+		if frame.Target != 0x08 {
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+		return &protocol.Frame{
+			Source:    0x08,
+			Target:    frame.Source,
+			Primary:   scanPrimary,
+			Secondary: scanSecondary,
+			Data:      []byte{0xB5, 'B', 'A', 'I', '0', '0', 0x12, 0x01, 0x76, 0x03},
+		}, nil
+	}
+
+	if frame.Primary == vaillantPrimary && frame.Secondary == vaillantScanIDSecondary {
+		if frame.Target != 0x08 || len(frame.Data) != 1 {
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+
+		var chunk []byte
+		switch frame.Data[0] {
+		case 0x24:
+			chunk = []byte{0x00, '2', '1', '2', '2', '0', '1', '0', '0'}
+		case 0x25:
+			chunk = []byte{'1', '0', '0', '2', '4', '6', '0', '4', '0'}
+		case 0x26:
+			chunk = []byte{'0', '0', '1', '0', '0', '5', '0', '3', '4'}
+		case 0x27:
+			chunk = []byte{'N', '9', '<', '<', '<', '<', '<', '<', '<'}
+		default:
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+
+		return &protocol.Frame{
+			Source:    frame.Target,
+			Target:    frame.Source,
+			Primary:   vaillantPrimary,
+			Secondary: vaillantScanIDSecondary,
+			Data:      chunk,
+		}, nil
+	}
+
+	return nil, ebuserrors.ErrNoSuchDevice
+}
+
 type vaillantScanIDCanceledBus struct {
 	calls []protocol.Frame
 }
@@ -290,6 +341,33 @@ func TestScanUsesDiscoveredAddressForVaillantScanID(t *testing.T) {
 		t.Fatalf("expected device 0x30 to be registered")
 	}
 	if entry.SerialNumber() != "21-22-09-0020184848-0082-005409-N4" {
+		t.Fatalf("unexpected serial number: %q", entry.SerialNumber())
+	}
+
+	if len(bus.calls) != 5 {
+		t.Fatalf("expected 5 calls (scan + 4 scan.id), got %d", len(bus.calls))
+	}
+}
+
+func TestScanUsesFallbackChunkLayoutForVaillantScanID(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &vaillantScanIDMixedChunkBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x71, []byte{0x08})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entry, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected device 0x08 to be registered")
+	}
+	if entry.SerialNumber() != "21-22-01-0010024604-0001-005034-N9" {
 		t.Fatalf("unexpected serial number: %q", entry.SerialNumber())
 	}
 


### PR DESCRIPTION
## What
Relax Vaillant `ScanID` parsing in the shared registry layer so it accepts mixed chunk layouts, not only all-chunks-with-status-byte responses.

## Why
Live verification on the boiler at `0x08` showed that manual explorer `ScanID` reads succeed, but startup enrichment through `registry.ReadVaillantScanID` fails. The difference is that explorer already supports a fallback path when some chunks arrive as raw 9-byte serial payloads instead of `0x00 + 8 bytes`. The shared registry parser was stricter and rejected those responses, so the boiler serial never propagated into the registry during startup.

## Impact
Both direct `Scan()` identity enrichment and gateway startup enrichment can now parse the boiler's real `ScanID` response shape and recover `21-22-01-0010024604-0001-005034-N9`.

## Validation
- `go test ./registry -run 'TestScanUsesDiscoveredAddressForVaillantScanID|TestScanUsesFallbackChunkLayoutForVaillantScanID|TestFormatVaillantSerial'`
- `go test ./...`
