### PR TITLE
fix: deduplicate devices by serial number across different DeviceIDs

### DIFF
--- a/registry/identity.go
+++ b/registry/identity.go
@@ -23,14 +23,13 @@ func canonicalPhysicalIdentity(info DeviceInfo) physicalIdentity {
 }
 
 func (identity physicalIdentity) key() string {
-	if identity.manufacturer == "" || identity.deviceID == "" {
+	if identity.manufacturer == "" {
 		return identity.withFallbackModelSignature()
 	}
 	if identity.serialNumber != "" {
 		return strings.Join([]string{
 			"sn",
 			identity.manufacturer,
-			identity.deviceID,
 			identity.serialNumber,
 		}, "|")
 	}
@@ -38,7 +37,6 @@ func (identity physicalIdentity) key() string {
 		return strings.Join([]string{
 			"mac",
 			identity.manufacturer,
-			identity.deviceID,
 			identity.macAddress,
 		}, "|")
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -91,7 +91,6 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 
 	existingByAddress := r.entries[info.Address]
 	if identityKey == "" && existingByAddress != nil {
-		physical = existingByAddress.physical
 		identityKey = existingByAddress.identityKey
 	}
 
@@ -131,7 +130,8 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	if storedInfo.Manufacturer == "" {
 		storedInfo.Manufacturer = entry.info.Manufacturer
 	}
-	if existingByIdentity != nil && entry.info.DeviceID != "" && storedInfo.DeviceID != entry.info.DeviceID {
+	preserveExistingDeviceID := existingByIdentity != nil && existingByIdentity != existingByAddress
+	if preserveExistingDeviceID && entry.info.DeviceID != "" && storedInfo.DeviceID != entry.info.DeviceID {
 		storedInfo.DeviceID = entry.info.DeviceID
 	} else if storedInfo.DeviceID == "" {
 		storedInfo.DeviceID = entry.info.DeviceID

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -90,6 +90,10 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	matched := make([]PlaneProvider, 0, len(r.providers))
 
 	existingByAddress := r.entries[info.Address]
+	incomingHasStableIdentity := normalizeIdentityPart(info.SerialNumber) != "" || normalizeIdentityPart(info.MacAddress) != ""
+	if !incomingHasStableIdentity && existingByAddress != nil && len(existingByAddress.addresses) > 1 && existingByAddress.identityKey != "" {
+		identityKey = existingByAddress.identityKey
+	}
 	if identityKey == "" && existingByAddress != nil {
 		identityKey = existingByAddress.identityKey
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -131,7 +131,9 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	if storedInfo.Manufacturer == "" {
 		storedInfo.Manufacturer = entry.info.Manufacturer
 	}
-	if storedInfo.DeviceID == "" {
+	if existingByIdentity != nil && entry.info.DeviceID != "" && storedInfo.DeviceID != entry.info.DeviceID {
+		storedInfo.DeviceID = entry.info.DeviceID
+	} else if storedInfo.DeviceID == "" {
 		storedInfo.DeviceID = entry.info.DeviceID
 	}
 	if storedInfo.SoftwareVersion == "" {
@@ -147,7 +149,9 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 		storedInfo.MacAddress = entry.info.MacAddress
 	}
 	storedInfo.Address = entry.primaryAddress
-	if info.SerialNumber == "" && info.MacAddress == "" && entry.identityKey != "" {
+	physical = canonicalPhysicalIdentity(storedInfo)
+	identityKey = physical.key()
+	if identityKey == "" && entry.identityKey != "" {
 		identityKey = entry.identityKey
 	}
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -446,6 +446,82 @@ func TestDeviceRegistry_SplitsAliasWhenConflictingSerialArrives(t *testing.T) {
 	}
 }
 
+func TestDeviceRegistry_MergesSameSerialDifferentDeviceID(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+
+	// Step 1-2: scan discovers two addresses with different DeviceIDs
+	registry.Register(DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0xEC,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "SOL00",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+	})
+
+	// Before enrichment: separate entries
+	entry15, _ := registry.Lookup(0x15)
+	entryEC, _ := registry.Lookup(0xEC)
+	if entry15 == entryEC {
+		t.Fatalf("expected separate entries before serial enrichment")
+	}
+
+	// Step 3-4: enrichment discovers same serial on both
+	registry.Register(DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+		SerialNumber:    "21-22-09-0020184848-0082-005409-N4",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0xEC,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "SOL00",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+		SerialNumber:    "21-22-09-0020184848-0082-005409-N4",
+	})
+
+	// After enrichment: merged into single entry
+	entry15, ok := registry.Lookup(0x15)
+	if !ok {
+		t.Fatalf("expected address 0x15 to exist")
+	}
+	entryEC, ok = registry.Lookup(0xEC)
+	if !ok {
+		t.Fatalf("expected address 0xEC to exist")
+	}
+	if entry15 != entryEC {
+		t.Fatalf("same serial number must merge entries regardless of DeviceID")
+	}
+	if entry15.DeviceID() != "BASV2" {
+		t.Fatalf("merged DeviceID = %q; want BASV2 (primary)", entry15.DeviceID())
+	}
+	if !slices.Equal(entry15.Addresses(), []byte{0x15, 0xEC}) {
+		t.Fatalf("merged addresses = %v; want [21 236]", entry15.Addresses())
+	}
+
+	// Iterate should return single canonical entry
+	var count int
+	registry.Iterate(func(entry DeviceEntry) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("iterate count = %d; want 1 (merged)", count)
+	}
+}
+
 func TestDeviceRegistry_PreservesKnownIdentityOnSparseUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -522,6 +522,36 @@ func TestDeviceRegistry_MergesSameSerialDifferentDeviceID(t *testing.T) {
 	}
 }
 
+func TestDeviceRegistry_UpdatesDeviceIDOnSerialSelfUpdate(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "OLD30",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+		SerialNumber:    "SN-CORRECTED",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "DEV30",
+		SoftwareVersion: "0514",
+		HardwareVersion: "1204",
+		SerialNumber:    "SN-CORRECTED",
+	})
+
+	entry, ok := registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("expected address 0x08 to exist")
+	}
+	if entry.DeviceID() != "DEV30" {
+		t.Fatalf("device id = %q; want DEV30", entry.DeviceID())
+	}
+}
+
 func TestDeviceRegistry_PreservesKnownIdentityOnSparseUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -522,6 +522,55 @@ func TestDeviceRegistry_MergesSameSerialDifferentDeviceID(t *testing.T) {
 	}
 }
 
+func TestDeviceRegistry_KeepsSerialAliasMergeOnSparseSecondaryUpdate(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceRegistry(nil)
+	serial := "21-22-09-0020184848-0082-005409-N4"
+
+	registry.Register(DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+		SerialNumber:    serial,
+	})
+	registry.Register(DeviceInfo{
+		Address:         0xEC,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "SOL00",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+		SerialNumber:    serial,
+	})
+	registry.Register(DeviceInfo{
+		Address:         0xEC,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "SOL00",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+	})
+
+	entry15, ok := registry.Lookup(0x15)
+	if !ok {
+		t.Fatalf("expected address 0x15 to exist")
+	}
+	entryEC, ok := registry.Lookup(0xEC)
+	if !ok {
+		t.Fatalf("expected address 0xEC to exist")
+	}
+	if entry15 != entryEC {
+		t.Fatalf("sparse secondary update must not split serial-merged aliases")
+	}
+	if entry15.SerialNumber() != serial {
+		t.Fatalf("serial = %q; want preserved serial", entry15.SerialNumber())
+	}
+	if !slices.Equal(entry15.Addresses(), []byte{0x15, 0xEC}) {
+		t.Fatalf("merged addresses = %v; want [21 236]", entry15.Addresses())
+	}
+}
+
 func TestDeviceRegistry_UpdatesDeviceIDOnSerialSelfUpdate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Remove `DeviceID` from serial-based and MAC-based identity keys in `identity.go` — the serial number alone (with manufacturer) uniquely identifies a physical device
- Preserve primary entry's DeviceID when merging via serial identity in `registry.go`
- Recompute physical identity and key from merged state for consistency

## Context

SOL00 (0xEC) and BASV2 (0x15) are the same physical VRC700 regulator — identical SW/HW and serial number. The registry treated them as separate devices because the identity key included DeviceID: `"sn|VAILLANT|BASV2|SN"` vs `"sn|VAILLANT|SOL00|SN"`. Now the key is `"sn|VAILLANT|SN"`, allowing automatic merge during enrichment.

## Test plan

- [x] `go test ./...` in helianthus-ebusreg — all pass
- [x] `go test ./...` in helianthus-ebusgateway — no regressions
- [x] New test `TestDeviceRegistry_MergesSameSerialDifferentDeviceID` validates full SOL00/BASV2 flow
- [ ] Deploy gateway, verify SOL00 and BASV2 merge into single entry with addresses [0x15, 0xEC]

🤖 Generated with [Claude Code](https://claude.com/claude-code)