### PR TITLE
fix: normalize mixed Vaillant scanid fallback chunks

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -259,7 +259,7 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 
 	fullRaw := make([]byte, 0, 36)
 	for _, chunk := range chunks {
-		fullRaw = append(fullRaw, chunk...)
+		fullRaw = append(fullRaw, normalizeScanIDChunk(chunk)...)
 	}
 
 	trimmed := trimScanIDBytes(fullRaw)
@@ -272,6 +272,13 @@ func readVaillantScanID(ctx context.Context, bus ScanBus, source byte, target by
 		return "", false, nil
 	}
 	return formatted, true, nil
+}
+
+func normalizeScanIDChunk(chunk []byte) []byte {
+	if len(chunk) == 9 && chunk[0] == 0x00 {
+		return chunk[1:]
+	}
+	return chunk
 }
 
 func trimScanIDBytes(data []byte) []byte {

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -264,6 +264,57 @@ func (bus *vaillantScanIDMixedChunkBus) Send(ctx context.Context, frame protocol
 	return nil, ebuserrors.ErrNoSuchDevice
 }
 
+type vaillantScanIDInterleavedChunkBus struct {
+	calls []protocol.Frame
+}
+
+func (bus *vaillantScanIDInterleavedChunkBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	bus.calls = append(bus.calls, frame)
+
+	if frame.Primary == scanPrimary && frame.Secondary == scanSecondary {
+		if frame.Target != 0x08 {
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+		return &protocol.Frame{
+			Source:    0x08,
+			Target:    frame.Source,
+			Primary:   scanPrimary,
+			Secondary: scanSecondary,
+			Data:      []byte{0xB5, 'B', 'A', 'I', '0', '0', 0x12, 0x01, 0x76, 0x03},
+		}, nil
+	}
+
+	if frame.Primary == vaillantPrimary && frame.Secondary == vaillantScanIDSecondary {
+		if frame.Target != 0x08 || len(frame.Data) != 1 {
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+
+		var chunk []byte
+		switch frame.Data[0] {
+		case 0x24:
+			chunk = []byte{'2', '1', '2', '2', '0', '1', '0', '0', '1'}
+		case 0x25:
+			chunk = []byte{0x00, '0', '0', '2', '4', '6', '0', '4', '0'}
+		case 0x26:
+			chunk = []byte{0x00, '0', '0', '1', '0', '0', '5', '0', '3'}
+		case 0x27:
+			chunk = []byte{0x00, '4', 'N', '9', '<', '<', '<', '<', '<'}
+		default:
+			return nil, ebuserrors.ErrNoSuchDevice
+		}
+
+		return &protocol.Frame{
+			Source:    frame.Target,
+			Target:    frame.Source,
+			Primary:   vaillantPrimary,
+			Secondary: vaillantScanIDSecondary,
+			Data:      chunk,
+		}, nil
+	}
+
+	return nil, ebuserrors.ErrNoSuchDevice
+}
+
 type vaillantScanIDCanceledBus struct {
 	calls []protocol.Frame
 }
@@ -354,6 +405,33 @@ func TestScanUsesFallbackChunkLayoutForVaillantScanID(t *testing.T) {
 
 	registry := NewDeviceRegistry(nil)
 	bus := &vaillantScanIDMixedChunkBus{}
+
+	entries, err := Scan(context.Background(), bus, registry, 0x71, []byte{0x08})
+	if err != nil {
+		t.Fatalf("Scan error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entry, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected device 0x08 to be registered")
+	}
+	if entry.SerialNumber() != "21-22-01-0010024604-0001-005034-N9" {
+		t.Fatalf("unexpected serial number: %q", entry.SerialNumber())
+	}
+
+	if len(bus.calls) != 5 {
+		t.Fatalf("expected 5 calls (scan + 4 scan.id), got %d", len(bus.calls))
+	}
+}
+
+func TestScanNormalizesStatusPrefixedChunksInFallbackLayout(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	bus := &vaillantScanIDInterleavedChunkBus{}
 
 	entries, err := Scan(context.Background(), bus, registry, 0x71, []byte{0x08})
 	if err != nil {


### PR DESCRIPTION
## What
Normalize each `ScanID` fallback chunk before concatenation in `registry.ReadVaillantScanID`, and add regression coverage for interleaved raw/status-prefixed chunk layouts.

## Why
The previous fix accepted mixed chunk layouts only if the fallback payload was normalized at the ends. A review correctly pointed out that if an interior chunk still arrived as `0x00 + 8 bytes`, that status byte stayed in the middle of the assembled payload, causing `formatVaillantSerial` to fall back to the raw blob while `ReadVaillantScanID` still returned `ok=true`.

## Impact
The shared parser now handles truly interleaved raw and status-prefixed `ScanID` chunks, so boiler serial recovery stays stable even when chunk layouts vary across `0x24..0x27`.

## Validation
- `go test ./registry -run 'TestScanUsesFallbackChunkLayoutForVaillantScanID|TestScanNormalizesStatusPrefixedChunksInFallbackLayout|TestScanUsesDiscoveredAddressForVaillantScanID'`
- `go test ./...`
