### PR TITLE
fix(registry): add 100ms pacing between scan probes

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -29,6 +29,11 @@ type ScanBus interface {
 
 const scanCollisionMaxPasses = 3
 
+// scanProbeDelay is the pause between scan probes. The eBUS supports ~10
+// frames/second; 100 ms per probe uses ~10 % of bus capacity for scanning
+// while leaving 90 % for semantic B524 polling traffic.
+const scanProbeDelay = 100 * time.Millisecond
+
 // Scan performs a 07 04 identification scan over the provided targets.
 func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byte, targets []byte) ([]DeviceEntry, error) {
 	if bus == nil {
@@ -140,6 +145,13 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 			if _, ok := registered[canonicalAddress]; !ok {
 				registered[canonicalAddress] = struct{}{}
 				entries = append(entries, entry)
+			}
+
+			// Pace scan probes to avoid monopolising the bus.runLoop queue.
+			select {
+			case <-time.After(scanProbeDelay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Add `scanProbeDelay` (100ms) between each probe in the scan inner loop
- Prevents scan from monopolizing the `bus.runLoop` queue and blocking B524 semantic polling
- eBUS supports ~10 fps; 100ms pacing uses ~10% of bus capacity for scanning, leaving 90% for semantic traffic
- Pacing respects context cancellation (returns immediately on `ctx.Done()`)

## Test plan

- [x] `go test ./...` passes locally (all 11 packages)
- [ ] CI green
- [ ] Deploy to RPi4, verify scan still discovers all devices but with interleaved B524 traffic
- [ ] Stress test: 50 concurrent MCP requests during scan