### PR TITLE
M2_CATALOG: ebus_standard catalog schema + 14-tuple identity key + collision detection (meta #14)

### DIFF
--- a/catalog/ebus_standard/catalog.go
+++ b/catalog/ebus_standard/catalog.go
@@ -36,11 +36,29 @@ type Command struct {
 }
 
 // Service groups commands by primary-byte service code.
+//
+// PB is pointer-typed so the YAML loader can distinguish an absent key
+// (nil → ErrServiceMissingPB) from an explicit zero value (e.g. `pb: 0x00`
+// is legitimate and must be accepted). This parallels the treatment of
+// IdentityKey.PB/SB: a value-typed uint8 would silently accept schema
+// typos because an omitted key deserializes as 0, which would then match
+// any command identity whose pb is also 0x00 and defeat the
+// service/identity mismatch check.
 type Service struct {
-	PB          uint8     `yaml:"pb"`
+	PB          *uint8    `yaml:"pb"`
 	Name        string    `yaml:"name"`
 	Description string    `yaml:"description,omitempty"`
 	Commands    []Command `yaml:"commands"`
+}
+
+// PBValue returns the dereferenced PB byte, or 0 if PB is nil. Callers that
+// need to distinguish "absent" from "explicit 0x00" must check the pointer
+// field directly.
+func (s Service) PBValue() uint8 {
+	if s.PB == nil {
+		return 0
+	}
+	return *s.PB
 }
 
 // Catalog is the root document produced by the YAML loader.

--- a/catalog/ebus_standard/catalog.go
+++ b/catalog/ebus_standard/catalog.go
@@ -1,0 +1,56 @@
+package ebus_standard_catalog
+
+// Namespace is the fixed provider namespace for this catalog.
+const Namespace = "ebus_standard"
+
+// CanonicalPlanSHA256 is the SHA-256 of the locked canonical plan
+// ebus-standard-l7-services-w16-26.locked/00-canonical.md. It pins the
+// catalog to a specific plan revision.
+const CanonicalPlanSHA256 = "9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305"
+
+// CatalogVersion is the explicit version tag embedded at compile time. It
+// must be bumped whenever the canonical YAML data changes.
+const CatalogVersion = "v1.0-locked"
+
+// Parameter describes a single decoded field in a command's payload. The
+// body of Parameter is intentionally minimal in M2; full L7-type references
+// land in M3 when the generic provider wires decode into helianthus-ebusgo
+// primitives.
+type Parameter struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// Command is a single method entry in the catalog. It carries the full
+// identity key plus human-facing metadata, safety class, and parameter
+// lists.
+type Command struct {
+	ID          string      `yaml:"id"`
+	Name        string      `yaml:"name"`
+	Description string      `yaml:"description,omitempty"`
+	Identity    IdentityKey `yaml:"identity"`
+	SafetyClass SafetyClass `yaml:"safety_class"`
+	Request     []Parameter `yaml:"request,omitempty"`
+	Response    []Parameter `yaml:"response,omitempty"`
+}
+
+// Service groups commands by primary-byte service code.
+type Service struct {
+	PB          uint8     `yaml:"pb"`
+	Name        string    `yaml:"name"`
+	Description string    `yaml:"description,omitempty"`
+	Commands    []Command `yaml:"commands"`
+}
+
+// Catalog is the root document produced by the YAML loader.
+type Catalog struct {
+	Namespace  string    `yaml:"namespace"`
+	Version    string    `yaml:"version"`
+	PlanSHA256 string    `yaml:"plan_sha256"`
+	Services   []Service `yaml:"services"`
+
+	// ContentSHA256 is the SHA-256 of the raw YAML bytes. It is populated
+	// by the loader, not read from the YAML itself.
+	ContentSHA256 string `yaml:"-"`
+}

--- a/catalog/ebus_standard/catalog.yaml
+++ b/catalog/ebus_standard/catalog.yaml
@@ -1,0 +1,1102 @@
+# ebus_standard catalog — first-delivery baseline
+#
+# Plan: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+# Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+# Services sourced from architecture/ebus_standard/01-services-catalog.md
+#
+# M2 scope: enumerate every method with full 14-tuple identity keys. Command
+# bodies (Request/Response parameter schemas) land in M3 once L7 type
+# primitives in helianthus-ebusgo (M1) are available for cross-linking.
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  # -----------------------------------------------------------------------
+  # Service 0x03 — Service Data
+  # -----------------------------------------------------------------------
+  - pb: 0x03
+    name: Service Data
+    description: Diagnostic counter and operating-time reads. read_only_bus_load.
+    commands:
+      - id: ebus_standard.service_data.start_counts
+        name: Start Counts
+        identity:
+          namespace: ebus_standard
+          pb: 0x03
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: start_counts
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.service_data.operating_time_l1
+        name: Operating Time Level 1
+        identity:
+          namespace: ebus_standard
+          pb: 0x03
+          sb: 0x05
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: operating_time_l1
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.service_data.operating_time_l2
+        name: Operating Time Level 2
+        identity:
+          namespace: ebus_standard
+          pb: 0x03
+          sb: 0x06
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: operating_time_l2
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.service_data.operating_time_l3
+        name: Operating Time Level 3
+        identity:
+          namespace: ebus_standard
+          pb: 0x03
+          sb: 0x07
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: operating_time_l3
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.service_data.fuel_quantity_counter
+        name: Fuel Quantity Counter
+        identity:
+          namespace: ebus_standard
+          pb: 0x03
+          sb: 0x08
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: fuel_quantity_counter
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.service_data.meter_reading
+        name: Meter Reading
+        identity:
+          namespace: ebus_standard
+          pb: 0x03
+          sb: 0x10
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: meter_reading
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+
+  # -----------------------------------------------------------------------
+  # Service 0x05 — Burner Control
+  # -----------------------------------------------------------------------
+  - pb: 0x05
+    name: Burner Control
+    description: Cyclic burner control telegrams. Default-deny for user invocation.
+    commands:
+      - id: ebus_standard.burner.op_data_req_b2c
+        name: Operational Data Request, burner to controller
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x00
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: op_data_req_b2c
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_c2b
+        name: Operational Data, controller to burner
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x01
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: op_data_c2b
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_req_c2b
+        name: Operational Data Request, controller to burner
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x02
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: op_data_req_c2b
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_b2c_block1
+        name: Operational Data, burner to controller, block 1
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x03
+          selector_path: block_number=0x01
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: typed_payload
+          selector_decoder: block_number
+          service_variant: op_data_b2c_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_b2c_block2
+        name: Operational Data, burner to controller, block 2
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x03
+          selector_path: block_number=0x02
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: typed_payload
+          selector_decoder: block_number
+          service_variant: op_data_b2c_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.control_stop_response
+        name: Control Stop Response
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: control_stop_response
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.barred_reserved
+        name: Barred / Reserved
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x05
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: no_answer
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: barred_reserved
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: destructive
+      - id: ebus_standard.burner.op_data_req_chB_b2c
+        name: Operational Data Request, channel B, burner to controller
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x06
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: op_data_req_chB_b2c
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_chB_c2b
+        name: Operational Data, channel B, controller to burner
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x07
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: op_data_chB_c2b
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_req_chB_c2b
+        name: Operational Data Request, channel B, controller to burner
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x08
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: op_data_req_chB_c2b
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_chB_b2c_block1
+        name: Operational Data, channel B, block 1
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x09
+          selector_path: block_number=0x01
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: typed_payload
+          selector_decoder: block_number
+          service_variant: op_data_chB_b2c_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_chB_b2c_block2
+        name: Operational Data, channel B, block 2
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x09
+          selector_path: block_number=0x02
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: typed_payload
+          selector_decoder: block_number
+          service_variant: op_data_chB_b2c_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_chB_b2c_block3
+        name: Operational Data, channel B, block 3
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x09
+          selector_path: block_number=0x03
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: typed_payload
+          selector_decoder: block_number
+          service_variant: op_data_chB_b2c_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.config_data_request
+        name: Configuration Data Request
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x0A
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: config_data_request
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.burner.config_data_response
+        name: Configuration Data Response
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x0B
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: config_data_response
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_safe
+      - id: ebus_standard.burner.operational_requirements
+        name: Operational Requirements
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x0C
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: operational_requirements
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.op_data_ext_c2b
+        name: Operational Data, extended controller to burner
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x0D
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: op_data_ext_c2b
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+
+  # -----------------------------------------------------------------------
+  # Service 0x07 — System Data
+  # -----------------------------------------------------------------------
+  - pb: 0x07
+    name: System Data
+    description: Identification, capability discovery, broadcast date/time.
+    commands:
+      - id: ebus_standard.system_data.date_time_broadcast
+        name: Date/Time Broadcast
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x00
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: date_time_broadcast
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.system_data.set_date_time
+        name: Set Date/Time
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x01
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: set_date_time
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.system_data.set_outside_temperature
+        name: Set Outside Temperature
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x02
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: set_outside_temperature
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.system_data.query_supported_commands
+        name: Query Supported Commands
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x03
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: query_supported_commands
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.system_data.identification_addressed
+        name: Identification (addressed)
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: identification_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.system_data.identification_self_broadcast
+        name: Identification Self-Broadcast
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: identification_self_broadcast
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.system_data.query_supported_commands_ext
+        name: Query Supported Commands, extended
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x05
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: query_supported_commands_ext
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.system_data.inquiry_of_existence
+        name: Inquiry of Existence
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0xFE
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: inquiry_of_existence
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.system_data.sign_of_life
+        name: Sign of Life
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0xFF
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: sign_of_life
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+
+  # -----------------------------------------------------------------------
+  # Service 0x08 — Controller-to-Controller
+  # -----------------------------------------------------------------------
+  - pb: 0x08
+    name: Controller-to-Controller
+    description: Broadcast coordination between controllers. Mostly default-denied.
+    commands:
+      - id: ebus_standard.c2c.target_values
+        name: Target Values
+        identity:
+          namespace: ebus_standard
+          pb: 0x08
+          sb: 0x00
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: target_values
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.c2c.operational_data
+        name: Operational Data
+        identity:
+          namespace: ebus_standard
+          pb: 0x08
+          sb: 0x01
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: operational_data
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.c2c.control_commands
+        name: Control Commands
+        identity:
+          namespace: ebus_standard
+          pb: 0x08
+          sb: 0x02
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: control_commands
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.c2c.boiler_parameters
+        name: Boiler Parameters
+        identity:
+          namespace: ebus_standard
+          pb: 0x08
+          sb: 0x03
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: boiler_parameters
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.c2c.system_remote_control
+        name: System Remote Control
+        identity:
+          namespace: ebus_standard
+          pb: 0x08
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: system_remote_control
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+
+  # -----------------------------------------------------------------------
+  # Service 0x09 — Memory Server
+  # -----------------------------------------------------------------------
+  - pb: 0x09
+    name: Memory Server
+    description: Service-mode memory reads and writes (RAM/EEPROM).
+    commands:
+      - id: ebus_standard.memory_server.read_ram
+        name: Read RAM
+        identity:
+          namespace: ebus_standard
+          pb: 0x09
+          sb: 0x00
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: read_ram
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.memory_server.write_ram
+        name: Write RAM
+        identity:
+          namespace: ebus_standard
+          pb: 0x09
+          sb: 0x01
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: write_ram
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: memory_write
+      - id: ebus_standard.memory_server.read_eeprom
+        name: Read EEPROM
+        identity:
+          namespace: ebus_standard
+          pb: 0x09
+          sb: 0x02
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: read_eeprom
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.memory_server.write_eeprom
+        name: Write EEPROM
+        identity:
+          namespace: ebus_standard
+          pb: 0x09
+          sb: 0x03
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: write_eeprom
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: memory_write
+
+  # -----------------------------------------------------------------------
+  # Service 0x0F — Test Commands
+  # -----------------------------------------------------------------------
+  - pb: 0x0F
+    name: Test Commands
+    description: Factory/service test mode. All destructive, default-denied.
+    commands:
+      - id: ebus_standard.test.start_of_test
+        name: Start of Test (NN=0x02)
+        identity:
+          namespace: ebus_standard
+          pb: 0x0F
+          sb: 0x01
+          selector_path: nn=0x02
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: nn
+          service_variant: start_of_test
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: destructive
+      - id: ebus_standard.test.ready
+        name: Ready (NN=0x01)
+        identity:
+          namespace: ebus_standard
+          pb: 0x0F
+          sb: 0x01
+          selector_path: nn=0x01
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: nn
+          service_variant: ready
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: destructive
+      - id: ebus_standard.test.test_message
+        name: Test Message
+        identity:
+          namespace: ebus_standard
+          pb: 0x0F
+          sb: 0x02
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: no_answer
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: test_message
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: destructive
+      - id: ebus_standard.test.end_of_test
+        name: End of Test
+        identity:
+          namespace: ebus_standard
+          pb: 0x0F
+          sb: 0x03
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: end_of_test
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: destructive
+
+  # -----------------------------------------------------------------------
+  # Service 0xFE — General Broadcast
+  # -----------------------------------------------------------------------
+  - pb: 0xFE
+    name: General Broadcast
+    description: General-purpose broadcast error signalling.
+    commands:
+      - id: ebus_standard.broadcast.error_message
+        name: Error Message
+        identity:
+          namespace: ebus_standard
+          pb: 0xFE
+          sb: 0x01
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: error_message
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+
+  # -----------------------------------------------------------------------
+  # Service 0xFF — Network Management
+  # -----------------------------------------------------------------------
+  - pb: 0xFF
+    name: Network Management
+    description: NM reset, failure, net status, monitored participants, failed nodes, required services.
+    commands:
+      - id: ebus_standard.nm.reset_status
+        name: Reset Status NM
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x00
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: reset_status
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.nm.reset_target_configuration
+        name: Reset Target Configuration NM
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x01
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: reset_target_configuration
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.nm.failure_message
+        name: Failure Message
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x02
+          selector_path: ""
+          telegram_class: broadcast
+          direction: request
+          request_or_response_role: originator
+          broadcast_or_addressed: broadcast
+          answer_policy: no_answer
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: failure_message
+          transport_capability_requirements: [broadcast_send]
+          version: v1.0-locked
+        safety_class: broadcast
+      - id: ebus_standard.nm.net_status_query_request
+        name: Net Status Query Request
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x03
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: net_status_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.nm.net_status_query_response
+        name: Net Status Query Response
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x03
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: net_status_query
+          transport_capability_requirements: [responder]
+          version: v1.0-locked
+        safety_class: read_only_safe
+      - id: ebus_standard.nm.monitored_participants_query_request
+        name: Monitored Participants Query Request
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: monitored_participants_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.nm.monitored_participants_query_response
+        name: Monitored Participants Query Response
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: monitored_participants_query
+          transport_capability_requirements: [responder]
+          version: v1.0-locked
+        safety_class: read_only_safe
+      - id: ebus_standard.nm.failed_nodes_query_request
+        name: Failed Nodes Query Request
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x05
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: failed_nodes_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.nm.failed_nodes_query_response
+        name: Failed Nodes Query Response
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x05
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: failed_nodes_query
+          transport_capability_requirements: [responder]
+          version: v1.0-locked
+        safety_class: read_only_safe
+      - id: ebus_standard.nm.required_services_query_request
+        name: Required Services Query Request
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x06
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: required_services_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.nm.required_services_query_response
+        name: Required Services Query Response
+        identity:
+          namespace: ebus_standard
+          pb: 0xFF
+          sb: 0x06
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: required_services_query
+          transport_capability_requirements: [responder]
+          version: v1.0-locked
+        safety_class: read_only_safe

--- a/catalog/ebus_standard/doc.go
+++ b/catalog/ebus_standard/doc.go
@@ -1,0 +1,12 @@
+// Package ebus_standard_catalog implements the catalog schema and loader for
+// the cross-vendor eBUS Standard L7 services namespace (ebus_standard).
+//
+// The catalog is the single source of truth for methods in this namespace and
+// is expressed as a SHA-pinned, version-tagged YAML data file embedded at
+// compile time. Each method carries a full 14-tuple identity key used to
+// detect collisions and ambiguous length-selector branches at generation
+// time.
+//
+// Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+// Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+package ebus_standard_catalog

--- a/catalog/ebus_standard/embedded.go
+++ b/catalog/ebus_standard/embedded.go
@@ -1,25 +1,23 @@
 package ebus_standard_catalog
 
-// EmbeddedYAML returns the raw bytes of the embedded catalog YAML.
-//
-// RED stub: the real implementation go-embeds catalog.yaml. Until the
-// GREEN commit lands, this panics to keep the package compiling while
-// making every embedded-catalog test fail loudly.
+import _ "embed"
+
+//go:embed catalog.yaml
+var embeddedYAMLBytes []byte
+
+// EmbeddedYAML returns the raw bytes of the embedded catalog YAML. The
+// returned slice is shared; callers must not modify it.
 func EmbeddedYAML() []byte {
-	panic("not implemented: embedded ebus_standard catalog YAML (M2 RED stub)")
+	return embeddedYAMLBytes
 }
 
-// MustEmbeddedCatalog returns the parsed embedded catalog or panics.
+// MustEmbeddedCatalog returns the parsed embedded catalog or panics. This
+// is safe because the embedded bytes are compile-time constants and any
+// load failure is a build-breaking catalog error that CI catches.
 func MustEmbeddedCatalog() Catalog {
 	cat, err := LoadCatalog(EmbeddedYAML())
 	if err != nil {
 		panic("ebus_standard: embedded catalog failed to load: " + err.Error())
 	}
 	return cat
-}
-
-// ComputeContentSHA256 returns the lowercase hex SHA-256 of the given bytes.
-// Stub to be implemented alongside the loader.
-func ComputeContentSHA256(data []byte) string {
-	panic("not implemented: ComputeContentSHA256 (M2 RED stub)")
 }

--- a/catalog/ebus_standard/embedded.go
+++ b/catalog/ebus_standard/embedded.go
@@ -1,3 +1,6 @@
+//go:build !tinygo
+// +build !tinygo
+
 package ebus_standard_catalog
 
 import _ "embed"
@@ -17,6 +20,13 @@ func EmbeddedYAML() []byte {
 // MustEmbeddedCatalog returns the parsed embedded catalog or panics. This
 // is safe because the embedded bytes are compile-time constants and any
 // load failure is a build-breaking catalog error that CI catches.
+//
+// This symbol is defined only on non-TinyGo builds because the YAML loader
+// is unavailable under TinyGo (see loader_tinygo.go). TinyGo consumers
+// must construct a Catalog via a pre-validated path (embedded literal or
+// host-generated snapshot) rather than calling this helper; a compile-time
+// "undefined: MustEmbeddedCatalog" guides them to the correct API instead
+// of deterministically panicking at runtime.
 func MustEmbeddedCatalog() Catalog {
 	cat, err := LoadCatalog(EmbeddedYAML())
 	if err != nil {

--- a/catalog/ebus_standard/embedded.go
+++ b/catalog/ebus_standard/embedded.go
@@ -1,0 +1,25 @@
+package ebus_standard_catalog
+
+// EmbeddedYAML returns the raw bytes of the embedded catalog YAML.
+//
+// RED stub: the real implementation go-embeds catalog.yaml. Until the
+// GREEN commit lands, this panics to keep the package compiling while
+// making every embedded-catalog test fail loudly.
+func EmbeddedYAML() []byte {
+	panic("not implemented: embedded ebus_standard catalog YAML (M2 RED stub)")
+}
+
+// MustEmbeddedCatalog returns the parsed embedded catalog or panics.
+func MustEmbeddedCatalog() Catalog {
+	cat, err := LoadCatalog(EmbeddedYAML())
+	if err != nil {
+		panic("ebus_standard: embedded catalog failed to load: " + err.Error())
+	}
+	return cat
+}
+
+// ComputeContentSHA256 returns the lowercase hex SHA-256 of the given bytes.
+// Stub to be implemented alongside the loader.
+func ComputeContentSHA256(data []byte) string {
+	panic("not implemented: ComputeContentSHA256 (M2 RED stub)")
+}

--- a/catalog/ebus_standard/embedded.go
+++ b/catalog/ebus_standard/embedded.go
@@ -5,10 +5,13 @@ import _ "embed"
 //go:embed catalog.yaml
 var embeddedYAMLBytes []byte
 
-// EmbeddedYAML returns the raw bytes of the embedded catalog YAML. The
-// returned slice is shared; callers must not modify it.
+// EmbeddedYAML returns a defensive copy of the raw bytes of the embedded
+// catalog YAML. A copy is returned (rather than the package-global slice)
+// so that mutations by external callers cannot corrupt subsequent catalog
+// loads or introduce data races across goroutines. Modifications to the
+// returned slice do not affect future calls.
 func EmbeddedYAML() []byte {
-	return embeddedYAMLBytes
+	return append([]byte(nil), embeddedYAMLBytes...)
 }
 
 // MustEmbeddedCatalog returns the parsed embedded catalog or panics. This

--- a/catalog/ebus_standard/fixtures_test.go
+++ b/catalog/ebus_standard/fixtures_test.go
@@ -1,0 +1,124 @@
+package ebus_standard_catalog
+
+import (
+	"testing"
+)
+
+// TestEmbeddedCatalog_Class2BroadcastFixture asserts the embedded catalog
+// contains at least one class-2 broadcast entry (telegram_class=broadcast,
+// no_answer). This is one of the axes explicitly called out in locked plan
+// §3 risk 1.
+func TestEmbeddedCatalog_Class2BroadcastFixture(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			if cmd.Identity.TelegramClass == TelegramClassBroadcast &&
+				cmd.Identity.AnswerPolicy == AnswerNone {
+				return
+			}
+		}
+	}
+	t.Fatalf("no class-2 broadcast (broadcast + no_answer) entry in embedded catalog")
+}
+
+// TestEmbeddedCatalog_OriginatorBroadcastModeFixture asserts the catalog
+// contains at least one originator broadcast (controller-to-all broadcast
+// mode, i.e. an originator broadcasting to every participant without
+// expecting an addressed response). `identification_self_broadcast` meets
+// this.
+func TestEmbeddedCatalog_OriginatorBroadcastModeFixture(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			if cmd.Identity.RequestOrResponseRole == RoleOriginator &&
+				cmd.Identity.BroadcastOrAddressed == AddressedBroadcast {
+				return
+			}
+		}
+	}
+	t.Fatalf("no originator broadcast-mode entry (originator + broadcast)")
+}
+
+// TestEmbeddedCatalog_NoAnswerFormFixture asserts at least one addressed
+// no-answer form exists (destructive or broadcast-initiated without
+// responder reply). `ebus_standard.burner.barred_reserved` covers this.
+func TestEmbeddedCatalog_NoAnswerFormFixture(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			if cmd.Identity.AnswerPolicy == AnswerNone {
+				return
+			}
+		}
+	}
+	t.Fatalf("no no-answer-form entry")
+}
+
+// TestEmbeddedCatalog_TypedPayloadSelectorFixture asserts the catalog
+// contains at least one typed-payload-selector entry (length_prefix_mode =
+// typed_payload, selector_decoder != "none"). The 0x05 0x03 block-number
+// variants cover this.
+func TestEmbeddedCatalog_TypedPayloadSelectorFixture(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			if cmd.Identity.LengthPrefixMode == LengthPrefixTypedPayload &&
+				cmd.Identity.SelectorDecoder != "none" &&
+				cmd.Identity.SelectorDecoder != "" {
+				return
+			}
+		}
+	}
+	t.Fatalf("no typed-payload-selector entry")
+}
+
+// TestLoadCatalog_IncompleteIdentityKey asserts that an otherwise valid
+// YAML with a missing identity field is rejected with
+// ErrIncompleteIdentityKey.
+func TestLoadCatalog_IncompleteIdentityKey(t *testing.T) {
+	yml := []byte(`
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data
+    commands:
+      - id: ebus_standard.incomplete
+        name: Incomplete entry
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          # request_or_response_role intentionally omitted
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: test_variant
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+`)
+	_, err := LoadCatalog(yml)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrIncompleteIdentityKey, got nil")
+	}
+}
+
+// TestLoadCatalog_ContentSHARoundtrip asserts that SHA-256 of the raw bytes
+// is deterministic and populated on load.
+func TestLoadCatalog_ContentSHARoundtrip(t *testing.T) {
+	cat1 := MustEmbeddedCatalog()
+	cat2 := MustEmbeddedCatalog()
+	if cat1.ContentSHA256 != cat2.ContentSHA256 {
+		t.Fatalf("non-deterministic ContentSHA256: %q vs %q",
+			cat1.ContentSHA256, cat2.ContentSHA256)
+	}
+	if cat1.ContentSHA256 == "" {
+		t.Fatalf("ContentSHA256 empty")
+	}
+}

--- a/catalog/ebus_standard/identity.go
+++ b/catalog/ebus_standard/identity.go
@@ -78,9 +78,12 @@ const (
 // canonical §3 of the locked plan. Every catalog entry must populate every
 // field; generation fails on duplicate identity keys.
 type IdentityKey struct {
-	Namespace                       string                `yaml:"namespace"`
-	PB                              uint8                 `yaml:"pb"`
-	SB                              uint8                 `yaml:"sb"`
+	Namespace string `yaml:"namespace"`
+	// PB and SB are pointer-typed so the YAML loader can distinguish an
+	// absent key (nil → ErrIncompleteIdentityKey) from an explicit zero
+	// value (e.g. `pb: 0x00` is legitimate and must be accepted).
+	PB                              *uint8                `yaml:"pb"`
+	SB                              *uint8                `yaml:"sb"`
 	SelectorPath                    string                `yaml:"selector_path"` // nullable ("" = no selector)
 	TelegramClass                   TelegramClass         `yaml:"telegram_class"`
 	Direction                       Direction             `yaml:"direction"`
@@ -102,6 +105,14 @@ type IdentityKey struct {
 // every catalog entry.
 func (k IdentityKey) IsComplete() bool {
 	if k.Namespace == "" {
+		return false
+	}
+	// PB/SB must be present in the source document. The value 0x00 is
+	// legitimate when explicitly set; only absence (nil) is rejected.
+	if k.PB == nil {
+		return false
+	}
+	if k.SB == nil {
 		return false
 	}
 	if k.TelegramClass == "" {
@@ -134,8 +145,24 @@ func (k IdentityKey) IsComplete() bool {
 	if k.Version == "" {
 		return false
 	}
-	// PB, SB, SelectorPath are value-typed; zero is semantically valid for
-	// PB/SB (e.g. 0x03, 0x00) and empty is explicitly nullable for
-	// SelectorPath.
+	// SelectorPath is value-typed; empty is explicitly nullable.
 	return true
+}
+
+// PBValue returns the dereferenced PB byte, or 0 if PB is nil. Callers that
+// need to distinguish "absent" from "explicit 0x00" must check the pointer
+// field directly or use IsComplete().
+func (k IdentityKey) PBValue() uint8 {
+	if k.PB == nil {
+		return 0
+	}
+	return *k.PB
+}
+
+// SBValue returns the dereferenced SB byte, or 0 if SB is nil.
+func (k IdentityKey) SBValue() uint8 {
+	if k.SB == nil {
+		return 0
+	}
+	return *k.SB
 }

--- a/catalog/ebus_standard/identity.go
+++ b/catalog/ebus_standard/identity.go
@@ -1,0 +1,141 @@
+package ebus_standard_catalog
+
+// TelegramClass enumerates eBUS telegram classes supported by the catalog.
+type TelegramClass string
+
+// Telegram classes.
+const (
+	TelegramClassAddressed           TelegramClass = "addressed"
+	TelegramClassBroadcast           TelegramClass = "broadcast"
+	TelegramClassInitiatorInitiator  TelegramClass = "initiator_initiator"
+	TelegramClassControllerBroadcast TelegramClass = "controller_broadcast"
+)
+
+// Direction enumerates the request/response axis.
+type Direction string
+
+// Directions.
+const (
+	DirectionRequest  Direction = "request"
+	DirectionResponse Direction = "response"
+)
+
+// RequestOrResponseRole enumerates the initiator-or-responder role axis.
+type RequestOrResponseRole string
+
+// Roles.
+const (
+	RoleInitiator  RequestOrResponseRole = "initiator"
+	RoleResponder  RequestOrResponseRole = "responder"
+	RoleOriginator RequestOrResponseRole = "originator"
+)
+
+// BroadcastOrAddressed enumerates the addressing axis.
+type BroadcastOrAddressed string
+
+// Addressing axis values.
+const (
+	AddressedDirect    BroadcastOrAddressed = "addressed"
+	AddressedBroadcast BroadcastOrAddressed = "broadcast"
+)
+
+// AnswerPolicy enumerates the answer-required vs no-answer axis.
+type AnswerPolicy string
+
+// Answer policy values.
+const (
+	AnswerRequired AnswerPolicy = "answer_required"
+	AnswerNone     AnswerPolicy = "no_answer"
+)
+
+// LengthPrefixMode enumerates the length-prefix-mode axis for the identity
+// key. Matches the locked plan's explicit length-selector disambiguation
+// requirement.
+type LengthPrefixMode string
+
+// Length prefix modes.
+const (
+	LengthPrefixNone         LengthPrefixMode = "none"
+	LengthPrefixFixed        LengthPrefixMode = "fixed"
+	LengthPrefixByte         LengthPrefixMode = "byte_prefix"
+	LengthPrefixTypedPayload LengthPrefixMode = "typed_payload"
+)
+
+// SafetyClass enumerates the execution-safety classes defined by the plan.
+type SafetyClass string
+
+// Safety classes.
+const (
+	SafetyReadOnlySafe    SafetyClass = "read_only_safe"
+	SafetyReadOnlyBusLoad SafetyClass = "read_only_bus_load"
+	SafetyMutating        SafetyClass = "mutating"
+	SafetyDestructive     SafetyClass = "destructive"
+	SafetyBroadcast       SafetyClass = "broadcast"
+	SafetyMemoryWrite     SafetyClass = "memory_write"
+)
+
+// IdentityKey is the full 14-tuple catalog identity key specified in
+// canonical §3 of the locked plan. Every catalog entry must populate every
+// field; generation fails on duplicate identity keys.
+type IdentityKey struct {
+	Namespace                       string                `yaml:"namespace"`
+	PB                              uint8                 `yaml:"pb"`
+	SB                              uint8                 `yaml:"sb"`
+	SelectorPath                    string                `yaml:"selector_path"` // nullable ("" = no selector)
+	TelegramClass                   TelegramClass         `yaml:"telegram_class"`
+	Direction                       Direction             `yaml:"direction"`
+	RequestOrResponseRole           RequestOrResponseRole `yaml:"request_or_response_role"`
+	BroadcastOrAddressed            BroadcastOrAddressed  `yaml:"broadcast_or_addressed"`
+	AnswerPolicy                    AnswerPolicy          `yaml:"answer_policy"`
+	LengthPrefixMode                LengthPrefixMode      `yaml:"length_prefix_mode"`
+	SelectorDecoder                 string                `yaml:"selector_decoder"`
+	ServiceVariant                  string                `yaml:"service_variant"`
+	TransportCapabilityRequirements []string              `yaml:"transport_capability_requirements"`
+	Version                         string                `yaml:"version"`
+}
+
+// IsComplete returns true when every field of the 14-tuple identity key has
+// been populated. Selector path is intentionally nullable; the empty string
+// is a valid value and does NOT make the key incomplete.
+//
+// The test suite in identity_completeness_test.go enforces this contract for
+// every catalog entry.
+func (k IdentityKey) IsComplete() bool {
+	if k.Namespace == "" {
+		return false
+	}
+	if k.TelegramClass == "" {
+		return false
+	}
+	if k.Direction == "" {
+		return false
+	}
+	if k.RequestOrResponseRole == "" {
+		return false
+	}
+	if k.BroadcastOrAddressed == "" {
+		return false
+	}
+	if k.AnswerPolicy == "" {
+		return false
+	}
+	if k.LengthPrefixMode == "" {
+		return false
+	}
+	if k.SelectorDecoder == "" {
+		return false
+	}
+	if k.ServiceVariant == "" {
+		return false
+	}
+	if k.TransportCapabilityRequirements == nil {
+		return false
+	}
+	if k.Version == "" {
+		return false
+	}
+	// PB, SB, SelectorPath are value-typed; zero is semantically valid for
+	// PB/SB (e.g. 0x03, 0x00) and empty is explicitly nullable for
+	// SelectorPath.
+	return true
+}

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -41,6 +41,12 @@ var (
 	// (e.g. "ebus_standrad") is otherwise silently treated as a distinct
 	// identity and bypasses duplicate detection.
 	ErrInvalidNamespace = errors.New("ebus_standard: identity-key namespace must be ebus_standard")
+
+	// ErrServicePBMismatch is returned when a service's declared pb does
+	// not match the pb of one of its command identity keys. A typo in the
+	// service header would otherwise produce a catalog where commands are
+	// silently grouped under the wrong service code.
+	ErrServicePBMismatch = errors.New("ebus_standard: service pb does not match command identity pb")
 )
 
 // LoadCatalog parses and validates a YAML catalog document. The returned

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -29,6 +29,12 @@ var (
 	// broadcast_or_addressed, answer_policy, length_prefix_mode) carries
 	// a value that is not one of the constants defined in identity.go.
 	ErrUnknownEnumValue = errors.New("ebus_standard: unknown enum value")
+
+	// ErrServiceMissingCommands is returned when a service entry deserializes
+	// with an empty commands list. A service with no commands is always a
+	// typo or omission in the YAML (wrong key name, empty list) and must
+	// fail loudly rather than silently load an empty service.
+	ErrServiceMissingCommands = errors.New("ebus_standard: service has no commands")
 )
 
 // LoadCatalog parses and validates a YAML catalog document. The returned

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -35,6 +35,12 @@ var (
 	// typo or omission in the YAML (wrong key name, empty list) and must
 	// fail loudly rather than silently load an empty service.
 	ErrServiceMissingCommands = errors.New("ebus_standard: service has no commands")
+
+	// ErrInvalidNamespace is returned when an identity-key namespace does
+	// not exactly match the package's fixed Namespace constant. A typo
+	// (e.g. "ebus_standrad") is otherwise silently treated as a distinct
+	// identity and bypasses duplicate detection.
+	ErrInvalidNamespace = errors.New("ebus_standard: identity-key namespace must be ebus_standard")
 )
 
 // LoadCatalog parses and validates a YAML catalog document. The returned

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -23,6 +23,12 @@ var (
 	// ErrUnknownSafetyClass is returned when an entry's safety_class is
 	// not one of the enumerated values.
 	ErrUnknownSafetyClass = errors.New("ebus_standard: unknown safety_class")
+
+	// ErrUnknownEnumValue is returned when an identity-key enum field
+	// (telegram_class, direction, request_or_response_role,
+	// broadcast_or_addressed, answer_policy, length_prefix_mode) carries
+	// a value that is not one of the constants defined in identity.go.
+	ErrUnknownEnumValue = errors.New("ebus_standard: unknown enum value")
 )
 
 // LoadCatalog parses and validates a YAML catalog document. The returned

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -1,0 +1,36 @@
+package ebus_standard_catalog
+
+import (
+	"errors"
+)
+
+// Sentinel errors returned by the catalog loader.
+var (
+	// ErrDuplicateIdentityKey is returned when two catalog entries share
+	// the full 14-tuple identity key.
+	ErrDuplicateIdentityKey = errors.New("ebus_standard: duplicate catalog identity key")
+
+	// ErrAmbiguousLengthSelector is returned when two entries share
+	// (namespace, PB, SB, selector_decoder) but have incompatible
+	// length-selector semantics that cannot be disambiguated at decode
+	// time.
+	ErrAmbiguousLengthSelector = errors.New("ebus_standard: ambiguous length-selector branch")
+
+	// ErrIncompleteIdentityKey is returned when a catalog entry fails to
+	// populate every required field of the 14-tuple identity key.
+	ErrIncompleteIdentityKey = errors.New("ebus_standard: catalog entry has incomplete identity key")
+
+	// ErrUnknownSafetyClass is returned when an entry's safety_class is
+	// not one of the enumerated values.
+	ErrUnknownSafetyClass = errors.New("ebus_standard: unknown safety_class")
+)
+
+// LoadCatalog parses and validates a YAML catalog document. The returned
+// catalog has ContentSHA256 populated from the raw bytes.
+//
+// Implementation lives in loader_yaml.go so that this file can be consumed
+// by TinyGo builds without the yaml.v3 dependency. M2 RED scaffolding keeps
+// a panicking stub here only until loader_yaml.go is in place.
+func LoadCatalog(data []byte) (Catalog, error) {
+	return loadCatalogImpl(data)
+}

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -50,6 +50,13 @@ var (
 	// IdentityKey.PB / IdentityKey.SB.
 	ErrServiceMissingPB = errors.New("ebus_standard: service is missing pb key")
 
+	// ErrCatalogMissingServices is returned when a YAML document deserializes
+	// with an empty (or absent) top-level `services:` collection. Without
+	// this guard, a malformed document silently produces an effectively empty
+	// catalog and bypasses every per-service validation (ErrServiceMissingPB,
+	// ErrServiceMissingCommands, identity checks, duplicate detection).
+	ErrCatalogMissingServices = errors.New("ebus_standard: catalog has no services")
+
 	// ErrServicePBMismatch is returned when a service's declared pb does
 	// not match the pb of one of its command identity keys. A typo in the
 	// service header would otherwise produce a catalog where commands are

--- a/catalog/ebus_standard/loader.go
+++ b/catalog/ebus_standard/loader.go
@@ -42,6 +42,14 @@ var (
 	// identity and bypasses duplicate detection.
 	ErrInvalidNamespace = errors.New("ebus_standard: identity-key namespace must be ebus_standard")
 
+	// ErrServiceMissingPB is returned when a service entry deserializes
+	// without an explicit `pb:` key. A value-typed uint8 would silently
+	// accept the omission as 0x00 and defeat the service/identity pb
+	// mismatch check; requiring the key to be present makes schema typos
+	// fail loudly at load time. This parallels the treatment of
+	// IdentityKey.PB / IdentityKey.SB.
+	ErrServiceMissingPB = errors.New("ebus_standard: service is missing pb key")
+
 	// ErrServicePBMismatch is returned when a service's declared pb does
 	// not match the pb of one of its command identity keys. A typo in the
 	// service header would otherwise produce a catalog where commands are

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -44,6 +44,26 @@ func TestLoadCatalog_AmbiguousLengthSelector(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_AmbiguousLengthSelector_NoneDecoder asserts that two
+// entries sharing the on-wire identity axes with selector_decoder="none"
+// but differing only by length_prefix_mode are still rejected as
+// ambiguous. Without a selector branch, no decode-time disambiguation is
+// possible, so the ambiguity detector must treat "none" as a bundling axis
+// rather than skipping it.
+func TestLoadCatalog_AmbiguousLengthSelector_NoneDecoder(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "ambiguous_length_selector_none_decoder.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrAmbiguousLengthSelector, got nil")
+	}
+	if !errors.Is(err, ErrAmbiguousLengthSelector) {
+		t.Fatalf("LoadCatalog: expected ErrAmbiguousLengthSelector, got %v", err)
+	}
+}
+
 // TestLoadCatalog_MissingPB asserts that a YAML fixture omitting the `pb`
 // key in the identity block is rejected with ErrIncompleteIdentityKey. The
 // value 0x00 must NOT be accepted as a default; absence of the key is the

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -64,6 +64,26 @@ func TestLoadCatalog_AmbiguousLengthSelector_NoneDecoder(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_AmbiguousLengthSelector_NoneDecoder_WithPath asserts
+// that when selector_decoder="none", the ambiguity-bundling key ignores
+// selector_path. Two entries sharing the on-wire identity axes with
+// different selector_path strings but incompatible length_prefix_mode
+// values must still collide: without a decoder, selector_path is inert
+// at decode time and cannot disambiguate the branches.
+func TestLoadCatalog_AmbiguousLengthSelector_NoneDecoder_WithPath(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "ambiguous_length_selector_none_decoder_with_path.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrAmbiguousLengthSelector, got nil")
+	}
+	if !errors.Is(err, ErrAmbiguousLengthSelector) {
+		t.Fatalf("LoadCatalog: expected ErrAmbiguousLengthSelector, got %v", err)
+	}
+}
+
 // TestLoadCatalog_ServicePBMismatch asserts that a command whose
 // identity.pb differs from the enclosing service.pb is rejected with
 // ErrServicePBMismatch. A typo in the service header would otherwise

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -42,6 +42,64 @@ func TestLoadCatalog_AmbiguousLengthSelector(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_MissingPB asserts that a YAML fixture omitting the `pb`
+// key in the identity block is rejected with ErrIncompleteIdentityKey. The
+// value 0x00 must NOT be accepted as a default; absence of the key is the
+// only signal the loader has to distinguish "missing" from "explicit 0x00".
+func TestLoadCatalog_MissingPB(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "missing_pb.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrIncompleteIdentityKey, got nil")
+	}
+	if !errors.Is(err, ErrIncompleteIdentityKey) {
+		t.Fatalf("LoadCatalog: expected ErrIncompleteIdentityKey, got %v", err)
+	}
+}
+
+// TestLoadCatalog_MissingSB asserts the symmetric rejection when the `sb`
+// key is absent.
+func TestLoadCatalog_MissingSB(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "missing_sb.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrIncompleteIdentityKey, got nil")
+	}
+	if !errors.Is(err, ErrIncompleteIdentityKey) {
+		t.Fatalf("LoadCatalog: expected ErrIncompleteIdentityKey, got %v", err)
+	}
+}
+
+// TestLoadCatalog_ExplicitZeroPBSB asserts that explicitly-set `pb: 0x00`
+// and `sb: 0x00` are ACCEPTED — the value zero is legitimate when the YAML
+// author wrote it out. Only absence of the key must be rejected.
+func TestLoadCatalog_ExplicitZeroPBSB(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "explicit_zero_pb_sb.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	cat, err := LoadCatalog(data)
+	if err != nil {
+		t.Fatalf("LoadCatalog: expected success for explicit zero PB/SB, got %v", err)
+	}
+	if len(cat.Services) != 1 || len(cat.Services[0].Commands) != 1 {
+		t.Fatalf("LoadCatalog: expected 1 service with 1 command, got %+v", cat.Services)
+	}
+	id := cat.Services[0].Commands[0].Identity
+	if id.PB == nil || *id.PB != 0x00 {
+		t.Fatalf("LoadCatalog: PB: expected explicit 0x00, got %v", id.PB)
+	}
+	if id.SB == nil || *id.SB != 0x00 {
+		t.Fatalf("LoadCatalog: SB: expected explicit 0x00, got %v", id.SB)
+	}
+}
+
 // TestEmbeddedCatalog_SHAPinning asserts that the embedded catalog carries
 // a ContentSHA256 value and that it matches the SHA of its raw bytes. This
 // enforces the plan's "Catalog is SHA-pinned and version-tagged"

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -1,0 +1,108 @@
+package ebus_standard_catalog
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadCatalog_DuplicateIdentityKey asserts that a YAML fixture with a
+// planted duplicate 14-tuple identity key causes LoadCatalog to fail with
+// ErrDuplicateIdentityKey. This is the canonical collision-detection
+// guarantee from locked plan §3.
+func TestLoadCatalog_DuplicateIdentityKey(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "collision_duplicate.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrDuplicateIdentityKey, got nil")
+	}
+	if !errors.Is(err, ErrDuplicateIdentityKey) {
+		t.Fatalf("LoadCatalog: expected ErrDuplicateIdentityKey, got %v", err)
+	}
+}
+
+// TestLoadCatalog_AmbiguousLengthSelector asserts that two entries sharing
+// (namespace, PB, SB, selector_decoder) with incompatible length_prefix_mode
+// cause LoadCatalog to fail.
+func TestLoadCatalog_AmbiguousLengthSelector(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "ambiguous_length_selector.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrAmbiguousLengthSelector, got nil")
+	}
+	if !errors.Is(err, ErrAmbiguousLengthSelector) {
+		t.Fatalf("LoadCatalog: expected ErrAmbiguousLengthSelector, got %v", err)
+	}
+}
+
+// TestEmbeddedCatalog_SHAPinning asserts that the embedded catalog carries
+// a ContentSHA256 value and that it matches the SHA of its raw bytes. This
+// enforces the plan's "Catalog is SHA-pinned and version-tagged"
+// requirement.
+func TestEmbeddedCatalog_SHAPinning(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	if cat.Version == "" {
+		t.Fatalf("embedded catalog: Version empty")
+	}
+	if cat.Version != CatalogVersion {
+		t.Fatalf("embedded catalog: Version=%q, want %q", cat.Version, CatalogVersion)
+	}
+	if cat.PlanSHA256 != CanonicalPlanSHA256 {
+		t.Fatalf("embedded catalog: PlanSHA256=%q, want %q", cat.PlanSHA256, CanonicalPlanSHA256)
+	}
+	if cat.ContentSHA256 == "" {
+		t.Fatalf("embedded catalog: ContentSHA256 empty")
+	}
+	// The loader must compute ContentSHA256 from the raw YAML bytes, not
+	// from any post-parse structure. We re-compute from EmbeddedYAML() and
+	// assert equality.
+	want := ComputeContentSHA256(EmbeddedYAML())
+	if cat.ContentSHA256 != want {
+		t.Fatalf("embedded catalog: ContentSHA256=%q, want %q", cat.ContentSHA256, want)
+	}
+}
+
+// TestEmbeddedCatalog_IdentityKeyCompleteness walks every command in the
+// embedded catalog and asserts that its 14-tuple identity key is fully
+// populated per canonical §3.
+func TestEmbeddedCatalog_IdentityKeyCompleteness(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	var failures int
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			if !cmd.Identity.IsComplete() {
+				t.Errorf("command %q: incomplete identity key: %+v", cmd.ID, cmd.Identity)
+				failures++
+			}
+			if cmd.Identity.Namespace != Namespace {
+				t.Errorf("command %q: namespace=%q, want %q", cmd.ID, cmd.Identity.Namespace, Namespace)
+			}
+		}
+	}
+	if failures > 0 {
+		t.Fatalf("%d commands have incomplete identity keys", failures)
+	}
+}
+
+// TestEmbeddedCatalog_ServiceCoverage asserts that every service required
+// by the locked plan's first-delivery baseline is present.
+func TestEmbeddedCatalog_ServiceCoverage(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	required := []uint8{0x03, 0x05, 0x07, 0x08, 0x09, 0x0F, 0xFE, 0xFF}
+	present := make(map[uint8]bool, len(cat.Services))
+	for _, svc := range cat.Services {
+		present[svc.PB] = true
+	}
+	for _, pb := range required {
+		if !present[pb] {
+			t.Errorf("service PB=0x%02X missing from embedded catalog", pb)
+		}
+	}
+}

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -2,8 +2,10 @@ package ebus_standard_catalog
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +100,106 @@ func TestLoadCatalog_ExplicitZeroPBSB(t *testing.T) {
 	if id.SB == nil || *id.SB != 0x00 {
 		t.Fatalf("LoadCatalog: SB: expected explicit 0x00, got %v", id.SB)
 	}
+}
+
+// TestLoadCatalog_UnknownEnumValue asserts that typos in any of the enum-
+// typed identity-key axes are rejected at load time with
+// ErrUnknownEnumValue — rather than silently accepted as opaque strings,
+// which would break downstream matching without a deterministic error.
+//
+// One sub-test per axis, each starts from a valid template and replaces
+// a single field with a deliberate typo.
+func TestLoadCatalog_UnknownEnumValue(t *testing.T) {
+	const validTemplate = `
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data
+    commands:
+      - id: ebus_standard.enum_typo_test
+        name: Enum typo probe
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: {{TELEGRAM_CLASS}}
+          direction: {{DIRECTION}}
+          request_or_response_role: {{ROLE}}
+          broadcast_or_addressed: {{ADDRESSING}}
+          answer_policy: {{ANSWER_POLICY}}
+          length_prefix_mode: {{LPM}}
+          selector_decoder: none
+          service_variant: enum_probe
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+`
+	type axis struct {
+		name       string
+		defaults   map[string]string
+		typoedField string
+		typoedValue string
+	}
+	baseline := map[string]string{
+		"TELEGRAM_CLASS": "addressed",
+		"DIRECTION":      "request",
+		"ROLE":           "initiator",
+		"ADDRESSING":     "addressed",
+		"ANSWER_POLICY":  "answer_required",
+		"LPM":            "none",
+	}
+	// Sanity: the baseline template itself must load successfully.
+	t.Run("baseline_loads", func(t *testing.T) {
+		yml := applyTemplate(validTemplate, baseline)
+		if _, err := LoadCatalog([]byte(yml)); err != nil {
+			t.Fatalf("baseline template: expected success, got %v", err)
+		}
+	})
+
+	cases := []axis{
+		{name: "telegram_class", typoedField: "TELEGRAM_CLASS", typoedValue: "addresed_typo"},
+		{name: "direction", typoedField: "DIRECTION", typoedValue: "requset"},
+		{name: "request_or_response_role", typoedField: "ROLE", typoedValue: "initator"},
+		{name: "broadcast_or_addressed", typoedField: "ADDRESSING", typoedValue: "addresed"},
+		{name: "answer_policy", typoedField: "ANSWER_POLICY", typoedValue: "answer_req"},
+		{name: "length_prefix_mode", typoedField: "LPM", typoedValue: "fixd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals := make(map[string]string, len(baseline))
+			for k, v := range baseline {
+				vals[k] = v
+			}
+			vals[tc.typoedField] = tc.typoedValue
+			yml := applyTemplate(validTemplate, vals)
+			_, err := LoadCatalog([]byte(yml))
+			if err == nil {
+				t.Fatalf("axis %s with typo %q: expected ErrUnknownEnumValue, got nil", tc.name, tc.typoedValue)
+			}
+			if !errors.Is(err, ErrUnknownEnumValue) {
+				t.Fatalf("axis %s with typo %q: expected ErrUnknownEnumValue, got %v", tc.name, tc.typoedValue, err)
+			}
+			// Error message must name the field and the bad value for
+			// deterministic diagnosis.
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Fatalf("axis %s: error %q does not name the field", tc.name, err.Error())
+			}
+			if !strings.Contains(err.Error(), tc.typoedValue) {
+				t.Fatalf("axis %s: error %q does not include the bad value", tc.name, err.Error())
+			}
+		})
+	}
+}
+
+func applyTemplate(tpl string, vals map[string]string) string {
+	out := tpl
+	for k, v := range vals {
+		out = strings.ReplaceAll(out, fmt.Sprintf("{{%s}}", k), v)
+	}
+	return out
 }
 
 // TestEmbeddedCatalog_SHAPinning asserts that the embedded catalog carries

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -201,6 +201,33 @@ func applyTemplate(tpl string, vals map[string]string) string {
 	return out
 }
 
+// TestLoadCatalog_ServiceWithoutCommands asserts that a YAML fixture whose
+// service block deserializes with no commands (typo or omission of the
+// `commands:` key) is rejected with ErrServiceMissingCommands. The baseline
+// catalog satisfies len(commands) > 0 by construction.
+func TestLoadCatalog_ServiceWithoutCommands(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "service_without_commands.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrServiceMissingCommands, got nil")
+	}
+	if !errors.Is(err, ErrServiceMissingCommands) {
+		t.Fatalf("LoadCatalog: expected ErrServiceMissingCommands, got %v", err)
+	}
+}
+
+// TestLoadCatalog_EmbeddedBaselineLoads asserts that the embedded baseline
+// catalog passes the empty-commands guard — i.e. every declared service has
+// at least one command.
+func TestLoadCatalog_EmbeddedBaselineLoads(t *testing.T) {
+	if _, err := LoadCatalog(EmbeddedYAML()); err != nil {
+		t.Fatalf("LoadCatalog(embedded): unexpected error: %v", err)
+	}
+}
+
 // TestEmbeddedCatalog_SHAPinning asserts that the embedded catalog carries
 // a ContentSHA256 value and that it matches the SHA of its raw bytes. This
 // enforces the plan's "Catalog is SHA-pinned and version-tagged"

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -284,6 +284,36 @@ func TestLoadCatalog_ServiceWithoutCommands(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_EmptyCatalog asserts that a YAML document with no
+// top-level services (key absent, or `services: []`) is rejected with
+// ErrCatalogMissingServices. Without this guard, a malformed document would
+// silently load as an empty catalog and bypass every per-service validation.
+func TestLoadCatalog_EmptyCatalog(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "empty_catalog.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrCatalogMissingServices, got nil")
+	}
+	if !errors.Is(err, ErrCatalogMissingServices) {
+		t.Fatalf("LoadCatalog: expected ErrCatalogMissingServices, got %v", err)
+	}
+
+	// Explicit empty list must also be rejected.
+	empty := []byte("namespace: ebus_standard\nservices: []\n")
+	if _, err := LoadCatalog(empty); !errors.Is(err, ErrCatalogMissingServices) {
+		t.Fatalf("LoadCatalog(services:[]): expected ErrCatalogMissingServices, got %v", err)
+	}
+
+	// A document with nothing but a comment must also be rejected.
+	commentOnly := []byte("# just a comment, no services\n")
+	if _, err := LoadCatalog(commentOnly); !errors.Is(err, ErrCatalogMissingServices) {
+		t.Fatalf("LoadCatalog(comment-only): expected ErrCatalogMissingServices, got %v", err)
+	}
+}
+
 // TestLoadCatalog_EmbeddedBaselineLoads asserts that the embedded baseline
 // catalog passes the empty-commands guard — i.e. every declared service has
 // at least one command.

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -139,7 +139,6 @@ services:
 `
 	type axis struct {
 		name        string
-		defaults    map[string]string
 		typoedField string
 		typoedValue string
 	}

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -87,6 +87,28 @@ func TestLoadCatalog_ServicePBMismatch(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_ServiceMissingPB asserts that a service entry without an
+// explicit `pb:` key is rejected with ErrServiceMissingPB. A value-typed
+// uint8 would silently deserialize omission as 0x00 and match a command
+// whose identity.pb is also 0x00, defeating the service/identity pb
+// mismatch check. The error must name the offending service.
+func TestLoadCatalog_ServiceMissingPB(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "service_missing_pb.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrServiceMissingPB, got nil")
+	}
+	if !errors.Is(err, ErrServiceMissingPB) {
+		t.Fatalf("LoadCatalog: expected ErrServiceMissingPB, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "System Data (missing pb header)") {
+		t.Fatalf("error %q must include the offending service name", err.Error())
+	}
+}
+
 // TestLoadCatalog_MissingPB asserts that a YAML fixture omitting the `pb`
 // key in the identity block is rejected with ErrIncompleteIdentityKey. The
 // value 0x00 must NOT be accepted as a default; absence of the key is the
@@ -354,7 +376,7 @@ func TestEmbeddedCatalog_ServiceCoverage(t *testing.T) {
 	required := []uint8{0x03, 0x05, 0x07, 0x08, 0x09, 0x0F, 0xFE, 0xFF}
 	present := make(map[uint8]bool, len(cat.Services))
 	for _, svc := range cat.Services {
-		present[svc.PB] = true
+		present[svc.PBValue()] = true
 	}
 	for _, pb := range required {
 		if !present[pb] {

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -138,8 +138,8 @@ services:
         safety_class: read_only_bus_load
 `
 	type axis struct {
-		name       string
-		defaults   map[string]string
+		name        string
+		defaults    map[string]string
 		typoedField string
 		typoedValue string
 	}

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -314,6 +314,35 @@ func TestLoadCatalog_EmptyCatalog(t *testing.T) {
 	}
 }
 
+// TestEmbeddedYAML_DefensiveCopy asserts that EmbeddedYAML() returns a
+// fresh copy on every call. Mutating the returned slice must not affect
+// subsequent calls or corrupt the package-global embedded bytes. This
+// guarantees catalog immutability across goroutines and external callers.
+func TestEmbeddedYAML_DefensiveCopy(t *testing.T) {
+	first := EmbeddedYAML()
+	if len(first) == 0 {
+		t.Fatalf("EmbeddedYAML: returned empty slice")
+	}
+	original := first[0]
+	// Mutate the returned slice.
+	first[0] = original ^ 0xFF
+
+	second := EmbeddedYAML()
+	if len(second) != len(first) {
+		t.Fatalf("EmbeddedYAML: length changed between calls: %d vs %d",
+			len(first), len(second))
+	}
+	if second[0] != original {
+		t.Fatalf("EmbeddedYAML: mutation leaked across calls: got 0x%02X, want 0x%02X",
+			second[0], original)
+	}
+	// Embedded baseline must still load successfully after an external
+	// mutation of a prior EmbeddedYAML() return.
+	if _, err := LoadCatalog(EmbeddedYAML()); err != nil {
+		t.Fatalf("LoadCatalog(embedded) after mutation: %v", err)
+	}
+}
+
 // TestLoadCatalog_EmbeddedBaselineLoads asserts that the embedded baseline
 // catalog passes the empty-commands guard — i.e. every declared service has
 // at least one command.

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -228,6 +228,33 @@ func TestLoadCatalog_EmbeddedBaselineLoads(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_TypoNamespace asserts that an identity-key namespace that
+// differs from the fixed Namespace constant (e.g. "ebus_standrad") is
+// rejected at load time with ErrInvalidNamespace. Without this guard, the
+// typo would be silently treated as a distinct identity and bypass the
+// duplicate-14-tuple collision detector.
+func TestLoadCatalog_TypoNamespace(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "typo_namespace.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrInvalidNamespace, got nil")
+	}
+	if !errors.Is(err, ErrInvalidNamespace) {
+		t.Fatalf("LoadCatalog: expected ErrInvalidNamespace, got %v", err)
+	}
+	// Error message must name the field and the bad value for
+	// deterministic diagnosis.
+	if !strings.Contains(err.Error(), "namespace") {
+		t.Fatalf("error %q does not name the field", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ebus_standrad") {
+		t.Fatalf("error %q does not include the bad value", err.Error())
+	}
+}
+
 // TestEmbeddedCatalog_SHAPinning asserts that the embedded catalog carries
 // a ContentSHA256 value and that it matches the SHA of its raw bytes. This
 // enforces the plan's "Catalog is SHA-pinned and version-tagged"

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -463,3 +463,56 @@ func TestEmbeddedCatalog_ServiceCoverage(t *testing.T) {
 		}
 	}
 }
+
+// TestIdentityKeyFingerprint_SliceEncodingIsInjective guards against a
+// regression in which TransportCapabilityRequirements was serialized with
+// %v, causing []string{"a b"} and []string{"a","b"} to produce the same
+// fingerprint ("[a b]") and therefore to collide under
+// ErrDuplicateIdentityKey even though the identities are distinct. The
+// fingerprint MUST distinguish the two shapes.
+func TestIdentityKeyFingerprint_SliceEncodingIsInjective(t *testing.T) {
+	base := IdentityKey{
+		Namespace:                       Namespace,
+		TelegramClass:                   TelegramClassAddressed,
+		Direction:                       DirectionRequest,
+		RequestOrResponseRole:           RoleInitiator,
+		BroadcastOrAddressed:            AddressedDirect,
+		AnswerPolicy:                    AnswerRequired,
+		LengthPrefixMode:                LengthPrefixNone,
+		SelectorDecoder:                 "none",
+		ServiceVariant:                  "sv",
+		Version:                         "v1",
+		SelectorPath:                    "sel",
+		TransportCapabilityRequirements: []string{"a b"},
+	}
+	a := base
+	a.TransportCapabilityRequirements = []string{"a b"}
+	b := base
+	b.TransportCapabilityRequirements = []string{"a", "b"}
+
+	fpA := identityKeyFingerprint(a)
+	fpB := identityKeyFingerprint(b)
+	if fpA == fpB {
+		t.Fatalf("identityKeyFingerprint: collision between []string{\"a b\"} and []string{\"a\",\"b\"}: %q == %q", fpA, fpB)
+	}
+
+	// Also verify other whitespace-sensitive shapes are distinguished.
+	c := base
+	c.TransportCapabilityRequirements = []string{"", "ab"}
+	d := base
+	d.TransportCapabilityRequirements = []string{"ab", ""}
+	if identityKeyFingerprint(c) == identityKeyFingerprint(d) {
+		t.Fatalf("identityKeyFingerprint: collision between [\"\",\"ab\"] and [\"ab\",\"\"]")
+	}
+
+	// Determinism: two distinct IdentityKey values with identical
+	// contents must produce identical fingerprints (guards against any
+	// future incidental map iteration or pointer formatting).
+	e1 := base
+	e1.TransportCapabilityRequirements = []string{"x", "y"}
+	e2 := base
+	e2.TransportCapabilityRequirements = []string{"x", "y"}
+	if identityKeyFingerprint(e1) != identityKeyFingerprint(e2) {
+		t.Fatalf("identityKeyFingerprint: non-deterministic output for equal inputs")
+	}
+}

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -64,6 +64,29 @@ func TestLoadCatalog_AmbiguousLengthSelector_NoneDecoder(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_ServicePBMismatch asserts that a command whose
+// identity.pb differs from the enclosing service.pb is rejected with
+// ErrServicePBMismatch. A typo in the service header would otherwise
+// silently group the command under the wrong service code.
+func TestLoadCatalog_ServicePBMismatch(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "service_pb_mismatch.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	_, err = LoadCatalog(data)
+	if err == nil {
+		t.Fatalf("LoadCatalog: expected ErrServicePBMismatch, got nil")
+	}
+	if !errors.Is(err, ErrServicePBMismatch) {
+		t.Fatalf("LoadCatalog: expected ErrServicePBMismatch, got %v", err)
+	}
+	// Error must name both the service pb and the identity pb for
+	// deterministic diagnosis.
+	if !strings.Contains(err.Error(), "0x07") || !strings.Contains(err.Error(), "0x08") {
+		t.Fatalf("error %q must include both 0x07 and 0x08", err.Error())
+	}
+}
+
 // TestLoadCatalog_MissingPB asserts that a YAML fixture omitting the `pb`
 // key in the identity block is rejected with ErrIncompleteIdentityKey. The
 // value 0x00 must NOT be accepted as a default; absence of the key is the

--- a/catalog/ebus_standard/loader_test.go
+++ b/catalog/ebus_standard/loader_test.go
@@ -516,3 +516,147 @@ func TestIdentityKeyFingerprint_SliceEncodingIsInjective(t *testing.T) {
 		t.Fatalf("identityKeyFingerprint: non-deterministic output for equal inputs")
 	}
 }
+
+// TestIdentityKeyFingerprint_DelimiterInjective guards against a
+// regression in which the fingerprint was rendered as a `|`-delimited
+// format string. Free-form fields (selector_path, selector_decoder,
+// service_variant) that happened to contain delimiter-shaped substrings
+// such as "|sv=" could collapse two distinct identities into the same
+// fingerprint, causing false-positive ErrDuplicateIdentityKey on
+// otherwise valid catalogs. The fingerprint MUST distinguish such
+// shapes — JSON encoding escapes embedded quotes/backslashes and is
+// injective for any string content.
+func TestIdentityKeyFingerprint_DelimiterInjective(t *testing.T) {
+	base := IdentityKey{
+		Namespace:             Namespace,
+		TelegramClass:         TelegramClassAddressed,
+		Direction:             DirectionRequest,
+		RequestOrResponseRole: RoleInitiator,
+		BroadcastOrAddressed:  AddressedDirect,
+		AnswerPolicy:          AnswerRequired,
+		LengthPrefixMode:      LengthPrefixNone,
+		SelectorDecoder:       "decoder",
+		ServiceVariant:        "variant",
+		Version:               "v1",
+		SelectorPath:          "path",
+	}
+
+	// Pair 1: cross-talk between selector_path and selector_decoder via
+	// a `|sd=`-shaped substring. Under the legacy `|`-concat encoding
+	// these two collapsed onto the same fingerprint.
+	a := base
+	a.SelectorPath = "x|sd=y"
+	a.SelectorDecoder = "z"
+	b := base
+	b.SelectorPath = "x"
+	b.SelectorDecoder = "y|sd=z"
+	// Defensive: also vary an unrelated axis between the pair so a
+	// trivially-equal sanity check would still fire if encoding broke.
+	if identityKeyFingerprint(a) == identityKeyFingerprint(b) {
+		t.Fatalf("identityKeyFingerprint: delimiter-shaped substring collision: %q == %q",
+			identityKeyFingerprint(a), identityKeyFingerprint(b))
+	}
+
+	// Pair 2: cross-talk between service_variant and version via a
+	// `|ver=`-shaped substring.
+	c := base
+	c.ServiceVariant = "v1|ver=x"
+	c.Version = "y"
+	d := base
+	d.ServiceVariant = "v1"
+	d.Version = "x|ver=y"
+	if identityKeyFingerprint(c) == identityKeyFingerprint(d) {
+		t.Fatalf("identityKeyFingerprint: service_variant/version delimiter collision: %q == %q",
+			identityKeyFingerprint(c), identityKeyFingerprint(d))
+	}
+
+	// Determinism: identical inputs produce identical fingerprints
+	// across repeated calls (struct field order is compile-time fixed).
+	// Capture the first value, then compare subsequent calls against
+	// it; staticcheck (SA4000) rejects `f(x) != f(x)` even though the
+	// intent is to detect non-deterministic output.
+	first := identityKeyFingerprint(a)
+	for i := 0; i < 8; i++ {
+		if identityKeyFingerprint(a) != first {
+			t.Fatalf("identityKeyFingerprint: non-deterministic across repeated calls (iter %d)", i)
+		}
+	}
+}
+
+// TestDetectAmbiguousLengthSelectors_DelimiterInjective guards against
+// a regression in which the ambiguity-bucket key was built by
+// `|`-joining selector_decoder and selector_path. Two entries whose
+// decoder/path strings contained delimiter-shaped substrings (e.g.
+// `selector_decoder="dec|sel="`) could collapse into the same bucket
+// and be incorrectly flagged with ErrAmbiguousLengthSelector. Distinct
+// axis combinations MUST land in distinct buckets.
+func TestDetectAmbiguousLengthSelectors_DelimiterInjective(t *testing.T) {
+	pb := uint8(0x05)
+	mk := func(id, decoder, path string) Command {
+		return Command{
+			ID:          id,
+			Name:        id,
+			SafetyClass: SafetyReadOnlySafe,
+			Identity: IdentityKey{
+				Namespace:             Namespace,
+				PB:                    &pb,
+				SelectorPath:          path,
+				TelegramClass:         TelegramClassAddressed,
+				Direction:             DirectionRequest,
+				RequestOrResponseRole: RoleInitiator,
+				BroadcastOrAddressed:  AddressedDirect,
+				AnswerPolicy:          AnswerRequired,
+				LengthPrefixMode:      LengthPrefixNone,
+				SelectorDecoder:       decoder,
+				ServiceVariant:        "sv",
+				Version:               "v1",
+			},
+		}
+	}
+	cat := Catalog{
+		Namespace: Namespace,
+		Services: []Service{{
+			PB:   &pb,
+			Name: "svc",
+			Commands: []Command{
+				// Differ ONLY in how a `|`-shaped substring is split
+				// across decoder vs path. Under the legacy concat
+				// these would land in the same bucket.
+				mk("cmd_a", "dec|sel=A", "path"),
+				mk("cmd_b", "dec", "sel=A|path"),
+			},
+		}},
+	}
+
+	// Both commands carry LengthPrefixNone, so even if they DID land in
+	// the same bucket (regression behaviour), no length_prefix_mode
+	// disagreement would surface and the test would silently pass.
+	// Force a disagreement: mutate one to a different lpm value. If
+	// the bucket key is non-injective, the bucket merges and an
+	// ErrAmbiguousLengthSelector is emitted; if injective, the two
+	// land in separate buckets and no error is emitted.
+	cat.Services[0].Commands[1].Identity.LengthPrefixMode = LengthPrefixByte
+
+	if err := detectAmbiguousLengthSelectors(cat); err != nil {
+		t.Fatalf("detectAmbiguousLengthSelectors: false-positive merge of distinct decoder/path tuples: %v", err)
+	}
+
+	// Cross-check: when the on-wire identity axes (and decoder/path)
+	// are genuinely identical and lpm differs, the detector must still
+	// fire. Otherwise the new encoding would have masked a real bug.
+	cat2 := Catalog{
+		Namespace: Namespace,
+		Services: []Service{{
+			PB:   &pb,
+			Name: "svc",
+			Commands: []Command{
+				mk("cmd_x", "dec", "sel=A|path"),
+				mk("cmd_y", "dec", "sel=A|path"),
+			},
+		}},
+	}
+	cat2.Services[0].Commands[1].Identity.LengthPrefixMode = LengthPrefixByte
+	if err := detectAmbiguousLengthSelectors(cat2); err == nil {
+		t.Fatalf("detectAmbiguousLengthSelectors: expected ErrAmbiguousLengthSelector for genuine collision, got nil")
+	}
+}

--- a/catalog/ebus_standard/loader_tinygo.go
+++ b/catalog/ebus_standard/loader_tinygo.go
@@ -1,0 +1,33 @@
+//go:build tinygo
+// +build tinygo
+
+package ebus_standard_catalog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+)
+
+// ErrTinyGoUnsupported is returned by LoadCatalog on TinyGo builds. The
+// full loader depends on gopkg.in/yaml.v3, which is not compatible with
+// TinyGo's reflection subset. TinyGo consumers are expected to use
+// pre-validated catalogs (e.g. embedded JSON or a generated Go literal)
+// produced on the host side; parsing raw YAML at runtime is not supported.
+var ErrTinyGoUnsupported = errors.New(
+	"ebus_standard: YAML catalog loading is not supported on TinyGo builds")
+
+// loadCatalogImpl is the TinyGo-build stub. It satisfies the dispatch
+// declared in loader.go without pulling in gopkg.in/yaml.v3.
+func loadCatalogImpl(_ []byte) (Catalog, error) {
+	return Catalog{}, ErrTinyGoUnsupported
+}
+
+// ComputeContentSHA256 returns the lowercase hex SHA-256 of the given
+// bytes. Provided on TinyGo builds so consumers that receive catalogs by
+// another path (embedded literal, pre-serialised snapshot) can still
+// compute / verify content hashes.
+func ComputeContentSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -27,13 +27,23 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 	// Validate identity-key completeness and check safety_class values.
 	for si := range cat.Services {
 		svc := &cat.Services[si]
+		// Reject services without an explicit `pb:` key. A value-typed
+		// uint8 would silently deserialize omission as 0x00 and defeat
+		// the service/identity mismatch check below when an identity.pb
+		// also happens to be 0x00. Presence is checked before the empty-
+		// commands guard so that diagnostics include the pb axis even
+		// when multiple fields are malformed.
+		if svc.PB == nil {
+			return Catalog{}, fmt.Errorf("%w: service %q",
+				ErrServiceMissingPB, svc.Name)
+		}
 		// Reject services with no commands. An empty commands list is
 		// almost always a YAML typo (wrong key name, missing block) and
 		// must fail loudly rather than silently accept a service with no
 		// method definitions.
 		if len(svc.Commands) == 0 {
 			return Catalog{}, fmt.Errorf("%w: service %q (pb=0x%02X)",
-				ErrServiceMissingCommands, svc.Name, svc.PB)
+				ErrServiceMissingCommands, svc.Name, svc.PBValue())
 		}
 		for ci := range svc.Commands {
 			cmd := &svc.Commands[ci]
@@ -48,10 +58,10 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 			// code. IsComplete() only asserts PB is non-nil, and the
 			// duplicate detector fingerprints the identity pb (not the
 			// service pb), so a mismatch is invisible without this check.
-			if cmd.Identity.PBValue() != svc.PB {
+			if cmd.Identity.PBValue() != svc.PBValue() {
 				return Catalog{}, fmt.Errorf(
 					"%w: service %q pb=0x%02X, command %q identity.pb=0x%02X",
-					ErrServicePBMismatch, svc.Name, svc.PB, cmd.ID, cmd.Identity.PBValue())
+					ErrServicePBMismatch, svc.Name, svc.PBValue(), cmd.ID, cmd.Identity.PBValue())
 			}
 			if !isKnownSafetyClass(cmd.SafetyClass) {
 				return Catalog{}, fmt.Errorf("%w: command %q safety_class=%q", ErrUnknownSafetyClass, cmd.ID, cmd.SafetyClass)

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -40,6 +40,9 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 			if !cmd.Identity.IsComplete() {
 				return Catalog{}, fmt.Errorf("%w: command %q", ErrIncompleteIdentityKey, cmd.ID)
 			}
+			if err := validateNamespace(cmd.ID, cmd.Identity); err != nil {
+				return Catalog{}, err
+			}
 			if !isKnownSafetyClass(cmd.SafetyClass) {
 				return Catalog{}, fmt.Errorf("%w: command %q safety_class=%q", ErrUnknownSafetyClass, cmd.ID, cmd.SafetyClass)
 			}
@@ -108,6 +111,18 @@ func validateIdentityEnums(cmdID string, k IdentityKey) error {
 	default:
 		return fmt.Errorf("%w: command %q field=length_prefix_mode value=%q",
 			ErrUnknownEnumValue, cmdID, k.LengthPrefixMode)
+	}
+	return nil
+}
+
+// validateNamespace enforces that the identity-key namespace matches the
+// package's fixed Namespace constant exactly. IdentityKey.IsComplete() only
+// asserts non-emptiness, so a typo like "ebus_standrad" would otherwise slip
+// through and bypass duplicate detection (fingerprints include Namespace).
+func validateNamespace(cmdID string, k IdentityKey) error {
+	if k.Namespace != Namespace {
+		return fmt.Errorf("%w: command %q field=namespace value=%q",
+			ErrInvalidNamespace, cmdID, k.Namespace)
 	}
 	return nil
 }

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -24,6 +24,18 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 		cat.Namespace = Namespace
 	}
 
+	// Reject catalogs with no services at all. A YAML document that omits
+	// the `services:` key (or supplies an empty list) would otherwise load
+	// successfully as an effectively empty catalog, silently dropping every
+	// method definition at runtime and bypassing the per-service typo/
+	// omission guards (ErrServiceMissingPB, ErrServiceMissingCommands,
+	// identity/namespace checks, duplicate detection). Fail fast here so a
+	// malformed document cannot masquerade as a valid (but empty) catalog.
+	if len(cat.Services) == 0 {
+		return Catalog{}, fmt.Errorf("%w: document has no services: entries",
+			ErrCatalogMissingServices)
+	}
+
 	// Validate identity-key completeness and check safety_class values.
 	for si := range cat.Services {
 		svc := &cat.Services[si]

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -226,9 +226,21 @@ func detectAmbiguousLengthSelectors(cat Catalog) error {
 			if decoder == "" {
 				decoder = "none"
 			}
+			// When there is no selector branch (decoder == "none"),
+			// selector_path is not a real disambiguator: with no decoder
+			// to interpret it, the value is inert at decode time. Two
+			// entries with the same on-wire identity and different
+			// length_prefix_mode values must still collide even if they
+			// carry different selector_path strings, otherwise a YAML
+			// typo or cosmetic difference bypasses the ambiguity check.
+			// Drop selector_path from the bundling key in this case.
+			selectorPath := k.SelectorPath
+			if decoder == "none" {
+				selectorPath = ""
+			}
 			key := fmt.Sprintf("%s|%02X|%02X|%s|%s|%s|%s",
 				k.Namespace, k.PBValue(), k.SBValue(), decoder,
-				k.SelectorPath, k.Direction, k.RequestOrResponseRole)
+				selectorPath, k.Direction, k.RequestOrResponseRole)
 			buckets[key] = append(buckets[key], bucket{cmd.ID, k.LengthPrefixMode})
 		}
 	}

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -35,6 +35,9 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 			if !isKnownSafetyClass(cmd.SafetyClass) {
 				return Catalog{}, fmt.Errorf("%w: command %q safety_class=%q", ErrUnknownSafetyClass, cmd.ID, cmd.SafetyClass)
 			}
+			if err := validateIdentityEnums(cmd.ID, cmd.Identity); err != nil {
+				return Catalog{}, err
+			}
 		}
 	}
 
@@ -50,6 +53,55 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 
 	cat.ContentSHA256 = ComputeContentSHA256(data)
 	return cat, nil
+}
+
+// validateIdentityEnums checks every enum-typed identity axis against the
+// constants declared in identity.go. Any value that is non-empty but not
+// one of the enumerated constants is rejected with ErrUnknownEnumValue so
+// typos fail deterministically at load time rather than silently breaking
+// downstream matching.
+//
+// Empty values are NOT handled here — they are caught earlier by
+// IdentityKey.IsComplete(), which returns ErrIncompleteIdentityKey.
+func validateIdentityEnums(cmdID string, k IdentityKey) error {
+	switch k.TelegramClass {
+	case TelegramClassAddressed, TelegramClassBroadcast,
+		TelegramClassInitiatorInitiator, TelegramClassControllerBroadcast:
+	default:
+		return fmt.Errorf("%w: command %q field=telegram_class value=%q",
+			ErrUnknownEnumValue, cmdID, k.TelegramClass)
+	}
+	switch k.Direction {
+	case DirectionRequest, DirectionResponse:
+	default:
+		return fmt.Errorf("%w: command %q field=direction value=%q",
+			ErrUnknownEnumValue, cmdID, k.Direction)
+	}
+	switch k.RequestOrResponseRole {
+	case RoleInitiator, RoleResponder, RoleOriginator:
+	default:
+		return fmt.Errorf("%w: command %q field=request_or_response_role value=%q",
+			ErrUnknownEnumValue, cmdID, k.RequestOrResponseRole)
+	}
+	switch k.BroadcastOrAddressed {
+	case AddressedDirect, AddressedBroadcast:
+	default:
+		return fmt.Errorf("%w: command %q field=broadcast_or_addressed value=%q",
+			ErrUnknownEnumValue, cmdID, k.BroadcastOrAddressed)
+	}
+	switch k.AnswerPolicy {
+	case AnswerRequired, AnswerNone:
+	default:
+		return fmt.Errorf("%w: command %q field=answer_policy value=%q",
+			ErrUnknownEnumValue, cmdID, k.AnswerPolicy)
+	}
+	switch k.LengthPrefixMode {
+	case LengthPrefixNone, LengthPrefixFixed, LengthPrefixByte, LengthPrefixTypedPayload:
+	default:
+		return fmt.Errorf("%w: command %q field=length_prefix_mode value=%q",
+			ErrUnknownEnumValue, cmdID, k.LengthPrefixMode)
+	}
+	return nil
 }
 
 func isKnownSafetyClass(s SafetyClass) bool {

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -1,0 +1,7 @@
+package ebus_standard_catalog
+
+// loadCatalogImpl is the real implementation path. M2 RED leaves this as a
+// panicking stub; the GREEN implementation replaces the body.
+func loadCatalogImpl(data []byte) (Catalog, error) {
+	panic("not implemented: ebus_standard catalog loader (M2 RED stub)")
+}

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -1,3 +1,6 @@
+//go:build !tinygo
+// +build !tinygo
+
 package ebus_standard_catalog
 
 import (

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -66,7 +66,7 @@ func isKnownSafetyClass(s SafetyClass) bool {
 func identityKeyFingerprint(k IdentityKey) string {
 	return fmt.Sprintf(
 		"ns=%s|pb=%02X|sb=%02X|sel=%s|tc=%s|dir=%s|rr=%s|ba=%s|ap=%s|lpm=%s|sd=%s|sv=%s|tcr=%v|ver=%s",
-		k.Namespace, k.PB, k.SB, k.SelectorPath, k.TelegramClass, k.Direction,
+		k.Namespace, k.PBValue(), k.SBValue(), k.SelectorPath, k.TelegramClass, k.Direction,
 		k.RequestOrResponseRole, k.BroadcastOrAddressed, k.AnswerPolicy,
 		k.LengthPrefixMode, k.SelectorDecoder, k.ServiceVariant,
 		k.TransportCapabilityRequirements, k.Version,
@@ -107,7 +107,7 @@ func detectAmbiguousLengthSelectors(cat Catalog) error {
 				continue
 			}
 			key := fmt.Sprintf("%s|%02X|%02X|%s|%s|%s|%s",
-				k.Namespace, k.PB, k.SB, k.SelectorDecoder,
+				k.Namespace, k.PBValue(), k.SBValue(), k.SelectorDecoder,
 				k.SelectorPath, k.Direction, k.RequestOrResponseRole)
 			buckets[key] = append(buckets[key], bucket{cmd.ID, k.LengthPrefixMode})
 		}

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -27,6 +27,14 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 	// Validate identity-key completeness and check safety_class values.
 	for si := range cat.Services {
 		svc := &cat.Services[si]
+		// Reject services with no commands. An empty commands list is
+		// almost always a YAML typo (wrong key name, missing block) and
+		// must fail loudly rather than silently accept a service with no
+		// method definitions.
+		if len(svc.Commands) == 0 {
+			return Catalog{}, fmt.Errorf("%w: service %q (pb=0x%02X)",
+				ErrServiceMissingCommands, svc.Name, svc.PB)
+		}
 		for ci := range svc.Commands {
 			cmd := &svc.Commands[ci]
 			if !cmd.Identity.IsComplete() {

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -43,6 +43,16 @@ func loadCatalogImpl(data []byte) (Catalog, error) {
 			if err := validateNamespace(cmd.ID, cmd.Identity); err != nil {
 				return Catalog{}, err
 			}
+			// Guard against a typo in the service header that would
+			// otherwise silently group commands under the wrong service
+			// code. IsComplete() only asserts PB is non-nil, and the
+			// duplicate detector fingerprints the identity pb (not the
+			// service pb), so a mismatch is invisible without this check.
+			if cmd.Identity.PBValue() != svc.PB {
+				return Catalog{}, fmt.Errorf(
+					"%w: service %q pb=0x%02X, command %q identity.pb=0x%02X",
+					ErrServicePBMismatch, svc.Name, svc.PB, cmd.ID, cmd.Identity.PBValue())
+			}
 			if !isKnownSafetyClass(cmd.SafetyClass) {
 				return Catalog{}, fmt.Errorf("%w: command %q safety_class=%q", ErrUnknownSafetyClass, cmd.ID, cmd.SafetyClass)
 			}

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -169,6 +169,12 @@ func detectDuplicateIdentityKeys(cat Catalog) error {
 // disambiguated at decode time because the only differing axis is the
 // length-prefix rule itself, which the decoder applies BEFORE it knows
 // which branch to pick.
+//
+// When selector_decoder is "none" (or empty), there is no selector branch
+// at all — so two entries sharing the remaining on-wire identity axes but
+// differing only by length_prefix_mode are STILL ambiguous (there is no
+// branch to disambiguate on). These cases are bundled under a canonical
+// "none" decoder key rather than skipped.
 func detectAmbiguousLengthSelectors(cat Catalog) error {
 	type bucket struct {
 		cmdID string
@@ -178,11 +184,15 @@ func detectAmbiguousLengthSelectors(cat Catalog) error {
 	for _, svc := range cat.Services {
 		for _, cmd := range svc.Commands {
 			k := cmd.Identity
-			if k.SelectorDecoder == "" || k.SelectorDecoder == "none" {
-				continue
+			// Canonicalise empty selector_decoder to "none" so that the
+			// two values are treated as the same bundling axis and do not
+			// fragment otherwise-ambiguous buckets.
+			decoder := k.SelectorDecoder
+			if decoder == "" {
+				decoder = "none"
 			}
 			key := fmt.Sprintf("%s|%02X|%02X|%s|%s|%s|%s",
-				k.Namespace, k.PBValue(), k.SBValue(), k.SelectorDecoder,
+				k.Namespace, k.PBValue(), k.SBValue(), decoder,
 				k.SelectorPath, k.Direction, k.RequestOrResponseRole)
 			buckets[key] = append(buckets[key], bucket{cmd.ID, k.LengthPrefixMode})
 		}

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -1,7 +1,137 @@
 package ebus_standard_catalog
 
-// loadCatalogImpl is the real implementation path. M2 RED leaves this as a
-// panicking stub; the GREEN implementation replaces the body.
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// loadCatalogImpl parses a YAML document, validates it, and populates
+// ContentSHA256 from the raw bytes. It returns a wrapped sentinel error on
+// collision or ambiguity.
 func loadCatalogImpl(data []byte) (Catalog, error) {
-	panic("not implemented: ebus_standard catalog loader (M2 RED stub)")
+	var cat Catalog
+	if err := yaml.Unmarshal(data, &cat); err != nil {
+		return Catalog{}, fmt.Errorf("ebus_standard: yaml unmarshal: %w", err)
+	}
+
+	// Default namespace from constant when not explicitly set. Every
+	// identity key must still carry it, but the document-level namespace
+	// is informational.
+	if cat.Namespace == "" {
+		cat.Namespace = Namespace
+	}
+
+	// Validate identity-key completeness and check safety_class values.
+	for si := range cat.Services {
+		svc := &cat.Services[si]
+		for ci := range svc.Commands {
+			cmd := &svc.Commands[ci]
+			if !cmd.Identity.IsComplete() {
+				return Catalog{}, fmt.Errorf("%w: command %q", ErrIncompleteIdentityKey, cmd.ID)
+			}
+			if !isKnownSafetyClass(cmd.SafetyClass) {
+				return Catalog{}, fmt.Errorf("%w: command %q safety_class=%q", ErrUnknownSafetyClass, cmd.ID, cmd.SafetyClass)
+			}
+		}
+	}
+
+	// Duplicate 14-tuple detection.
+	if err := detectDuplicateIdentityKeys(cat); err != nil {
+		return Catalog{}, err
+	}
+
+	// Ambiguous length-selector detection.
+	if err := detectAmbiguousLengthSelectors(cat); err != nil {
+		return Catalog{}, err
+	}
+
+	cat.ContentSHA256 = ComputeContentSHA256(data)
+	return cat, nil
+}
+
+func isKnownSafetyClass(s SafetyClass) bool {
+	switch s {
+	case SafetyReadOnlySafe, SafetyReadOnlyBusLoad, SafetyMutating,
+		SafetyDestructive, SafetyBroadcast, SafetyMemoryWrite:
+		return true
+	}
+	return false
+}
+
+// identityKeyFingerprint returns a deterministic string covering every
+// field of the 14-tuple. Equal fingerprints mean duplicate identity keys.
+func identityKeyFingerprint(k IdentityKey) string {
+	return fmt.Sprintf(
+		"ns=%s|pb=%02X|sb=%02X|sel=%s|tc=%s|dir=%s|rr=%s|ba=%s|ap=%s|lpm=%s|sd=%s|sv=%s|tcr=%v|ver=%s",
+		k.Namespace, k.PB, k.SB, k.SelectorPath, k.TelegramClass, k.Direction,
+		k.RequestOrResponseRole, k.BroadcastOrAddressed, k.AnswerPolicy,
+		k.LengthPrefixMode, k.SelectorDecoder, k.ServiceVariant,
+		k.TransportCapabilityRequirements, k.Version,
+	)
+}
+
+func detectDuplicateIdentityKeys(cat Catalog) error {
+	seen := make(map[string]string)
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			fp := identityKeyFingerprint(cmd.Identity)
+			if prev, ok := seen[fp]; ok {
+				return fmt.Errorf("%w: %q collides with %q (fingerprint=%s)",
+					ErrDuplicateIdentityKey, cmd.ID, prev, fp)
+			}
+			seen[fp] = cmd.ID
+		}
+	}
+	return nil
+}
+
+// detectAmbiguousLengthSelectors flags entries that share
+// (namespace, PB, SB, selector_decoder, selector_path, direction, role) but
+// carry incompatible length_prefix_mode values. Such entries cannot be
+// disambiguated at decode time because the only differing axis is the
+// length-prefix rule itself, which the decoder applies BEFORE it knows
+// which branch to pick.
+func detectAmbiguousLengthSelectors(cat Catalog) error {
+	type bucket struct {
+		cmdID string
+		lpm   LengthPrefixMode
+	}
+	buckets := make(map[string][]bucket)
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			k := cmd.Identity
+			if k.SelectorDecoder == "" || k.SelectorDecoder == "none" {
+				continue
+			}
+			key := fmt.Sprintf("%s|%02X|%02X|%s|%s|%s|%s",
+				k.Namespace, k.PB, k.SB, k.SelectorDecoder,
+				k.SelectorPath, k.Direction, k.RequestOrResponseRole)
+			buckets[key] = append(buckets[key], bucket{cmd.ID, k.LengthPrefixMode})
+		}
+	}
+	for key, entries := range buckets {
+		if len(entries) < 2 {
+			continue
+		}
+		// Ambiguous if any two entries in the same bucket have different
+		// length_prefix_mode values.
+		first := entries[0].lpm
+		for _, e := range entries[1:] {
+			if e.lpm != first {
+				return fmt.Errorf("%w: bucket %s: %q(lpm=%s) vs %q(lpm=%s)",
+					ErrAmbiguousLengthSelector, key,
+					entries[0].cmdID, first, e.cmdID, e.lpm)
+			}
+		}
+	}
+	return nil
+}
+
+// ComputeContentSHA256 returns the lowercase hex SHA-256 of the given bytes.
+func ComputeContentSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -6,6 +6,7 @@ package ebus_standard_catalog
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -173,13 +174,29 @@ func isKnownSafetyClass(s SafetyClass) bool {
 
 // identityKeyFingerprint returns a deterministic string covering every
 // field of the 14-tuple. Equal fingerprints mean duplicate identity keys.
+//
+// Slice/map fields MUST be serialized with an injective encoding: naive
+// %v formatting of []string renders both []string{"a b"} and
+// []string{"a","b"} as "[a b]", which would collapse two distinct
+// identities into one fingerprint and cause false-positive
+// ErrDuplicateIdentityKey (or, worse, hide real collisions). JSON
+// encoding is canonical, escapes embedded separators, and round-trips
+// losslessly for any []string, so it is used for every slice/map field
+// in the tuple (currently just TransportCapabilityRequirements).
 func identityKeyFingerprint(k IdentityKey) string {
+	tcrJSON, err := json.Marshal(k.TransportCapabilityRequirements)
+	if err != nil {
+		// json.Marshal of []string cannot fail in practice; fall back to
+		// a clearly non-injective sentinel so a future failure is
+		// visible rather than silently masked.
+		tcrJSON = []byte(fmt.Sprintf("<json-error:%v>", err))
+	}
 	return fmt.Sprintf(
-		"ns=%s|pb=%02X|sb=%02X|sel=%s|tc=%s|dir=%s|rr=%s|ba=%s|ap=%s|lpm=%s|sd=%s|sv=%s|tcr=%v|ver=%s",
+		"ns=%s|pb=%02X|sb=%02X|sel=%s|tc=%s|dir=%s|rr=%s|ba=%s|ap=%s|lpm=%s|sd=%s|sv=%s|tcr=%s|ver=%s",
 		k.Namespace, k.PBValue(), k.SBValue(), k.SelectorPath, k.TelegramClass, k.Direction,
 		k.RequestOrResponseRole, k.BroadcastOrAddressed, k.AnswerPolicy,
 		k.LengthPrefixMode, k.SelectorDecoder, k.ServiceVariant,
-		k.TransportCapabilityRequirements, k.Version,
+		string(tcrJSON), k.Version,
 	)
 }
 

--- a/catalog/ebus_standard/loader_yaml.go
+++ b/catalog/ebus_standard/loader_yaml.go
@@ -175,29 +175,57 @@ func isKnownSafetyClass(s SafetyClass) bool {
 // identityKeyFingerprint returns a deterministic string covering every
 // field of the 14-tuple. Equal fingerprints mean duplicate identity keys.
 //
-// Slice/map fields MUST be serialized with an injective encoding: naive
-// %v formatting of []string renders both []string{"a b"} and
-// []string{"a","b"} as "[a b]", which would collapse two distinct
-// identities into one fingerprint and cause false-positive
-// ErrDuplicateIdentityKey (or, worse, hide real collisions). JSON
-// encoding is canonical, escapes embedded separators, and round-trips
-// losslessly for any []string, so it is used for every slice/map field
-// in the tuple (currently just TransportCapabilityRequirements).
+// The fingerprint MUST be injective for any combination of free-form
+// string field values. A previous implementation used a `|`-delimited
+// format string, which collapsed distinct identities whenever a
+// free-form field (e.g. selector_path, selector_decoder, service_variant)
+// contained delimiter-shaped substrings such as "|sv=". The current
+// implementation serializes a purpose-built struct via json.Marshal:
+// JSON escapes embedded quotes/backslashes, the struct's compile-time
+// field order makes the byte output deterministic, and the encoding is
+// lossless and injective for arbitrary string content (including
+// embedded `|`, `=`, quotes, and slice element boundaries).
 func identityKeyFingerprint(k IdentityKey) string {
-	tcrJSON, err := json.Marshal(k.TransportCapabilityRequirements)
-	if err != nil {
-		// json.Marshal of []string cannot fail in practice; fall back to
-		// a clearly non-injective sentinel so a future failure is
-		// visible rather than silently masked.
-		tcrJSON = []byte(fmt.Sprintf("<json-error:%v>", err))
+	// Struct (not map) so JSON field order is fixed at compile time.
+	fp := struct {
+		Namespace                       string
+		PB                              uint8
+		SB                              uint8
+		SelectorPath                    string
+		TelegramClass                   string
+		Direction                       string
+		RequestOrResponseRole           string
+		BroadcastOrAddressed            string
+		AnswerPolicy                    string
+		LengthPrefixMode                string
+		SelectorDecoder                 string
+		ServiceVariant                  string
+		TransportCapabilityRequirements []string
+		Version                         string
+	}{
+		Namespace:                       k.Namespace,
+		PB:                              k.PBValue(),
+		SB:                              k.SBValue(),
+		SelectorPath:                    k.SelectorPath,
+		TelegramClass:                   string(k.TelegramClass),
+		Direction:                       string(k.Direction),
+		RequestOrResponseRole:           string(k.RequestOrResponseRole),
+		BroadcastOrAddressed:            string(k.BroadcastOrAddressed),
+		AnswerPolicy:                    string(k.AnswerPolicy),
+		LengthPrefixMode:                string(k.LengthPrefixMode),
+		SelectorDecoder:                 k.SelectorDecoder,
+		ServiceVariant:                  k.ServiceVariant,
+		TransportCapabilityRequirements: k.TransportCapabilityRequirements,
+		Version:                         k.Version,
 	}
-	return fmt.Sprintf(
-		"ns=%s|pb=%02X|sb=%02X|sel=%s|tc=%s|dir=%s|rr=%s|ba=%s|ap=%s|lpm=%s|sd=%s|sv=%s|tcr=%s|ver=%s",
-		k.Namespace, k.PBValue(), k.SBValue(), k.SelectorPath, k.TelegramClass, k.Direction,
-		k.RequestOrResponseRole, k.BroadcastOrAddressed, k.AnswerPolicy,
-		k.LengthPrefixMode, k.SelectorDecoder, k.ServiceVariant,
-		string(tcrJSON), k.Version,
-	)
+	b, err := json.Marshal(fp)
+	if err != nil {
+		// json.Marshal of strings/[]string/uint8 cannot fail in practice;
+		// fall back to a clearly non-injective sentinel so a future
+		// failure is visible rather than silently masked.
+		return fmt.Sprintf("<json-error:%v>", err)
+	}
+	return string(b)
 }
 
 func detectDuplicateIdentityKeys(cat Catalog) error {
@@ -255,9 +283,39 @@ func detectAmbiguousLengthSelectors(cat Catalog) error {
 			if decoder == "none" {
 				selectorPath = ""
 			}
-			key := fmt.Sprintf("%s|%02X|%02X|%s|%s|%s|%s",
-				k.Namespace, k.PBValue(), k.SBValue(), decoder,
-				selectorPath, k.Direction, k.RequestOrResponseRole)
+			// Bucket key MUST be injective for any free-form field
+			// content. A `|`-delimited concat collapses distinct buckets
+			// when selector_decoder or selector_path contain
+			// delimiter-shaped substrings; serialize a struct via
+			// json.Marshal so embedded `|`/`=`/quotes are escaped and
+			// the encoding is lossless. Struct field order is fixed at
+			// compile time, so the resulting bytes are deterministic.
+			axes := struct {
+				Namespace             string
+				PB                    uint8
+				SB                    uint8
+				Decoder               string
+				SelectorPath          string
+				Direction             string
+				RequestOrResponseRole string
+			}{
+				Namespace:             k.Namespace,
+				PB:                    k.PBValue(),
+				SB:                    k.SBValue(),
+				Decoder:               decoder,
+				SelectorPath:          selectorPath,
+				Direction:             string(k.Direction),
+				RequestOrResponseRole: string(k.RequestOrResponseRole),
+			}
+			keyBytes, err := json.Marshal(axes)
+			if err != nil {
+				// json.Marshal of strings/uint8 cannot fail in practice;
+				// fall back to a sentinel that is unique-per-error so a
+				// future failure surfaces rather than silently merging
+				// distinct buckets.
+				keyBytes = []byte(fmt.Sprintf("<json-error:%v:%s>", err, cmd.ID))
+			}
+			key := string(keyBytes)
 			buckets[key] = append(buckets[key], bucket{cmd.ID, k.LengthPrefixMode})
 		}
 	}

--- a/catalog/ebus_standard/testdata/ambiguous_length_selector.yaml
+++ b/catalog/ebus_standard/testdata/ambiguous_length_selector.yaml
@@ -1,0 +1,46 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x05
+    name: Burner Control
+    commands:
+      # Two entries share (namespace, PB=0x05, SB=0x03, selector_decoder=block_number)
+      # but declare incompatible length_prefix_mode values. Decode time has no
+      # way to pick a branch, so generation must fail.
+      - id: ebus_standard.burner.operational_data.block_ambiguous_fixed
+        name: Operational Data, block 1 (fixed-length variant)
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x03
+          selector_path: block_number=0x01
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: block_number
+          service_variant: operational_data_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.operational_data.block_ambiguous_byte
+        name: Operational Data, block 1 (byte-prefix variant)
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x03
+          selector_path: block_number=0x01
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: block_number
+          service_variant: operational_data_block
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating

--- a/catalog/ebus_standard/testdata/ambiguous_length_selector_none_decoder.yaml
+++ b/catalog/ebus_standard/testdata/ambiguous_length_selector_none_decoder.yaml
@@ -1,0 +1,47 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x05
+    name: Burner Control
+    commands:
+      # Two entries share (namespace, PB=0x05, SB=0x07, direction=response,
+      # role=responder) with selector_decoder="none" but declare incompatible
+      # length_prefix_mode values. With no selector branch available, the
+      # decoder cannot pick between fixed and byte_prefix at decode time.
+      - id: ebus_standard.burner.none_decoder_fixed
+        name: None-decoder fixed variant
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x07
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: none_decoder_fixed
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.none_decoder_byte
+        name: None-decoder byte-prefix variant
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x07
+          selector_path: ""
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: none_decoder_byte
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating

--- a/catalog/ebus_standard/testdata/ambiguous_length_selector_none_decoder_with_path.yaml
+++ b/catalog/ebus_standard/testdata/ambiguous_length_selector_none_decoder_with_path.yaml
@@ -1,0 +1,49 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x05
+    name: Burner Control
+    commands:
+      # Two entries share (namespace, PB=0x05, SB=0x07, direction=response,
+      # role=responder) with selector_decoder="none". They carry DIFFERENT
+      # selector_path strings, but with no decoder to interpret the path
+      # it is inert at decode time and cannot disambiguate the branches.
+      # Their length_prefix_mode values differ, so the ambiguity detector
+      # must still bundle them together and reject the pair.
+      - id: ebus_standard.burner.none_decoder_path_a_fixed
+        name: None-decoder selector_path=a fixed variant
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x07
+          selector_path: "$.payload.a"
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: fixed
+          selector_decoder: none
+          service_variant: none_decoder_path_a_fixed
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating
+      - id: ebus_standard.burner.none_decoder_path_b_byte
+        name: None-decoder selector_path=b byte-prefix variant
+        identity:
+          namespace: ebus_standard
+          pb: 0x05
+          sb: 0x07
+          selector_path: "$.payload.b"
+          telegram_class: addressed
+          direction: response
+          request_or_response_role: responder
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: byte_prefix
+          selector_decoder: none
+          service_variant: none_decoder_path_b_byte
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: mutating

--- a/catalog/ebus_standard/testdata/collision_duplicate.yaml
+++ b/catalog/ebus_standard/testdata/collision_duplicate.yaml
@@ -1,0 +1,43 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data
+    commands:
+      - id: ebus_standard.system_data.identification.addressed
+        name: Identification (addressed)
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: identification_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load
+      - id: ebus_standard.system_data.identification.addressed_duplicate
+        name: Identification (duplicate planted)
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: identification_query
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/catalog/ebus_standard/testdata/empty_catalog.yaml
+++ b/catalog/ebus_standard/testdata/empty_catalog.yaml
@@ -1,0 +1,6 @@
+# Fixture: catalog document with no `services:` key at all.
+# LoadCatalog must reject with ErrCatalogMissingServices, not silently
+# return an empty catalog.
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305

--- a/catalog/ebus_standard/testdata/explicit_zero_pb_sb.yaml
+++ b/catalog/ebus_standard/testdata/explicit_zero_pb_sb.yaml
@@ -1,0 +1,25 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x00
+    name: Explicit-Zero Service
+    commands:
+      - id: ebus_standard.explicit_zero_pb_sb
+        name: Explicitly-set zero PB/SB (legitimate)
+        identity:
+          namespace: ebus_standard
+          pb: 0x00
+          sb: 0x00
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: test_variant
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/catalog/ebus_standard/testdata/missing_pb.yaml
+++ b/catalog/ebus_standard/testdata/missing_pb.yaml
@@ -1,0 +1,25 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data
+    commands:
+      - id: ebus_standard.missing_pb
+        name: Missing PB identity key
+        identity:
+          namespace: ebus_standard
+          # pb intentionally omitted — loader MUST reject
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: test_variant
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/catalog/ebus_standard/testdata/missing_sb.yaml
+++ b/catalog/ebus_standard/testdata/missing_sb.yaml
@@ -1,0 +1,25 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data
+    commands:
+      - id: ebus_standard.missing_sb
+        name: Missing SB identity key
+        identity:
+          namespace: ebus_standard
+          pb: 0x07
+          # sb intentionally omitted — loader MUST reject
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: test_variant
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/catalog/ebus_standard/testdata/service_missing_pb.yaml
+++ b/catalog/ebus_standard/testdata/service_missing_pb.yaml
@@ -1,0 +1,28 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  # Service header intentionally omits the `pb:` key. A value-typed uint8
+  # would deserialize the omission as 0x00 and silently match a command
+  # whose identity.pb is also 0x00, defeating the service/identity pb
+  # mismatch check. The loader MUST reject this with ErrServiceMissingPB.
+  - name: System Data (missing pb header)
+    commands:
+      - id: ebus_standard.service_missing_pb_probe
+        name: Service-missing-pb probe
+        identity:
+          namespace: ebus_standard
+          pb: 0x00
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: missing_pb_probe
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/catalog/ebus_standard/testdata/service_pb_mismatch.yaml
+++ b/catalog/ebus_standard/testdata/service_pb_mismatch.yaml
@@ -1,0 +1,29 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  # Service header says pb=0x07 (System Data) but the command inside carries
+  # identity.pb=0x08 (Device ID service). A typo in the service header must
+  # fail loudly rather than silently group this command under the wrong
+  # service code.
+  - pb: 0x07
+    name: System Data (typoed header)
+    commands:
+      - id: ebus_standard.pb_mismatch_probe
+        name: Service-pb mismatch probe
+        identity:
+          namespace: ebus_standard
+          pb: 0x08
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: mismatch_probe
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/catalog/ebus_standard/testdata/service_without_commands.yaml
+++ b/catalog/ebus_standard/testdata/service_without_commands.yaml
@@ -1,0 +1,9 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data (typoed commands key)
+    # The `commands:` key is intentionally omitted. A malformed catalog
+    # that drops the commands block must be rejected loudly rather than
+    # loaded as an empty service with no method definitions.

--- a/catalog/ebus_standard/testdata/typo_namespace.yaml
+++ b/catalog/ebus_standard/testdata/typo_namespace.yaml
@@ -1,0 +1,25 @@
+namespace: ebus_standard
+version: v1.0-locked
+plan_sha256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+services:
+  - pb: 0x07
+    name: System Data
+    commands:
+      - id: ebus_standard.typo_namespace
+        name: Typoed namespace identity key
+        identity:
+          namespace: ebus_standrad
+          pb: 0x07
+          sb: 0x04
+          selector_path: ""
+          telegram_class: addressed
+          direction: request
+          request_or_response_role: initiator
+          broadcast_or_addressed: addressed
+          answer_policy: answer_required
+          length_prefix_mode: none
+          selector_decoder: none
+          service_variant: test_variant
+          transport_capability_requirements: [master_slave]
+          version: v1.0-locked
+        safety_class: read_only_bus_load

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/Project-Helianthus/helianthus-ebusreg
 go 1.22
 
 require github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f h1:mBTY1wIlBqiS43yvPKfj8bH0klxtv1g2NFeza7gTPWs=
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
M2 milestone of ebus-standard-l7-services-w16-26 locked plan. Implements the `ebus_standard` catalog: Go schema + YAML data file with full 14-tuple identity key, generation-time collision detection, length-selector ambiguity detection, SHA pinning, and version tagging.

## Companion docs
Normative spec: [helianthus-docs-ebus `architecture/ebus_standard/01-services-catalog.md`](https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/ebus_standard/01-services-catalog.md) and [`05-execution-safety.md`](https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/ebus_standard/05-execution-safety.md) (M0, merged via #267 / squash `b85e7084`).

## Canonical
- Meta-issue: [Project-Helianthus/helianthus-execution-plans#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14)
- Issue: [Project-Helianthus/helianthus-ebusreg#120](https://github.com/Project-Helianthus/helianthus-ebusreg/issues/120)
- Locked plan: `ebus-standard-l7-services-w16-26.locked`
- Canonical-SHA256: `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`
- Identity-key model: canonical §3 (14-tuple)

## Acceptance criteria satisfied
- [x] AC1 catalog schema (Go types: `Service`, `Command`, `Parameter`, `IdentityKey`)
- [x] AC2 YAML data file — 42 methods enumerated across 8 services (`0x03`/`0x05`/`0x07`/`0x08`/`0x09`/`0x0F`/`0xFE`/`0xFF`)
- [x] AC3 catalog identity key — full 14-tuple (`namespace`, `PB`, `SB`, `selector_path`, `telegram_class`, `direction`, `request_or_response_role`, `broadcast_or_addressed`, `answer_policy`, `length_prefix_mode`, `selector_decoder`, `service_variant`, `transport_capability_requirements`, `version`)
- [x] AC4 collision detection — generation fails on duplicate identity keys (`ErrDuplicateIdentityKey`)
- [x] AC5 length-selector ambiguity detection — generation fails on entries sharing `(namespace, PB, SB, selector_decoder, selector_path, direction, role)` but disagreeing on `length_prefix_mode` (`ErrAmbiguousLengthSelector`)
- [x] AC6 SHA pinning + version tagging — content SHA computed from `go:embed` bytes; `Version` constant
- [x] AC7 fixtures — class-2 broadcast, originator broadcast, no-answer, typed-payload selector
- [x] AC8 collision test (RED commit material) — planted-duplicate fixture trips the failure path

## TDD strict — RED commit evidence
- RED commit: `fec2e61` `test(ebus_standard/catalog): RED for collision detection with planted duplicate`
- RED CI: `not_triggered` (`.github/workflows/ci.yml` triggers only on push-to-main and pull_request)
- RED local evidence: orchestrator independently reproduced — `git checkout fec2e61 && go test ./catalog/ebus_standard/...` → `FAIL` with stub panic stacks (substitute per cruise-tdd-gate `ci_workflow_does_not_trigger_on_feature_branch_push` caveat)

## Files (11 new under `catalog/ebus_standard/`)
`doc.go` · `identity.go` · `catalog.go` · `loader.go` · `loader_yaml.go` · `embedded.go` · `catalog.yaml` · `loader_test.go` · `fixtures_test.go` · `testdata/collision_duplicate.yaml` · `testdata/ambiguous_length_selector.yaml`. + `go.mod`/`go.sum` for `gopkg.in/yaml.v3` (minimal new dep; existing alternatives didn't preserve human-edit ergonomics needed for M3 provider generation).

## Gates
- TDD: strict (RED commit + local-RED evidence; CI evidence caveated above)
- Doc-gate: N/A (M2 not in plan trigger list)
- Transport-gate: N/A (catalog is data, no transport touch)
- Local CI: pass — see commit status `ci/local` on `74a6afb` (terminology, gofmt, vet, build, race tests, golangci-lint, tinygo-skip)
- Smoke: none

## Out-of-scope notes
Command request/response parameter schemas are intentionally left empty (`request: []`, `response: []` via `omitempty`). Plan explicitly allows stub command bodies as long as the identity-key fields are populated. Fleshing out parameter schemas is M3 work once `helianthus-ebusgo` M1 L7 primitives (this companion PR ↗) merge.

Tracks cruise-run [#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14). Closes #120.