### PR TITLE
M3_PROVIDER: generic ebus_standard provider + ABI snapshot + namespace isolation + invoke safety (meta #14)

### DIFF
--- a/catalog/ebus_standard/internal/safetypolicy/safetypolicy.go
+++ b/catalog/ebus_standard/internal/safetypolicy/safetypolicy.go
@@ -1,0 +1,55 @@
+// Package safetypolicy holds the invoke-boundary safety-class enforcement
+// primitive for the generic ebus_standard provider.
+//
+// The package is placed under catalog/ebus_standard/internal/ so that Go's
+// internal-package visibility rule structurally forbids any importer whose
+// path is not rooted at catalog/ebus_standard/. This is the M3 AC6
+// BUILD_TIME_NAMESPACE_ISOLATION mechanism (option a): the Vaillant tree
+// cannot reach this symbol and therefore cannot reuse the gate by accident.
+// A second-line static-import regression test lives at
+// catalog/ebus_standard/provider_namespace_isolation_test.go and asserts
+// that no file inside catalog/ebus_standard/... imports any vaillant/...
+// package.
+package safetypolicy
+
+// Class is the subset of catalog safety classes the gate knows about. The
+// values MUST equal the string constants declared in identity.go so callers
+// can pass catalog SafetyClass values directly (after a type conversion).
+type Class string
+
+// Known safety classes (must mirror identity.go — duplicated here because
+// this package cannot import the outer package without a cycle).
+const (
+	ReadOnlySafe    Class = "read_only_safe"
+	ReadOnlyBusLoad Class = "read_only_bus_load"
+	Mutating        Class = "mutating"
+	Destructive     Class = "destructive"
+	Broadcast       Class = "broadcast"
+	MemoryWrite     Class = "memory_write"
+)
+
+// Caller tags the intent of an Invoke call. Future M4+ expansion may
+// whitelist mutating for system_nm_runtime; in M3 the gate is identical
+// for every caller context.
+type Caller int
+
+// Caller contexts.
+const (
+	CallerUserFacing Caller = iota
+	CallerSystemNMRuntime
+)
+
+// Allow reports whether a method carrying the given safety class may be
+// dispatched by a caller with the given context. Default-deny: every class
+// outside the explicit allow-list returns false.
+func Allow(class Class, caller Caller) bool {
+	_ = caller
+	switch class {
+	case ReadOnlySafe, ReadOnlyBusLoad:
+		return true
+	default:
+		// mutating | destructive | broadcast | memory_write => deny.
+		// Unknown strings also deny, preserving fail-closed semantics.
+		return false
+	}
+}

--- a/catalog/ebus_standard/provider.go
+++ b/catalog/ebus_standard/provider.go
@@ -115,6 +115,15 @@ var (
 	// this check the second entry would silently overwrite the first in
 	// the method index and Invoke would dispatch the wrong command.
 	ErrDuplicateMethodID = errors.New("ebus_standard: duplicate catalog method id")
+
+	// ErrEmptyMethodID is returned by NewProvider when a catalog command
+	// has an empty string ID. Without this check the bad entry would be
+	// indexed under "" and every normal method-name lookup would still
+	// succeed, while Invoke("") would silently dispatch the malformed
+	// command. LoadCatalog does not currently enforce non-empty IDs, so
+	// the provider converts this silent-correctness failure mode into a
+	// loud configuration error at construction time.
+	ErrEmptyMethodID = errors.New("ebus_standard: empty catalog method id")
 )
 
 // DisableEnvVar is the exact env-var name read at construction time.
@@ -135,6 +144,10 @@ func NewProvider(cat Catalog, enabled bool) (*Provider, error) {
 	idx := make(map[string]Command, len(cat.Services)*4)
 	for _, svc := range cat.Services {
 		for _, cmd := range svc.Commands {
+			if cmd.ID == "" {
+				return nil, fmt.Errorf("%w: service=%q command=%q",
+					ErrEmptyMethodID, svc.Name, cmd.Name)
+			}
 			if prev, dup := idx[cmd.ID]; dup {
 				return nil, fmt.Errorf("%w: id=%q first=%q second=%q",
 					ErrDuplicateMethodID, cmd.ID, prev.Name, cmd.Name)

--- a/catalog/ebus_standard/provider.go
+++ b/catalog/ebus_standard/provider.go
@@ -3,11 +3,16 @@ package ebus_standard_catalog
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard/internal/safetypolicy"
 )
 
-// Provider is the generic ebus_standard L7 provider. Methods are generated
-// at construction time from the loaded catalog; no per-device hard-coding
-// exists in this package.
+// Provider is the generic ebus_standard L7 provider. Method dispatch is
+// driven by the loaded catalog; there is no per-device hard-coding in this
+// package.
 //
 // Namespace isolation (M3 AC6): this provider and its internal helpers MUST
 // NOT import any Vaillant-specific package under github.com/Project-
@@ -15,8 +20,8 @@ import (
 // provided by placing the safety gate in catalog/ebus_standard/internal/
 // safetypolicy (Go's internal/ visibility rule excludes packages outside
 // catalog/ebus_standard/). A second line of defense is the static-import
-// regression test in provider_namespace_isolation_test.go which parses every
-// Go file in this package and fails if a Vaillant import appears.
+// regression test in provider_namespace_isolation_test.go which parses
+// every .go file in this package and fails if a Vaillant import appears.
 //
 // Disable switch (M3 AC4): the env variable EBUS_STANDARD_PROVIDER_ENABLED
 // is read once at provider construction via NewProviderFromEnv. When the
@@ -24,7 +29,9 @@ import (
 // constructed in the disabled state and every call to Invoke /
 // Identification returns ErrProviderDisabled. Default is enabled.
 type Provider struct {
-	// scaffolding only — populated by RED stubs so the package compiles.
+	catalog   Catalog
+	methodIdx map[string]Command
+	enabled   bool
 }
 
 // IdentificationDescriptor carries the canonical manufacturer / device-id /
@@ -35,9 +42,9 @@ type IdentificationDescriptor struct {
 	DeviceID        string
 	SoftwareVersion string
 	HardwareVersion string
-	// Provenance fields are populated per architecture doc 07-identity-
-	// provenance.md (source=ebus_standard.identification, catalog version,
-	// decode validity, timestamp).
+	// Provenance fields per architecture doc 07-identity-provenance.md
+	// (source=ebus_standard.identification, catalog version, decode
+	// validity).
 	Source         string
 	CatalogVersion string
 	Valid          bool
@@ -72,6 +79,18 @@ const (
 	CallerContextSystemNMRuntime
 )
 
+// toInternal converts a public CallerContext into the safetypolicy.Caller
+// tag. The enum values are mirrored deliberately so the translation is a
+// pure literal switch.
+func (c CallerContext) toInternal() safetypolicy.Caller {
+	switch c {
+	case CallerContextSystemNMRuntime:
+		return safetypolicy.CallerSystemNMRuntime
+	default:
+		return safetypolicy.CallerUserFacing
+	}
+}
+
 // Sentinel errors returned by the provider.
 var (
 	// ErrProviderDisabled is returned by every provider entrypoint when
@@ -92,51 +111,102 @@ var (
 // DisableEnvVar is the exact env-var name read at construction time.
 const DisableEnvVar = "EBUS_STANDARD_PROVIDER_ENABLED"
 
-// NewProvider constructs a provider from a loaded catalog, with the enabled
-// flag passed explicitly. Use NewProviderFromEnv to read the env var.
-//
-// RED stub: returns a non-functional provider.
+// NewProvider constructs a provider from a loaded catalog, with the
+// enabled flag passed explicitly. Use NewProviderFromEnv to read the env
+// var. The method index is built eagerly so Invoke lookups are O(1).
 func NewProvider(cat Catalog, enabled bool) *Provider {
-	_ = cat
-	_ = enabled
-	return &Provider{}
+	idx := make(map[string]Command, len(cat.Services)*4)
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			idx[cmd.ID] = cmd
+		}
+	}
+	return &Provider{
+		catalog:   cat,
+		methodIdx: idx,
+		enabled:   enabled,
+	}
 }
 
 // NewProviderFromEnv constructs a provider reading the disable switch from
 // the process environment at this point in time. The env value is captured
 // by copy; subsequent mutations to the environment do not affect the
-// provider.
-//
-// RED stub: not implemented.
+// provider. An unset or empty variable defaults to enabled (blast-radius
+// principle: the generic provider participates in the platform by default;
+// operators explicitly opt out by setting "0" or "false").
 func NewProviderFromEnv(cat Catalog) *Provider {
-	_ = cat
-	return &Provider{}
+	return NewProvider(cat, envEnabled(os.Getenv(DisableEnvVar)))
+}
+
+// envEnabled applies the disable-switch contract. "0" / "false" (any case)
+// => disabled. Empty / anything else => enabled.
+func envEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "false":
+		return false
+	default:
+		return true
+	}
 }
 
 // IsEnabled reports whether the provider is currently enabled.
-//
-// RED stub.
-func (p *Provider) IsEnabled() bool { return false }
+func (p *Provider) IsEnabled() bool { return p != nil && p.enabled }
 
-// Invoke dispatches a catalog method by ID after consulting the safety
-// class policy. See ErrSafetyClassDenied for the deny rules.
+// Invoke dispatches a catalog method by ID after consulting the
+// invoke-boundary safety gate. Error precedence:
 //
-// RED stub: always returns "not implemented".
+//  1. ErrProviderDisabled — provider constructed in disabled state.
+//  2. ErrUnknownMethod — method ID not present in the catalog.
+//  3. ErrSafetyClassDenied — safety_class not permitted for callerCtx.
+//  4. (future) decode / transport errors from the command body.
+//
+// M3 scope does not yet execute the wire request — the method signature is
+// generated from the catalog and dispatch returns a stub result map for
+// gated (allowed) methods. Decode into L7 primitives lands when the M1
+// helianthus-ebusgo/protocol/ebus_standard/types package is published and
+// the go.mod is bumped.
 func (p *Provider) Invoke(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error) {
+	if !p.IsEnabled() {
+		return nil, ErrProviderDisabled
+	}
+	cmd, ok := p.methodIdx[methodID]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownMethod, methodID)
+	}
+	if !safetypolicy.Allow(safetypolicy.Class(cmd.SafetyClass), caller.toInternal()) {
+		return nil, fmt.Errorf("%w: method=%q class=%s", ErrSafetyClassDenied, methodID, cmd.SafetyClass)
+	}
+	// M3: returning a minimal descriptor that proves the gate passed.
+	// Downstream milestones wire the actual decode/encode once the L7
+	// types package is available.
 	_ = ctx
-	_ = methodID
 	_ = params
-	_ = caller
-	return nil, errors.New("ebus_standard: Invoke not implemented (RED)")
+	return map[string]any{
+		"method_id":       cmd.ID,
+		"safety_class":    string(cmd.SafetyClass),
+		"catalog_version": p.catalog.Version,
+		"executed":        false, // M3 stub — handler body not yet wired
+	}, nil
 }
 
 // Identification returns the canonical 0x07 0x04 identification descriptor
-// wrapped in provenance metadata. It never mutates DeviceInfo.
+// wrapped in provenance metadata. It never mutates DeviceInfo; see
+// CompareIdentity for the provenance merge helper.
 //
-// RED stub: not implemented.
+// M3 scope: returns an empty descriptor with provenance labels populated.
+// The wire decode lands when the gateway transport layer passes an
+// observed Identification frame through to the provider in a later
+// milestone.
 func (p *Provider) Identification(ctx context.Context) (IdentificationDescriptor, error) {
 	_ = ctx
-	return IdentificationDescriptor{}, errors.New("ebus_standard: Identification not implemented (RED)")
+	if !p.IsEnabled() {
+		return IdentificationDescriptor{}, ErrProviderDisabled
+	}
+	return IdentificationDescriptor{
+		Source:         string(SourceEBUSStandardIdent),
+		CatalogVersion: p.catalog.Version,
+		Valid:          false, // no wire frame yet in M3
+	}, nil
 }
 
 // IdentitySource tags a single evidence contribution for the provenance
@@ -178,14 +248,49 @@ type ProvenanceRecord struct {
 
 // CompareIdentity merges an existing DeviceInfo with an ebus_standard
 // Identification descriptor. The existing DeviceInfo is never mutated; on
-// disagreement both values are retained with source labels. Deterministic
+// disagreement BOTH values are retained with source labels. Deterministic
 // precedence (see 07-identity-provenance.md §"Deterministic Precedence"):
 // device_info > ebus_standard.identification > operator_seed > passive >
-// "unknown". This function implements steps 1-2 of that order.
-//
-// RED stub.
+// "unknown". This function implements steps 1-2 (the two sources it has
+// evidence for); operator_seed and passive sources are stacked by the
+// caller via future helpers.
 func CompareIdentity(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord {
-	_ = existing
-	_ = desc
-	return ProvenanceRecord{}
+	mk := func(existingVal, descVal string) FieldProvenance {
+		// Both sources are considered valid when they are non-empty. A
+		// malformed descriptor value is the caller's responsibility to tag
+		// as invalid before passing it in (via the Valid flag on the
+		// descriptor as a whole — in M3 that flag applies uniformly to the
+		// four fields; future milestones may introduce per-field validity).
+		var srcs []IdentitySourceValue
+		if existingVal != "" {
+			srcs = append(srcs, IdentitySourceValue{
+				Source: SourceDeviceInfo, Value: existingVal, Valid: true,
+			})
+		}
+		if descVal != "" {
+			srcs = append(srcs, IdentitySourceValue{
+				Source: SourceEBUSStandardIdent, Value: descVal, Valid: desc.Valid,
+			})
+		}
+		// Preferred value: deterministic precedence => device_info wins.
+		preferred := existingVal
+		if preferred == "" {
+			preferred = descVal
+		}
+		// Agreement requires BOTH sources present AND equal. If only one
+		// side provides evidence, treat it as agreement (there is nothing
+		// to disagree with).
+		agreement := existingVal == "" || descVal == "" || existingVal == descVal
+		return FieldProvenance{
+			Preferred: preferred,
+			Sources:   srcs,
+			Agreement: agreement,
+		}
+	}
+	return ProvenanceRecord{
+		Manufacturer:    mk(existing.Manufacturer, desc.Manufacturer),
+		DeviceID:        mk(existing.DeviceID, desc.DeviceID),
+		SoftwareVersion: mk(existing.SoftwareVersion, desc.SoftwareVersion),
+		HardwareVersion: mk(existing.HardwareVersion, desc.HardwareVersion),
+	}
 }

--- a/catalog/ebus_standard/provider.go
+++ b/catalog/ebus_standard/provider.go
@@ -106,6 +106,15 @@ var (
 	// ErrUnknownMethod is returned when Invoke receives a method ID that
 	// does not exist in the loaded catalog.
 	ErrUnknownMethod = errors.New("ebus_standard: unknown method id")
+
+	// ErrDuplicateMethodID is returned by NewProvider when two catalog
+	// commands share the same ID. This is distinct from
+	// ErrDuplicateIdentityKey (loader-level, identity-fingerprint based): a
+	// catalog may pass loader validation yet still contain two commands
+	// with identical string IDs (e.g. YAML typo or merge mistake). Without
+	// this check the second entry would silently overwrite the first in
+	// the method index and Invoke would dispatch the wrong command.
+	ErrDuplicateMethodID = errors.New("ebus_standard: duplicate catalog method id")
 )
 
 // DisableEnvVar is the exact env-var name read at construction time.
@@ -114,10 +123,22 @@ const DisableEnvVar = "EBUS_STANDARD_PROVIDER_ENABLED"
 // NewProvider constructs a provider from a loaded catalog, with the
 // enabled flag passed explicitly. Use NewProviderFromEnv to read the env
 // var. The method index is built eagerly so Invoke lookups are O(1).
-func NewProvider(cat Catalog, enabled bool) *Provider {
+//
+// Returns ErrDuplicateMethodID wrapped with the colliding command names
+// when two catalog commands share the same ID. This is distinct from the
+// loader-level ErrDuplicateIdentityKey (which fingerprints on the identity
+// tuple). Two commands with identical IDs but different identity keys
+// would pass the loader yet silently overwrite each other in the method
+// index; this check converts that silent-correctness failure mode into a
+// loud configuration error at construction time.
+func NewProvider(cat Catalog, enabled bool) (*Provider, error) {
 	idx := make(map[string]Command, len(cat.Services)*4)
 	for _, svc := range cat.Services {
 		for _, cmd := range svc.Commands {
+			if prev, dup := idx[cmd.ID]; dup {
+				return nil, fmt.Errorf("%w: id=%q first=%q second=%q",
+					ErrDuplicateMethodID, cmd.ID, prev.Name, cmd.Name)
+			}
 			idx[cmd.ID] = cmd
 		}
 	}
@@ -125,7 +146,7 @@ func NewProvider(cat Catalog, enabled bool) *Provider {
 		catalog:   cat,
 		methodIdx: idx,
 		enabled:   enabled,
-	}
+	}, nil
 }
 
 // NewProviderFromEnv constructs a provider reading the disable switch from
@@ -134,7 +155,10 @@ func NewProvider(cat Catalog, enabled bool) *Provider {
 // provider. An unset or empty variable defaults to enabled (blast-radius
 // principle: the generic provider participates in the platform by default;
 // operators explicitly opt out by setting "0" or "false").
-func NewProviderFromEnv(cat Catalog) *Provider {
+//
+// Propagates ErrDuplicateMethodID from NewProvider when the catalog has
+// colliding command IDs.
+func NewProviderFromEnv(cat Catalog) (*Provider, error) {
 	return NewProvider(cat, envEnabled(os.Getenv(DisableEnvVar)))
 }
 

--- a/catalog/ebus_standard/provider.go
+++ b/catalog/ebus_standard/provider.go
@@ -297,8 +297,16 @@ func CompareIdentity(existing DeviceInfo, desc IdentificationDescriptor) Provena
 			})
 		}
 		// Preferred value: deterministic precedence => device_info wins.
+		// When existingVal is empty, the descriptor value is only promoted
+		// to Preferred if the descriptor is marked valid. An invalid
+		// descriptor (desc.Valid == false) must NOT surface malformed or
+		// failed-decode identity as the canonical preferred value; leave
+		// Preferred empty so the caller falls through to the next source
+		// in the deterministic precedence chain (operator_seed > passive >
+		// "unknown"). The invalid value is still retained in Sources with
+		// Valid=false so the evidence trail is preserved.
 		preferred := existingVal
-		if preferred == "" {
+		if preferred == "" && desc.Valid {
 			preferred = descVal
 		}
 		// Agreement requires BOTH sources present AND equal. If only one

--- a/catalog/ebus_standard/provider.go
+++ b/catalog/ebus_standard/provider.go
@@ -1,0 +1,191 @@
+package ebus_standard_catalog
+
+import (
+	"context"
+	"errors"
+)
+
+// Provider is the generic ebus_standard L7 provider. Methods are generated
+// at construction time from the loaded catalog; no per-device hard-coding
+// exists in this package.
+//
+// Namespace isolation (M3 AC6): this provider and its internal helpers MUST
+// NOT import any Vaillant-specific package under github.com/Project-
+// Helianthus/helianthus-ebusreg/vaillant/.... Compile-time enforcement is
+// provided by placing the safety gate in catalog/ebus_standard/internal/
+// safetypolicy (Go's internal/ visibility rule excludes packages outside
+// catalog/ebus_standard/). A second line of defense is the static-import
+// regression test in provider_namespace_isolation_test.go which parses every
+// Go file in this package and fails if a Vaillant import appears.
+//
+// Disable switch (M3 AC4): the env variable EBUS_STANDARD_PROVIDER_ENABLED
+// is read once at provider construction via NewProviderFromEnv. When the
+// value is literally "0" or "false" (case-insensitive), the provider is
+// constructed in the disabled state and every call to Invoke /
+// Identification returns ErrProviderDisabled. Default is enabled.
+type Provider struct {
+	// scaffolding only — populated by RED stubs so the package compiles.
+}
+
+// IdentificationDescriptor carries the canonical manufacturer / device-id /
+// software / hardware values produced by the 0x07 0x04 service, wrapped in
+// provenance metadata (never mutates DeviceInfo).
+type IdentificationDescriptor struct {
+	Manufacturer    string
+	DeviceID        string
+	SoftwareVersion string
+	HardwareVersion string
+	// Provenance fields are populated per architecture doc 07-identity-
+	// provenance.md (source=ebus_standard.identification, catalog version,
+	// decode validity, timestamp).
+	Source         string
+	CatalogVersion string
+	Valid          bool
+}
+
+// DeviceInfo is the existing registry identity tuple used for provenance
+// comparison. The shape is intentionally local — the provider does not
+// import the registry package to keep catalog/ebus_standard self-contained
+// (see AC6 namespace isolation). Callers that already have a
+// registry.DeviceInfo translate into this struct at the boundary.
+type DeviceInfo struct {
+	Manufacturer    string
+	DeviceID        string
+	SoftwareVersion string
+	HardwareVersion string
+}
+
+// CallerContext tags an Invoke call with the intent of the caller. In M3
+// it only affects future whitelist expansion of mutating / destructive
+// classes; currently every mutating class is denied regardless of context.
+type CallerContext int
+
+// CallerContext values.
+const (
+	// CallerContextUserFacing is the default. It denies every safety class
+	// outside read_only_safe / read_only_bus_load.
+	CallerContextUserFacing CallerContext = iota
+	// CallerContextSystemNMRuntime is reserved for a future whitelist
+	// expansion (network-management runtime). In M3 it is carried but NOT
+	// interpreted — callers passing it receive the same default-deny as
+	// user_facing.
+	CallerContextSystemNMRuntime
+)
+
+// Sentinel errors returned by the provider.
+var (
+	// ErrProviderDisabled is returned by every provider entrypoint when
+	// EBUS_STANDARD_PROVIDER_ENABLED resolves to a disabled value at
+	// construction time.
+	ErrProviderDisabled = errors.New("ebus_standard: provider disabled via EBUS_STANDARD_PROVIDER_ENABLED")
+
+	// ErrSafetyClassDenied is returned at the Invoke boundary when the
+	// catalog's safety_class for the requested method is not permitted for
+	// the caller context.
+	ErrSafetyClassDenied = errors.New("ebus_standard: safety_class denied at invoke boundary")
+
+	// ErrUnknownMethod is returned when Invoke receives a method ID that
+	// does not exist in the loaded catalog.
+	ErrUnknownMethod = errors.New("ebus_standard: unknown method id")
+)
+
+// DisableEnvVar is the exact env-var name read at construction time.
+const DisableEnvVar = "EBUS_STANDARD_PROVIDER_ENABLED"
+
+// NewProvider constructs a provider from a loaded catalog, with the enabled
+// flag passed explicitly. Use NewProviderFromEnv to read the env var.
+//
+// RED stub: returns a non-functional provider.
+func NewProvider(cat Catalog, enabled bool) *Provider {
+	_ = cat
+	_ = enabled
+	return &Provider{}
+}
+
+// NewProviderFromEnv constructs a provider reading the disable switch from
+// the process environment at this point in time. The env value is captured
+// by copy; subsequent mutations to the environment do not affect the
+// provider.
+//
+// RED stub: not implemented.
+func NewProviderFromEnv(cat Catalog) *Provider {
+	_ = cat
+	return &Provider{}
+}
+
+// IsEnabled reports whether the provider is currently enabled.
+//
+// RED stub.
+func (p *Provider) IsEnabled() bool { return false }
+
+// Invoke dispatches a catalog method by ID after consulting the safety
+// class policy. See ErrSafetyClassDenied for the deny rules.
+//
+// RED stub: always returns "not implemented".
+func (p *Provider) Invoke(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error) {
+	_ = ctx
+	_ = methodID
+	_ = params
+	_ = caller
+	return nil, errors.New("ebus_standard: Invoke not implemented (RED)")
+}
+
+// Identification returns the canonical 0x07 0x04 identification descriptor
+// wrapped in provenance metadata. It never mutates DeviceInfo.
+//
+// RED stub: not implemented.
+func (p *Provider) Identification(ctx context.Context) (IdentificationDescriptor, error) {
+	_ = ctx
+	return IdentificationDescriptor{}, errors.New("ebus_standard: Identification not implemented (RED)")
+}
+
+// IdentitySource tags a single evidence contribution for the provenance
+// comparison helper.
+type IdentitySource string
+
+// Evidence source labels per docs/architecture/ebus_standard/07-identity-
+// provenance.md.
+const (
+	SourceDeviceInfo         IdentitySource = "device_info"
+	SourceEBUSStandardIdent  IdentitySource = "ebus_standard.identification"
+	SourceOperatorSeed       IdentitySource = "operator_seed"
+	SourcePassiveObservation IdentitySource = "passive_observation"
+)
+
+// FieldProvenance is the per-field merge result produced by
+// CompareIdentity. When Agreement is false, both Preferred and Sources
+// remain populated.
+type FieldProvenance struct {
+	Preferred string
+	Sources   []IdentitySourceValue
+	Agreement bool
+}
+
+// IdentitySourceValue is a single labeled contribution.
+type IdentitySourceValue struct {
+	Source IdentitySource
+	Value  string
+	Valid  bool
+}
+
+// ProvenanceRecord is the full per-field provenance for a device.
+type ProvenanceRecord struct {
+	Manufacturer    FieldProvenance
+	DeviceID        FieldProvenance
+	SoftwareVersion FieldProvenance
+	HardwareVersion FieldProvenance
+}
+
+// CompareIdentity merges an existing DeviceInfo with an ebus_standard
+// Identification descriptor. The existing DeviceInfo is never mutated; on
+// disagreement both values are retained with source labels. Deterministic
+// precedence (see 07-identity-provenance.md §"Deterministic Precedence"):
+// device_info > ebus_standard.identification > operator_seed > passive >
+// "unknown". This function implements steps 1-2 of that order.
+//
+// RED stub.
+func CompareIdentity(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord {
+	_ = existing
+	_ = desc
+	return ProvenanceRecord{}
+}

--- a/catalog/ebus_standard/provider_abi_snapshot_test.go
+++ b/catalog/ebus_standard/provider_abi_snapshot_test.go
@@ -193,12 +193,124 @@ func ExportedFunc(a int) error { return nil }
 	}
 }
 
+// TestABISnapshot_PreservesTypeDeclForm asserts that formatTypeDecl
+// distinguishes defined types from aliases and renders type parameters
+// for generics. These are ABI-significant shape differences: a
+// defined→alias flip changes method-set reachability; a generic type
+// param add/remove changes the exported surface. The snapshot MUST
+// catch both.
+func TestABISnapshot_PreservesTypeDeclForm(t *testing.T) {
+	render := func(src string) []string {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "sample.go", src, 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		file.Comments = nil
+		var lines []string
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				if s, ok := spec.(*ast.TypeSpec); ok && s.Name.IsExported() {
+					lines = append(lines, formatTypeDecl(file.Name.Name, s, fset))
+				}
+			}
+		}
+		sort.Strings(lines)
+		return lines
+	}
+
+	// Defined type: no `=`.
+	defined := render(`package sample
+type Defined string
+`)
+	if len(defined) != 1 || !strings.Contains(defined[0], "type Defined string") {
+		t.Fatalf("defined type render wrong: %q", defined)
+	}
+	if strings.Contains(defined[0], "Defined = string") {
+		t.Fatalf("defined type rendered as alias: %q", defined[0])
+	}
+
+	// Alias type: `=` present.
+	alias := render(`package sample
+type Alias = string
+`)
+	if len(alias) != 1 || !strings.Contains(alias[0], "type Alias = string") {
+		t.Fatalf("alias type render wrong: %q", alias)
+	}
+
+	// Defined vs alias MUST produce distinct snapshot lines. This is the
+	// core regression: the pre-fix implementation hardcoded `" = "` and
+	// collapsed the two forms.
+	definedLine := render(`package sample
+type T string
+`)
+	aliasLine := render(`package sample
+type T = string
+`)
+	if definedLine[0] == aliasLine[0] {
+		t.Fatalf("defined and alias rendered identically: %q", definedLine[0])
+	}
+
+	// Generic type: type params present.
+	generic := render(`package sample
+type Generic[T any] struct{ Val T }
+`)
+	if len(generic) != 1 || !strings.Contains(generic[0], "Generic[T any]") {
+		t.Fatalf("generic type params missing: %q", generic)
+	}
+
+	// Adding/removing a type parameter MUST produce a snapshot diff.
+	oneParam := render(`package sample
+type G[T any] struct{ V T }
+`)
+	twoParams := render(`package sample
+type G[T any, U comparable] struct{ V T }
+`)
+	if oneParam[0] == twoParams[0] {
+		t.Fatalf("type-param count change not detected: %q", oneParam[0])
+	}
+}
+
 func formatTypeDecl(pkg string, s *ast.TypeSpec, fset *token.FileSet) string {
 	var buf bytes.Buffer
 	buf.WriteString(pkg)
 	buf.WriteString(" type ")
 	buf.WriteString(s.Name.Name)
-	buf.WriteString(" = ")
+	// Emit type parameters for generic type declarations (Go 1.18+):
+	// `type Generic[T any, U comparable] struct{...}`. TypeParams is nil
+	// for non-generic types, so guard the render.
+	if s.TypeParams != nil && len(s.TypeParams.List) > 0 {
+		buf.WriteString("[")
+		for i, field := range s.TypeParams.List {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			for j, name := range field.Names {
+				if j > 0 {
+					buf.WriteString(", ")
+				}
+				buf.WriteString(name.Name)
+			}
+			if len(field.Names) > 0 {
+				buf.WriteString(" ")
+			}
+			_ = printNode(&buf, fset, field.Type)
+		}
+		buf.WriteString("]")
+	}
+	// Distinguish a type alias (`type T = U`, TypeSpec.Assign != NoPos)
+	// from a defined type (`type T U`). The two forms are ABI-distinct:
+	// flipping one to the other changes method-set reachability and
+	// conversion rules, so the snapshot MUST preserve the separator.
+	if s.Assign != token.NoPos {
+		buf.WriteString(" = ")
+	} else {
+		buf.WriteString(" ")
+	}
 	_ = printNode(&buf, fset, s.Type)
 	return compactWhitespace(buf.String())
 }

--- a/catalog/ebus_standard/provider_abi_snapshot_test.go
+++ b/catalog/ebus_standard/provider_abi_snapshot_test.go
@@ -342,8 +342,57 @@ func formatFuncDecl(pkg string, d *ast.FuncDecl, fset *token.FileSet) string {
 		buf.WriteString(") ")
 	}
 	buf.WriteString(d.Name.Name)
-	_ = printNode(&buf, fset, d.Type)
+	// Render just the parameter/result lists. Printing d.Type (*ast.FuncType)
+	// directly via go/printer emits a leading "func" keyword, which
+	// concatenates with the function name to produce artifacts like
+	// "ComputeContentSHA256func(...)". We build the signature by hand:
+	// type parameters (generics), parameter list, result list.
+	if d.Type.TypeParams != nil && len(d.Type.TypeParams.List) > 0 {
+		buf.WriteString("[")
+		writeFieldList(&buf, fset, d.Type.TypeParams.List)
+		buf.WriteString("]")
+	}
+	buf.WriteString("(")
+	if d.Type.Params != nil {
+		writeFieldList(&buf, fset, d.Type.Params.List)
+	}
+	buf.WriteString(")")
+	if d.Type.Results != nil && len(d.Type.Results.List) > 0 {
+		buf.WriteString(" ")
+		// Parenthesize multi-result or named-result lists for clarity; a
+		// single unnamed result is rendered bare to match standard Go
+		// notation ("func F() error" vs "func F() (a, b int)").
+		multi := len(d.Type.Results.List) > 1 || (len(d.Type.Results.List) == 1 && len(d.Type.Results.List[0].Names) > 0)
+		if multi {
+			buf.WriteString("(")
+		}
+		writeFieldList(&buf, fset, d.Type.Results.List)
+		if multi {
+			buf.WriteString(")")
+		}
+	}
 	return compactWhitespace(buf.String())
+}
+
+// writeFieldList serializes an AST field list (function params, results,
+// or type params) as "name1, name2 Type, nextType" — the compact form
+// expected in Go signatures. Empty-name fields render only the type.
+func writeFieldList(buf *bytes.Buffer, fset *token.FileSet, fields []*ast.Field) {
+	for i, field := range fields {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		for j, name := range field.Names {
+			if j > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(name.Name)
+		}
+		if len(field.Names) > 0 {
+			buf.WriteString(" ")
+		}
+		_ = printNode(buf, fset, field.Type)
+	}
 }
 
 func printNode(buf *bytes.Buffer, fset *token.FileSet, node ast.Node) error {

--- a/catalog/ebus_standard/provider_abi_snapshot_test.go
+++ b/catalog/ebus_standard/provider_abi_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"os"
 	"path/filepath"
@@ -73,10 +74,19 @@ func mustComputeABISnapshot(t *testing.T) []byte {
 			}
 			path := filepath.Join(root, ent.Name())
 			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			// Parse WITHOUT parser.ParseComments: comments are irrelevant
+			// to the exported-API shape. Excluding them at parse time
+			// keeps the downstream AST serialization free of comment
+			// nodes and prevents comment-only edits from causing ABI
+			// golden drift (pre-fix behavior: raw-src slicing captured
+			// any comments that happened to fall inside a node's Pos..End
+			// range, causing false-positive CI failures).
+			file, err := parser.ParseFile(fset, path, nil, 0)
 			if err != nil {
 				t.Fatalf("parse %s: %v", path, err)
 			}
+			// Detach any parsed comment groups defensively.
+			file.Comments = nil
 			pkgLabel := file.Name.Name
 			for _, decl := range file.Decls {
 				switch d := decl.(type) {
@@ -120,6 +130,69 @@ func mustComputeABISnapshot(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
+// TestABISnapshot_CommentsInsensitive is the regression gate for the
+// go/printer-based serialization: it feeds the snapshot pipeline two
+// variants of the same exported type — one bare, one decorated with doc
+// comments and inline comments inside a struct field — and asserts the
+// formatter produces byte-identical output for both. A regression that
+// re-introduces raw-source slicing would make the commented variant
+// capture comment bytes and diverge.
+func TestABISnapshot_CommentsInsensitive(t *testing.T) {
+	bare := `package sample
+
+type ExportedShape struct {
+	Field1 int
+	Field2 string
+}
+
+func ExportedFunc(a int) error { return nil }
+`
+	commented := `package sample
+
+// ExportedShape is the documented shape.
+//
+// Multiple paragraphs of doc comments MUST NOT leak into the ABI snapshot.
+type ExportedShape struct {
+	// Field1 is the first field.
+	Field1 int // trailing comment on Field1
+	// Field2 is the second field.
+	Field2 string
+}
+
+// ExportedFunc has a lengthy doc comment that describes
+// every edge case in excruciating detail.
+func ExportedFunc(a int) error { return nil }
+`
+	render := func(src string) string {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "sample.go", src, 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		file.Comments = nil
+		var lines []string
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					if s, ok := spec.(*ast.TypeSpec); ok && s.Name.IsExported() {
+						lines = append(lines, formatTypeDecl(file.Name.Name, s, fset))
+					}
+				}
+			case *ast.FuncDecl:
+				if d.Name.IsExported() {
+					lines = append(lines, formatFuncDecl(file.Name.Name, d, fset))
+				}
+			}
+		}
+		sort.Strings(lines)
+		return strings.Join(lines, "\n")
+	}
+	if got, want := render(commented), render(bare); got != want {
+		t.Fatalf("ABI snapshot leaked comment bytes.\n  bare=%q\n  comm=%q", want, got)
+	}
+}
+
 func formatTypeDecl(pkg string, s *ast.TypeSpec, fset *token.FileSet) string {
 	var buf bytes.Buffer
 	buf.WriteString(pkg)
@@ -145,25 +218,18 @@ func formatFuncDecl(pkg string, d *ast.FuncDecl, fset *token.FileSet) string {
 }
 
 func printNode(buf *bytes.Buffer, fset *token.FileSet, node ast.Node) error {
-	// Use a minimal printer to avoid pulling go/format (which would pin us to
-	// a specific gofmt revision). The ast package's default String via
-	// position-aware extraction suffices for deterministic output across Go
-	// toolchain revisions.
-	start := fset.Position(node.Pos()).Offset
-	end := fset.Position(node.End()).Offset
-	file := fset.File(node.Pos())
-	if file == nil {
-		return nil
-	}
-	src, err := os.ReadFile(file.Name())
-	if err != nil {
-		return err
-	}
-	if start < 0 || end > len(src) {
-		return nil
-	}
-	buf.Write(src[start:end])
-	return nil
+	// Serialize the AST node canonically via go/printer with mode=0 (no
+	// raw-source/comment passthrough). This replaces a prior
+	// implementation that sliced raw source between node.Pos() and
+	// node.End(): that approach silently captured inline comments sitting
+	// inside struct literals and type declarations, which caused the
+	// golden fixture to drift on comment-only edits and produced
+	// false-positive ABI-gate failures in CI. Serializing the node itself
+	// is comments-insensitive by construction (comments live on
+	// *ast.File.Comments, not on the type/func node, and are additionally
+	// scrubbed by the caller via file.Comments = nil defensively).
+	cfg := printer.Config{Mode: 0, Tabwidth: 8}
+	return cfg.Fprint(buf, fset, node)
 }
 
 func compactWhitespace(s string) string {

--- a/catalog/ebus_standard/provider_abi_snapshot_test.go
+++ b/catalog/ebus_standard/provider_abi_snapshot_test.go
@@ -1,0 +1,221 @@
+package ebus_standard_catalog
+
+import (
+	"bytes"
+	"flag"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// updateABIGolden mirrors the `go test -update` convention used elsewhere
+// in the Helianthus toolchain. When true, the test overwrites the golden
+// fixture instead of asserting equality. The flag complements UPDATE=1 via
+// the OS environment; either mechanism works.
+var updateABIGolden = flag.Bool("update", false, "update provider ABI golden fixture")
+
+// TestProvider_ABISnapshot is the CONTRACT_ABI_SNAPSHOT_TEST (M3 AC5).
+// It parses every non-test .go file in this package (and the internal/
+// safetypolicy helper) and serializes the exported-symbol shape (type
+// declarations, method receivers + signatures, and top-level function
+// signatures). On a diff vs the golden fixture the test fails with a
+// directive to update the fixture AND add a PR-body rationale.
+func TestProvider_ABISnapshot(t *testing.T) {
+	got := mustComputeABISnapshot(t)
+
+	goldenPath := filepath.Join("testdata", "provider_abi.golden.txt")
+	if *updateABIGolden || os.Getenv("UPDATE") == "1" {
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("golden fixture updated at %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run `go test ./catalog/ebus_standard -update` or UPDATE=1 go test to create it, then add a PR-body rationale for the ABI change)", goldenPath, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("provider ABI drift detected.\n"+
+			"Directive: run `go test ./catalog/ebus_standard -update` (or UPDATE=1 go test) to refresh\n"+
+			"  testdata/provider_abi.golden.txt, THEN add a PR-body rationale explaining the ABI\n"+
+			"  change. Unapproved ABI drift is a merge blocker per canonical plan M3 §ADD-05.\n\n"+
+			"diff (got vs want):\n%s", unifiedDiff(string(want), string(got)))
+	}
+}
+
+// mustComputeABISnapshot walks the source tree rooted at the ebus_standard
+// catalog package and emits a deterministic textual representation of every
+// exported API symbol.
+func mustComputeABISnapshot(t *testing.T) []byte {
+	t.Helper()
+	var lines []string
+	// Package roots to cover. Relative paths are resolved against the
+	// package directory (where `go test` runs).
+	roots := []string{".", filepath.Join("internal", "safetypolicy")}
+	for _, root := range roots {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			t.Fatalf("readdir %s: %v", root, err)
+		}
+		for _, ent := range entries {
+			if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".go") {
+				continue
+			}
+			if strings.HasSuffix(ent.Name(), "_test.go") {
+				continue
+			}
+			path := filepath.Join(root, ent.Name())
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			pkgLabel := file.Name.Name
+			for _, decl := range file.Decls {
+				switch d := decl.(type) {
+				case *ast.GenDecl:
+					for _, spec := range d.Specs {
+						switch s := spec.(type) {
+						case *ast.TypeSpec:
+							if !s.Name.IsExported() {
+								continue
+							}
+							lines = append(lines, formatTypeDecl(pkgLabel, s, fset))
+						case *ast.ValueSpec:
+							// Exported constants and vars (errors, sentinels).
+							for _, n := range s.Names {
+								if !n.IsExported() {
+									continue
+								}
+								kind := "var"
+								if d.Tok == token.CONST {
+									kind = "const"
+								}
+								lines = append(lines, pkgLabel+" "+kind+" "+n.Name)
+							}
+						}
+					}
+				case *ast.FuncDecl:
+					if !d.Name.IsExported() {
+						continue
+					}
+					lines = append(lines, formatFuncDecl(pkgLabel, d, fset))
+				}
+			}
+		}
+	}
+	sort.Strings(lines)
+	var buf bytes.Buffer
+	for _, ln := range lines {
+		buf.WriteString(ln)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func formatTypeDecl(pkg string, s *ast.TypeSpec, fset *token.FileSet) string {
+	var buf bytes.Buffer
+	buf.WriteString(pkg)
+	buf.WriteString(" type ")
+	buf.WriteString(s.Name.Name)
+	buf.WriteString(" = ")
+	_ = printNode(&buf, fset, s.Type)
+	return compactWhitespace(buf.String())
+}
+
+func formatFuncDecl(pkg string, d *ast.FuncDecl, fset *token.FileSet) string {
+	var buf bytes.Buffer
+	buf.WriteString(pkg)
+	buf.WriteString(" func ")
+	if d.Recv != nil && len(d.Recv.List) == 1 {
+		buf.WriteString("(")
+		_ = printNode(&buf, fset, d.Recv.List[0].Type)
+		buf.WriteString(") ")
+	}
+	buf.WriteString(d.Name.Name)
+	_ = printNode(&buf, fset, d.Type)
+	return compactWhitespace(buf.String())
+}
+
+func printNode(buf *bytes.Buffer, fset *token.FileSet, node ast.Node) error {
+	// Use a minimal printer to avoid pulling go/format (which would pin us to
+	// a specific gofmt revision). The ast package's default String via
+	// position-aware extraction suffices for deterministic output across Go
+	// toolchain revisions.
+	start := fset.Position(node.Pos()).Offset
+	end := fset.Position(node.End()).Offset
+	file := fset.File(node.Pos())
+	if file == nil {
+		return nil
+	}
+	src, err := os.ReadFile(file.Name())
+	if err != nil {
+		return err
+	}
+	if start < 0 || end > len(src) {
+		return nil
+	}
+	buf.Write(src[start:end])
+	return nil
+}
+
+func compactWhitespace(s string) string {
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range s {
+		switch r {
+		case ' ', '\t', '\n', '\r':
+			if !prevSpace {
+				b.WriteRune(' ')
+				prevSpace = true
+			}
+		default:
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// unifiedDiff produces a minimal line-diff. Pulling in a full diff library
+// would be overkill for a fixture compare; this prints both sides line-by-
+// line so the operator can eyeball the drift.
+func unifiedDiff(a, b string) string {
+	aLines := strings.Split(a, "\n")
+	bLines := strings.Split(b, "\n")
+	var buf bytes.Buffer
+	buf.WriteString("--- want\n+++ got\n")
+	max := len(aLines)
+	if len(bLines) > max {
+		max = len(bLines)
+	}
+	for i := 0; i < max; i++ {
+		var av, bv string
+		if i < len(aLines) {
+			av = aLines[i]
+		}
+		if i < len(bLines) {
+			bv = bLines[i]
+		}
+		if av != bv {
+			if av != "" {
+				buf.WriteString("- ")
+				buf.WriteString(av)
+				buf.WriteByte('\n')
+			}
+			if bv != "" {
+				buf.WriteString("+ ")
+				buf.WriteString(bv)
+				buf.WriteByte('\n')
+			}
+		}
+	}
+	return buf.String()
+}

--- a/catalog/ebus_standard/provider_abi_snapshot_test.go
+++ b/catalog/ebus_standard/provider_abi_snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/printer"
 	"go/token"
@@ -60,6 +61,15 @@ func mustComputeABISnapshot(t *testing.T) []byte {
 	// Package roots to cover. Relative paths are resolved against the
 	// package directory (where `go test` runs).
 	roots := []string{".", filepath.Join("internal", "safetypolicy")}
+	// Use the default build context so files behind build tags that are
+	// inactive in the current build (e.g. loader_tinygo.go under `tinygo`
+	// while we're running the non-tinygo default) are excluded. Without
+	// this filter, mutually-exclusive tagged files were parsed together
+	// and produced duplicate symbols in the golden fixture (observed:
+	// ComputeContentSHA256 appearing twice from embedded.go + its tinygo
+	// counterpart). go/build.Context.MatchFile applies the same logic the
+	// compiler uses to decide which files belong in the package build.
+	bctx := build.Default
 	for _, root := range roots {
 		entries, err := os.ReadDir(root)
 		if err != nil {
@@ -70,6 +80,13 @@ func mustComputeABISnapshot(t *testing.T) []byte {
 				continue
 			}
 			if strings.HasSuffix(ent.Name(), "_test.go") {
+				continue
+			}
+			match, merr := bctx.MatchFile(root, ent.Name())
+			if merr != nil {
+				t.Fatalf("build.MatchFile %s/%s: %v", root, ent.Name(), merr)
+			}
+			if !match {
 				continue
 			}
 			path := filepath.Join(root, ent.Name())

--- a/catalog/ebus_standard/provider_namespace_isolation_test.go
+++ b/catalog/ebus_standard/provider_namespace_isolation_test.go
@@ -3,6 +3,7 @@ package ebus_standard_catalog
 import (
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,33 +36,98 @@ import (
 // test zero-cost for normal runs.
 func TestNamespaceIsolation_NoVaillantImports(t *testing.T) {
 	var violations []string
-	roots := []string{".", filepath.Join("internal", "safetypolicy")}
-	for _, root := range roots {
-		entries, err := os.ReadDir(root)
-		if err != nil {
-			t.Fatalf("readdir %s: %v", root, err)
+	// Walk the entire catalog/ebus_standard subtree recursively. A prior
+	// implementation only called os.ReadDir on two top-level roots, which
+	// produced a false-negative path: any Vaillant import dropped into a
+	// nested subdirectory (e.g. internal/anything/deeper/foo.go) escaped
+	// the scanner entirely. filepath.WalkDir catches the full subtree.
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
 		}
-		for _, ent := range entries {
-			if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".go") {
-				continue
+		if d.IsDir() {
+			// Skip testdata/ — it contains planted .go.txt fixtures that are
+			// exercised explicitly by TestNamespaceIsolation_PlantedViolationCaught.
+			if d.Name() == "testdata" {
+				return filepath.SkipDir
 			}
-			path := filepath.Join(root, ent.Name())
-			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
-			if err != nil {
-				t.Fatalf("parse %s: %v", path, err)
-			}
-			for _, imp := range file.Imports {
-				p := strings.Trim(imp.Path.Value, `"`)
-				if strings.Contains(p, "/vaillant/") || strings.HasSuffix(p, "/vaillant") {
-					violations = append(violations, path+": imports "+p)
-				}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Test files are allowed to reference fixtures by string path but
+		// must not import Vaillant packages either, so both .go and
+		// _test.go files are scanned uniformly.
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if perr != nil {
+			return perr
+		}
+		for _, imp := range file.Imports {
+			p := strings.Trim(imp.Path.Value, `"`)
+			if strings.Contains(p, "/vaillant/") || strings.HasSuffix(p, "/vaillant") {
+				violations = append(violations, path+": imports "+p)
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
 	}
 	if len(violations) > 0 {
 		t.Fatalf("namespace isolation violation (catalog/ebus_standard must not import Vaillant packages):\n  %s",
 			strings.Join(violations, "\n  "))
+	}
+}
+
+// TestNamespaceIsolation_RecursiveWalk_CatchesNestedViolation proves the
+// scanner descends into subdirectories. It copies the planted nested
+// fixture into a tempdir at a multi-level path and runs the same WalkDir
+// + parser.ImportsOnly pipeline the real test uses. A flat ReadDir
+// implementation would miss the deeply-nested file — this regression
+// test pins the recursive behavior.
+func TestNamespaceIsolation_RecursiveWalk_CatchesNestedViolation(t *testing.T) {
+	plantedPath := filepath.Join("testdata", "nested", "deeper", "planted_vaillant_nested.go.txt")
+	raw, err := os.ReadFile(plantedPath)
+	if err != nil {
+		t.Fatalf("read nested planted fixture: %v", err)
+	}
+	tmp := t.TempDir()
+	deep := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	tmpPath := filepath.Join(deep, "planted.go")
+	if err := os.WriteFile(tmpPath, raw, 0o644); err != nil {
+		t.Fatalf("write nested planted copy: %v", err)
+	}
+	var violations []string
+	err = filepath.WalkDir(tmp, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if perr != nil {
+			return perr
+		}
+		for _, imp := range file.Imports {
+			p := strings.Trim(imp.Path.Value, `"`)
+			if strings.Contains(p, "/vaillant/") || strings.HasSuffix(p, "/vaillant") {
+				violations = append(violations, path+": imports "+p)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk nested: %v", err)
+	}
+	if len(violations) == 0 {
+		t.Fatal("nested planted vaillant import was NOT caught — recursive walk regressed to flat ReadDir")
 	}
 }
 

--- a/catalog/ebus_standard/provider_namespace_isolation_test.go
+++ b/catalog/ebus_standard/provider_namespace_isolation_test.go
@@ -26,14 +26,14 @@ import (
 //     cross-vendor provider and silently bind the catalog to a single
 //     manufacturer.
 //
-// The test also includes a synthetic planted violation guarded by the
-// build tag `namespace_guard_violation`. When that tag is active (explicit
-// operator target), the file at testdata/planted_vaillant_import.go.txt
-// would be detected here. The test body ignores .txt fixtures (they are
-// not compiled), but under the build tag the fixture is symlinked or
-// copied by the Makefile/CI into a .go file to prove the scanner fires.
-// In the default build the .txt content is inert, keeping the regression
-// test zero-cost for normal runs.
+// The scanner's liveness is proven by companion tests below
+// (TestNamespaceIsolation_PlantedViolationCaught and
+// TestNamespaceIsolation_RecursiveWalk_CatchesNestedViolation) which
+// parse the `.go.txt` fixtures under testdata/ directly. The fixtures
+// are stored with a `.go.txt` extension specifically so that the default
+// go build ignores them (no build tags / Makefile / symlink indirection
+// is involved), which keeps this regression test zero-cost for normal
+// runs while still pinning the scanner's "not a no-op" guarantee.
 func TestNamespaceIsolation_NoVaillantImports(t *testing.T) {
 	var violations []string
 	// Walk the entire catalog/ebus_standard subtree recursively. A prior
@@ -162,7 +162,7 @@ func TestNamespaceIsolation_PlantedViolationCaught(t *testing.T) {
 			hits++
 		}
 	}
-	if hits == 0 {
-		t.Fatal("planted vaillant import was NOT caught — namespace-isolation scanner regressed")
+	if hits != 1 {
+		t.Fatalf("planted vaillant import: got %d hits, want exactly 1 — namespace-isolation scanner regressed or fixture changed", hits)
 	}
 }

--- a/catalog/ebus_standard/provider_namespace_isolation_test.go
+++ b/catalog/ebus_standard/provider_namespace_isolation_test.go
@@ -1,0 +1,102 @@
+package ebus_standard_catalog
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNamespaceIsolation_NoVaillantImports is the M3 AC6 regression test
+// that enforces build-time namespace isolation via static analysis. It
+// parses every Go file in the catalog/ebus_standard/... subtree and
+// asserts that NO import path contains "/vaillant/" or terminates with
+// "/vaillant". Together with the internal/safetypolicy placement (Go's
+// structural internal-rule prevents Vaillant-rooted importers), this
+// provides two lines of defense:
+//
+//  1. Structural: anything under internal/safetypolicy is unreachable
+//     from /vaillant/... packages per Go's compile-time internal rule.
+//  2. Static: this test catches accidental "the other direction" imports
+//     — code inside catalog/ebus_standard/ pulling Vaillant specifics into
+//     the generic namespace. That would leak Vaillant semantics into the
+//     cross-vendor provider and silently bind the catalog to a single
+//     manufacturer.
+//
+// The test also includes a synthetic planted violation guarded by the
+// build tag `namespace_guard_violation`. When that tag is active (explicit
+// operator target), the file at testdata/planted_vaillant_import.go.txt
+// would be detected here. The test body ignores .txt fixtures (they are
+// not compiled), but under the build tag the fixture is symlinked or
+// copied by the Makefile/CI into a .go file to prove the scanner fires.
+// In the default build the .txt content is inert, keeping the regression
+// test zero-cost for normal runs.
+func TestNamespaceIsolation_NoVaillantImports(t *testing.T) {
+	var violations []string
+	roots := []string{".", filepath.Join("internal", "safetypolicy")}
+	for _, root := range roots {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			t.Fatalf("readdir %s: %v", root, err)
+		}
+		for _, ent := range entries {
+			if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".go") {
+				continue
+			}
+			path := filepath.Join(root, ent.Name())
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			for _, imp := range file.Imports {
+				p := strings.Trim(imp.Path.Value, `"`)
+				if strings.Contains(p, "/vaillant/") || strings.HasSuffix(p, "/vaillant") {
+					violations = append(violations, path+": imports "+p)
+				}
+			}
+		}
+	}
+	if len(violations) > 0 {
+		t.Fatalf("namespace isolation violation (catalog/ebus_standard must not import Vaillant packages):\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+// TestNamespaceIsolation_PlantedViolationCaught asserts the scanner is
+// NOT a no-op: we feed it the planted fixture at
+// testdata/planted_vaillant_import.go.txt (which imports a real vaillant
+// package) and require that exactly one violation is returned. If this
+// ever stops firing, the scanner has regressed and the outer test is a
+// false-negative.
+func TestNamespaceIsolation_PlantedViolationCaught(t *testing.T) {
+	plantedPath := filepath.Join("testdata", "planted_vaillant_import.go.txt")
+	raw, err := os.ReadFile(plantedPath)
+	if err != nil {
+		t.Fatalf("read planted fixture: %v", err)
+	}
+	// Copy into a .go file in a temp dir so go/parser accepts it (parser
+	// itself is extension-agnostic, but we keep the parity explicit).
+	tmp := t.TempDir()
+	tmpPath := filepath.Join(tmp, "planted.go")
+	if err := os.WriteFile(tmpPath, raw, 0o644); err != nil {
+		t.Fatalf("write planted copy: %v", err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, tmpPath, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parse planted: %v", err)
+	}
+	var hits int
+	for _, imp := range file.Imports {
+		p := strings.Trim(imp.Path.Value, `"`)
+		if strings.Contains(p, "/vaillant/") || strings.HasSuffix(p, "/vaillant") {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Fatal("planted vaillant import was NOT caught — namespace-isolation scanner regressed")
+	}
+}

--- a/catalog/ebus_standard/provider_provenance_test.go
+++ b/catalog/ebus_standard/provider_provenance_test.go
@@ -1,0 +1,62 @@
+package ebus_standard_catalog
+
+import "testing"
+
+// TestCompareIdentity_RetainsBothOnDisagreement confirms the non-overwrite
+// policy from docs/architecture/ebus_standard/07-identity-provenance.md:
+// when DeviceInfo and the ebus_standard Identification disagree, both
+// values MUST be retained with source labels and Agreement=false.
+func TestCompareIdentity_RetainsBothOnDisagreement(t *testing.T) {
+	existing := DeviceInfo{
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0407",
+		HardwareVersion: "9001",
+	}
+	desc := IdentificationDescriptor{
+		Manufacturer:    "0xb5",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0407",
+		HardwareVersion: "9001",
+		Source:          string(SourceEBUSStandardIdent),
+		CatalogVersion:  CatalogVersion,
+		Valid:           true,
+	}
+	rec := CompareIdentity(existing, desc)
+
+	if rec.Manufacturer.Agreement {
+		t.Fatalf("Manufacturer.Agreement=true, want false (Vaillant != 0xb5)")
+	}
+	if rec.Manufacturer.Preferred != "Vaillant" {
+		t.Fatalf("Manufacturer.Preferred=%q, want %q (deterministic precedence: device_info wins)",
+			rec.Manufacturer.Preferred, "Vaillant")
+	}
+	if len(rec.Manufacturer.Sources) != 2 {
+		t.Fatalf("Manufacturer.Sources len=%d, want 2 (both sources retained)", len(rec.Manufacturer.Sources))
+	}
+	// Agreement rows for the identical fields must still carry both sources
+	// so consumers can see the evidence trail.
+	if !rec.DeviceID.Agreement {
+		t.Fatalf("DeviceID.Agreement=false, want true")
+	}
+}
+
+// TestCompareIdentity_DoesNotMutateExisting confirms the non-overwrite rule:
+// the existing DeviceInfo MUST remain byte-identical after the comparison.
+func TestCompareIdentity_DoesNotMutateExisting(t *testing.T) {
+	original := DeviceInfo{
+		Manufacturer: "Vaillant", DeviceID: "BAI00",
+		SoftwareVersion: "0407", HardwareVersion: "9001",
+	}
+	copy := original
+	desc := IdentificationDescriptor{
+		Manufacturer: "0xb5", DeviceID: "BAI00",
+		SoftwareVersion: "0407", HardwareVersion: "9001",
+		Source:         string(SourceEBUSStandardIdent),
+		CatalogVersion: CatalogVersion, Valid: true,
+	}
+	_ = CompareIdentity(copy, desc)
+	if copy != original {
+		t.Fatalf("CompareIdentity mutated existing DeviceInfo: before=%+v after=%+v", original, copy)
+	}
+}

--- a/catalog/ebus_standard/provider_provenance_test.go
+++ b/catalog/ebus_standard/provider_provenance_test.go
@@ -60,3 +60,122 @@ func TestCompareIdentity_DoesNotMutateExisting(t *testing.T) {
 		t.Fatalf("CompareIdentity mutated existing DeviceInfo: before=%+v after=%+v", original, copy)
 	}
 }
+
+// TestCompareIdentity_InvalidDescriptorDoesNotPromoteEmptyExisting confirms
+// that when existingVal is empty and the descriptor is marked invalid
+// (desc.Valid == false), the malformed descriptor value MUST NOT be
+// promoted to Preferred. This guards against surfacing failed-decode
+// identity as the canonical preferred value for new devices, which would
+// mislabel them until manually corrected (see docs/architecture/
+// ebus_standard/07-identity-provenance.md §"Deterministic Precedence":
+// an invalid descriptor is not a confident identity source).
+func TestCompareIdentity_InvalidDescriptorDoesNotPromoteEmptyExisting(t *testing.T) {
+	existing := DeviceInfo{} // no prior device_info evidence
+	desc := IdentificationDescriptor{
+		Manufacturer:    "??",
+		DeviceID:        "??",
+		SoftwareVersion: "??",
+		HardwareVersion: "??",
+		Source:          string(SourceEBUSStandardIdent),
+		CatalogVersion:  CatalogVersion,
+		Valid:           false, // malformed / failed decode
+	}
+	rec := CompareIdentity(existing, desc)
+
+	for name, fp := range map[string]FieldProvenance{
+		"Manufacturer":    rec.Manufacturer,
+		"DeviceID":        rec.DeviceID,
+		"SoftwareVersion": rec.SoftwareVersion,
+		"HardwareVersion": rec.HardwareVersion,
+	} {
+		if fp.Preferred != "" {
+			t.Fatalf("%s.Preferred=%q, want empty (invalid descriptor must not be promoted when existing is empty)",
+				name, fp.Preferred)
+		}
+		// Evidence trail must still carry the invalid descriptor value
+		// with Valid=false so downstream consumers can see it.
+		if len(fp.Sources) != 1 {
+			t.Fatalf("%s.Sources len=%d, want 1 (invalid descriptor retained in evidence trail)",
+				name, len(fp.Sources))
+		}
+		if fp.Sources[0].Valid {
+			t.Fatalf("%s.Sources[0].Valid=true, want false (descriptor was marked invalid)", name)
+		}
+	}
+}
+
+// TestCompareIdentity_ValidDescriptorPromotesEmptyExisting is the happy-path
+// sanity check for the empty-existing path: a VALID descriptor MUST be
+// promoted to Preferred when there is no prior device_info evidence.
+func TestCompareIdentity_ValidDescriptorPromotesEmptyExisting(t *testing.T) {
+	existing := DeviceInfo{} // no prior device_info evidence
+	desc := IdentificationDescriptor{
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0407",
+		HardwareVersion: "9001",
+		Source:          string(SourceEBUSStandardIdent),
+		CatalogVersion:  CatalogVersion,
+		Valid:           true,
+	}
+	rec := CompareIdentity(existing, desc)
+
+	if rec.Manufacturer.Preferred != "Vaillant" {
+		t.Fatalf("Manufacturer.Preferred=%q, want %q", rec.Manufacturer.Preferred, "Vaillant")
+	}
+	if rec.DeviceID.Preferred != "BAI00" {
+		t.Fatalf("DeviceID.Preferred=%q, want %q", rec.DeviceID.Preferred, "BAI00")
+	}
+	if rec.SoftwareVersion.Preferred != "0407" {
+		t.Fatalf("SoftwareVersion.Preferred=%q, want %q", rec.SoftwareVersion.Preferred, "0407")
+	}
+	if rec.HardwareVersion.Preferred != "9001" {
+		t.Fatalf("HardwareVersion.Preferred=%q, want %q", rec.HardwareVersion.Preferred, "9001")
+	}
+}
+
+// TestCompareIdentity_InvalidDescriptorPreservesExistingPrecedence confirms
+// that the existing precedence rule (device_info wins over descriptor) is
+// preserved when the descriptor is invalid AND existing is non-empty.
+// The invalid descriptor's value must be retained as evidence with
+// Valid=false, but Preferred must be the existing value.
+func TestCompareIdentity_InvalidDescriptorPreservesExistingPrecedence(t *testing.T) {
+	existing := DeviceInfo{
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0407",
+		HardwareVersion: "9001",
+	}
+	desc := IdentificationDescriptor{
+		Manufacturer:    "??",
+		DeviceID:        "??",
+		SoftwareVersion: "??",
+		HardwareVersion: "??",
+		Source:          string(SourceEBUSStandardIdent),
+		CatalogVersion:  CatalogVersion,
+		Valid:           false,
+	}
+	rec := CompareIdentity(existing, desc)
+
+	if rec.Manufacturer.Preferred != "Vaillant" {
+		t.Fatalf("Manufacturer.Preferred=%q, want %q (device_info precedence preserved)",
+			rec.Manufacturer.Preferred, "Vaillant")
+	}
+	if len(rec.Manufacturer.Sources) != 2 {
+		t.Fatalf("Manufacturer.Sources len=%d, want 2 (both sources retained as evidence)",
+			len(rec.Manufacturer.Sources))
+	}
+	// Locate the descriptor source and confirm Valid=false propagated.
+	foundInvalid := false
+	for _, s := range rec.Manufacturer.Sources {
+		if s.Source == SourceEBUSStandardIdent {
+			if s.Valid {
+				t.Fatalf("descriptor source Valid=true, want false (descriptor marked invalid)")
+			}
+			foundInvalid = true
+		}
+	}
+	if !foundInvalid {
+		t.Fatalf("descriptor source not present in Sources; got %+v", rec.Manufacturer.Sources)
+	}
+}

--- a/catalog/ebus_standard/provider_safety_enforcement_test.go
+++ b/catalog/ebus_standard/provider_safety_enforcement_test.go
@@ -28,8 +28,11 @@ func TestInvoke_SafetyClassGate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.class), func(t *testing.T) {
 			cat := syntheticCatalogForClass(tc.class)
-			p := NewProvider(cat, true)
-			_, err := p.Invoke(context.Background(), "ebus_standard.test.method", nil, CallerContextUserFacing)
+			p, err := NewProvider(cat, true)
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+			_, err = p.Invoke(context.Background(), "ebus_standard.test.method", nil, CallerContextUserFacing)
 			if tc.denied {
 				if !errors.Is(err, ErrSafetyClassDenied) {
 					t.Fatalf("class=%s err=%v, want ErrSafetyClassDenied", tc.class, err)
@@ -49,8 +52,11 @@ func TestInvoke_SafetyClassGate(t *testing.T) {
 // leak an earlier-than-planned escalation.
 func TestInvoke_SystemNMRuntimeCallerStillDenied(t *testing.T) {
 	cat := syntheticCatalogForClass(SafetyMutating)
-	p := NewProvider(cat, true)
-	_, err := p.Invoke(context.Background(), "ebus_standard.test.method", nil, CallerContextSystemNMRuntime)
+	p, err := NewProvider(cat, true)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	_, err = p.Invoke(context.Background(), "ebus_standard.test.method", nil, CallerContextSystemNMRuntime)
 	if !errors.Is(err, ErrSafetyClassDenied) {
 		t.Fatalf("err=%v, want ErrSafetyClassDenied for system_nm_runtime in M3", err)
 	}

--- a/catalog/ebus_standard/provider_safety_enforcement_test.go
+++ b/catalog/ebus_standard/provider_safety_enforcement_test.go
@@ -1,0 +1,100 @@
+package ebus_standard_catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestInvoke_SafetyClassGate exercises the invoke-boundary gate for every
+// safety class the catalog can carry. Allowed classes must NOT return
+// ErrSafetyClassDenied; denied classes MUST return it exactly.
+//
+// The test builds a synthetic single-command catalog per class so coverage
+// does not depend on which classes happen to appear in the real YAML.
+func TestInvoke_SafetyClassGate(t *testing.T) {
+	cases := []struct {
+		class  SafetyClass
+		denied bool
+	}{
+		{SafetyReadOnlySafe, false},
+		{SafetyReadOnlyBusLoad, false},
+		{SafetyMutating, true},
+		{SafetyDestructive, true},
+		{SafetyBroadcast, true},
+		{SafetyMemoryWrite, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.class), func(t *testing.T) {
+			cat := syntheticCatalogForClass(tc.class)
+			p := NewProvider(cat, true)
+			_, err := p.Invoke(context.Background(), "ebus_standard.test.method", nil, CallerContextUserFacing)
+			if tc.denied {
+				if !errors.Is(err, ErrSafetyClassDenied) {
+					t.Fatalf("class=%s err=%v, want ErrSafetyClassDenied", tc.class, err)
+				}
+			} else {
+				if errors.Is(err, ErrSafetyClassDenied) {
+					t.Fatalf("class=%s err=%v, want NOT ErrSafetyClassDenied", tc.class, err)
+				}
+			}
+		})
+	}
+}
+
+// TestInvoke_SystemNMRuntimeCallerStillDenied confirms that in M3 the
+// system_nm_runtime caller context is carried but does NOT whitelist any
+// mutating class. This contract is reserved for M4+ expansion; M3 must not
+// leak an earlier-than-planned escalation.
+func TestInvoke_SystemNMRuntimeCallerStillDenied(t *testing.T) {
+	cat := syntheticCatalogForClass(SafetyMutating)
+	p := NewProvider(cat, true)
+	_, err := p.Invoke(context.Background(), "ebus_standard.test.method", nil, CallerContextSystemNMRuntime)
+	if !errors.Is(err, ErrSafetyClassDenied) {
+		t.Fatalf("err=%v, want ErrSafetyClassDenied for system_nm_runtime in M3", err)
+	}
+}
+
+// syntheticCatalogForClass builds a one-service one-command catalog whose
+// single command carries the supplied safety_class. Its identity key is
+// complete and unique so LoadCatalog (indirectly, via the provider) has no
+// reason to reject it.
+func syntheticCatalogForClass(class SafetyClass) Catalog {
+	pb := uint8(0x03)
+	sb := uint8(0xF0)
+	return Catalog{
+		Namespace:  Namespace,
+		Version:    CatalogVersion,
+		PlanSHA256: CanonicalPlanSHA256,
+		Services: []Service{
+			{
+				PB:   &pb,
+				Name: "synthetic",
+				Commands: []Command{
+					{
+						ID:   "ebus_standard.test.method",
+						Name: "synthetic",
+						Identity: IdentityKey{
+							Namespace:                       Namespace,
+							PB:                              &pb,
+							SB:                              &sb,
+							SelectorPath:                    "",
+							TelegramClass:                   TelegramClassAddressed,
+							Direction:                       DirectionRequest,
+							RequestOrResponseRole:           RoleInitiator,
+							BroadcastOrAddressed:            AddressedDirect,
+							AnswerPolicy:                    AnswerRequired,
+							LengthPrefixMode:                LengthPrefixNone,
+							SelectorDecoder:                 "none",
+							ServiceVariant:                  "synthetic",
+							TransportCapabilityRequirements: []string{"master_slave"},
+							Version:                         CatalogVersion,
+						},
+						SafetyClass: class,
+					},
+				},
+			},
+		},
+	}
+}

--- a/catalog/ebus_standard/provider_test.go
+++ b/catalog/ebus_standard/provider_test.go
@@ -3,6 +3,7 @@ package ebus_standard_catalog
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -11,7 +12,10 @@ import (
 // phase: the stub returns an error.
 func TestProvider_ConstructsFromCatalog(t *testing.T) {
 	cat := MustEmbeddedCatalog()
-	p := NewProvider(cat, true)
+	p, err := NewProvider(cat, true)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
 	if p == nil {
 		t.Fatal("NewProvider returned nil")
 	}
@@ -25,7 +29,10 @@ func TestProvider_ConstructsFromCatalog(t *testing.T) {
 // ebus_standard.identification source label so downstream provenance code
 // cannot accidentally overwrite DeviceInfo.
 func TestProvider_IdentificationReturnsDescriptor(t *testing.T) {
-	p := NewProvider(MustEmbeddedCatalog(), true)
+	p, err := NewProvider(MustEmbeddedCatalog(), true)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
 	desc, err := p.Identification(context.Background())
 	if err != nil {
 		t.Fatalf("Identification returned error: %v", err)
@@ -41,7 +48,10 @@ func TestProvider_IdentificationReturnsDescriptor(t *testing.T) {
 // TestProvider_DisabledReturnsSentinel confirms that a provider constructed
 // in the disabled state refuses every entrypoint with ErrProviderDisabled.
 func TestProvider_DisabledReturnsSentinel(t *testing.T) {
-	p := NewProvider(MustEmbeddedCatalog(), false)
+	p, err := NewProvider(MustEmbeddedCatalog(), false)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
 	if p.IsEnabled() {
 		t.Fatal("expected IsEnabled() to be false")
 	}
@@ -59,7 +69,10 @@ func TestProvider_FromEnv_DefaultEnabled(t *testing.T) {
 	t.Setenv(DisableEnvVar, "")
 	// An empty string MUST be treated as "unset" => enabled by default.
 	// Use Unsetenv path via Setenv to "" then explicit unset.
-	p := NewProviderFromEnv(MustEmbeddedCatalog())
+	p, err := NewProviderFromEnv(MustEmbeddedCatalog())
+	if err != nil {
+		t.Fatalf("NewProviderFromEnv: %v", err)
+	}
 	if !p.IsEnabled() {
 		t.Fatal("empty env var should default to enabled")
 	}
@@ -71,7 +84,10 @@ func TestProvider_FromEnv_DisabledByFalse(t *testing.T) {
 	for _, v := range []string{"0", "false", "False", "FALSE"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(DisableEnvVar, v)
-			p := NewProviderFromEnv(MustEmbeddedCatalog())
+			p, err := NewProviderFromEnv(MustEmbeddedCatalog())
+			if err != nil {
+				t.Fatalf("NewProviderFromEnv: %v", err)
+			}
 			if p.IsEnabled() {
 				t.Fatalf("env=%q should produce disabled provider", v)
 			}
@@ -81,9 +97,71 @@ func TestProvider_FromEnv_DisabledByFalse(t *testing.T) {
 
 // TestProvider_UnknownMethodID confirms Invoke distinguishes "not in
 // catalog" from "safety denied".
+// TestProvider_DuplicateMethodIDRejected asserts NewProvider surfaces
+// ErrDuplicateMethodID when two catalog commands share the same ID. A
+// previous implementation silently overwrote the first entry in the
+// method index, which would cause Invoke to dispatch the wrong command.
+// The error message must name BOTH colliding commands.
+func TestProvider_DuplicateMethodIDRejected(t *testing.T) {
+	pb := uint8(0x03)
+	sbA := uint8(0xF0)
+	sbB := uint8(0xF1)
+	mkCmd := func(name string, sb uint8) Command {
+		return Command{
+			ID:   "ebus_standard.collision.method",
+			Name: name,
+			Identity: IdentityKey{
+				Namespace:                       Namespace,
+				PB:                              &pb,
+				SB:                              &sb,
+				TelegramClass:                   TelegramClassAddressed,
+				Direction:                       DirectionRequest,
+				RequestOrResponseRole:           RoleInitiator,
+				BroadcastOrAddressed:            AddressedDirect,
+				AnswerPolicy:                    AnswerRequired,
+				LengthPrefixMode:                LengthPrefixNone,
+				SelectorDecoder:                 "none",
+				ServiceVariant:                  "synthetic",
+				TransportCapabilityRequirements: []string{"master_slave"},
+				Version:                         CatalogVersion,
+			},
+			SafetyClass: SafetyReadOnlySafe,
+		}
+	}
+	cat := Catalog{
+		Namespace:  Namespace,
+		Version:    CatalogVersion,
+		PlanSHA256: CanonicalPlanSHA256,
+		Services: []Service{
+			{
+				PB:   &pb,
+				Name: "synthetic",
+				Commands: []Command{
+					mkCmd("first", sbA),
+					mkCmd("second", sbB),
+				},
+			},
+		},
+	}
+	p, err := NewProvider(cat, true)
+	if !errors.Is(err, ErrDuplicateMethodID) {
+		t.Fatalf("err=%v, want ErrDuplicateMethodID", err)
+	}
+	if p != nil {
+		t.Fatalf("expected nil provider on duplicate, got %+v", p)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "first") || !strings.Contains(msg, "second") {
+		t.Fatalf("error message %q must name both colliding commands", msg)
+	}
+}
+
 func TestProvider_UnknownMethodID(t *testing.T) {
-	p := NewProvider(MustEmbeddedCatalog(), true)
-	_, err := p.Invoke(context.Background(), "ebus_standard.does_not_exist", nil, CallerContextUserFacing)
+	p, err := NewProvider(MustEmbeddedCatalog(), true)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	_, err = p.Invoke(context.Background(), "ebus_standard.does_not_exist", nil, CallerContextUserFacing)
 	if !errors.Is(err, ErrUnknownMethod) {
 		t.Fatalf("err=%v, want ErrUnknownMethod", err)
 	}

--- a/catalog/ebus_standard/provider_test.go
+++ b/catalog/ebus_standard/provider_test.go
@@ -153,6 +153,63 @@ func TestProvider_DuplicateMethodIDRejected(t *testing.T) {
 	}
 }
 
+// TestProvider_EmptyMethodIDRejected asserts NewProvider fails fast with
+// ErrEmptyMethodID when a catalog command has an empty string ID. Without
+// this guard the bad entry would be indexed under "" and silently registered,
+// later surfacing as hard-to-diagnose ErrUnknownMethod behavior for normal
+// method names.
+func TestProvider_EmptyMethodIDRejected(t *testing.T) {
+	pb := uint8(0x03)
+	sb := uint8(0xF2)
+	cat := Catalog{
+		Namespace:  Namespace,
+		Version:    CatalogVersion,
+		PlanSHA256: CanonicalPlanSHA256,
+		Services: []Service{
+			{
+				PB:   &pb,
+				Name: "synthetic",
+				Commands: []Command{
+					{
+						ID:   "",
+						Name: "nameless",
+						Identity: IdentityKey{
+							Namespace:                       Namespace,
+							PB:                              &pb,
+							SB:                              &sb,
+							TelegramClass:                   TelegramClassAddressed,
+							Direction:                       DirectionRequest,
+							RequestOrResponseRole:           RoleInitiator,
+							BroadcastOrAddressed:            AddressedDirect,
+							AnswerPolicy:                    AnswerRequired,
+							LengthPrefixMode:                LengthPrefixNone,
+							SelectorDecoder:                 "none",
+							ServiceVariant:                  "synthetic",
+							TransportCapabilityRequirements: []string{"master_slave"},
+							Version:                         CatalogVersion,
+						},
+						SafetyClass: SafetyReadOnlySafe,
+					},
+				},
+			},
+		},
+	}
+	p, err := NewProvider(cat, true)
+	if !errors.Is(err, ErrEmptyMethodID) {
+		t.Fatalf("err=%v, want ErrEmptyMethodID", err)
+	}
+	if errors.Is(err, ErrDuplicateMethodID) {
+		t.Fatalf("err=%v must not be ErrDuplicateMethodID (empty-ID check must fire first)", err)
+	}
+	if p != nil {
+		t.Fatalf("expected nil provider on empty id, got %+v", p)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "synthetic") || !strings.Contains(msg, "nameless") {
+		t.Fatalf("error message %q must name service and command", msg)
+	}
+}
+
 // TestProvider_UnknownMethodID confirms Invoke distinguishes "not in
 // catalog" from "safety denied" by returning ErrUnknownMethod when the
 // requested method ID is absent from the catalog's method index.

--- a/catalog/ebus_standard/provider_test.go
+++ b/catalog/ebus_standard/provider_test.go
@@ -1,0 +1,90 @@
+package ebus_standard_catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestProvider_ConstructsFromCatalog confirms that NewProvider accepts the
+// embedded catalog and exposes Identification as a callable method. RED
+// phase: the stub returns an error.
+func TestProvider_ConstructsFromCatalog(t *testing.T) {
+	cat := MustEmbeddedCatalog()
+	p := NewProvider(cat, true)
+	if p == nil {
+		t.Fatal("NewProvider returned nil")
+	}
+	if !p.IsEnabled() {
+		t.Fatal("expected provider to be enabled when constructed with enabled=true")
+	}
+}
+
+// TestProvider_IdentificationReturnsDescriptor exercises the Identification
+// entrypoint on the enabled provider. The descriptor MUST carry the
+// ebus_standard.identification source label so downstream provenance code
+// cannot accidentally overwrite DeviceInfo.
+func TestProvider_IdentificationReturnsDescriptor(t *testing.T) {
+	p := NewProvider(MustEmbeddedCatalog(), true)
+	desc, err := p.Identification(context.Background())
+	if err != nil {
+		t.Fatalf("Identification returned error: %v", err)
+	}
+	if desc.Source != string(SourceEBUSStandardIdent) {
+		t.Fatalf("descriptor.Source=%q, want %q", desc.Source, SourceEBUSStandardIdent)
+	}
+	if desc.CatalogVersion != CatalogVersion {
+		t.Fatalf("descriptor.CatalogVersion=%q, want %q", desc.CatalogVersion, CatalogVersion)
+	}
+}
+
+// TestProvider_DisabledReturnsSentinel confirms that a provider constructed
+// in the disabled state refuses every entrypoint with ErrProviderDisabled.
+func TestProvider_DisabledReturnsSentinel(t *testing.T) {
+	p := NewProvider(MustEmbeddedCatalog(), false)
+	if p.IsEnabled() {
+		t.Fatal("expected IsEnabled() to be false")
+	}
+	if _, err := p.Identification(context.Background()); !errors.Is(err, ErrProviderDisabled) {
+		t.Fatalf("Identification err=%v, want ErrProviderDisabled", err)
+	}
+	if _, err := p.Invoke(context.Background(), "ebus_standard.service_data.start_counts", nil, CallerContextUserFacing); !errors.Is(err, ErrProviderDisabled) {
+		t.Fatalf("Invoke err=%v, want ErrProviderDisabled", err)
+	}
+}
+
+// TestProvider_FromEnv_DefaultEnabled confirms the env-var default (unset =
+// enabled).
+func TestProvider_FromEnv_DefaultEnabled(t *testing.T) {
+	t.Setenv(DisableEnvVar, "")
+	// An empty string MUST be treated as "unset" => enabled by default.
+	// Use Unsetenv path via Setenv to "" then explicit unset.
+	p := NewProviderFromEnv(MustEmbeddedCatalog())
+	if !p.IsEnabled() {
+		t.Fatal("empty env var should default to enabled")
+	}
+}
+
+// TestProvider_FromEnv_DisabledByFalse confirms that common "false" spellings
+// disable the provider.
+func TestProvider_FromEnv_DisabledByFalse(t *testing.T) {
+	for _, v := range []string{"0", "false", "False", "FALSE"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(DisableEnvVar, v)
+			p := NewProviderFromEnv(MustEmbeddedCatalog())
+			if p.IsEnabled() {
+				t.Fatalf("env=%q should produce disabled provider", v)
+			}
+		})
+	}
+}
+
+// TestProvider_UnknownMethodID confirms Invoke distinguishes "not in
+// catalog" from "safety denied".
+func TestProvider_UnknownMethodID(t *testing.T) {
+	p := NewProvider(MustEmbeddedCatalog(), true)
+	_, err := p.Invoke(context.Background(), "ebus_standard.does_not_exist", nil, CallerContextUserFacing)
+	if !errors.Is(err, ErrUnknownMethod) {
+		t.Fatalf("err=%v, want ErrUnknownMethod", err)
+	}
+}

--- a/catalog/ebus_standard/provider_test.go
+++ b/catalog/ebus_standard/provider_test.go
@@ -63,12 +63,11 @@ func TestProvider_DisabledReturnsSentinel(t *testing.T) {
 	}
 }
 
-// TestProvider_FromEnv_DefaultEnabled confirms the env-var default (unset =
-// enabled).
+// TestProvider_FromEnv_DefaultEnabled confirms the env-var default
+// behavior: an empty string MUST be treated as "unset" and the provider
+// MUST default to enabled.
 func TestProvider_FromEnv_DefaultEnabled(t *testing.T) {
 	t.Setenv(DisableEnvVar, "")
-	// An empty string MUST be treated as "unset" => enabled by default.
-	// Use Unsetenv path via Setenv to "" then explicit unset.
 	p, err := NewProviderFromEnv(MustEmbeddedCatalog())
 	if err != nil {
 		t.Fatalf("NewProviderFromEnv: %v", err)
@@ -95,8 +94,6 @@ func TestProvider_FromEnv_DisabledByFalse(t *testing.T) {
 	}
 }
 
-// TestProvider_UnknownMethodID confirms Invoke distinguishes "not in
-// catalog" from "safety denied".
 // TestProvider_DuplicateMethodIDRejected asserts NewProvider surfaces
 // ErrDuplicateMethodID when two catalog commands share the same ID. A
 // previous implementation silently overwrote the first entry in the
@@ -156,6 +153,9 @@ func TestProvider_DuplicateMethodIDRejected(t *testing.T) {
 	}
 }
 
+// TestProvider_UnknownMethodID confirms Invoke distinguishes "not in
+// catalog" from "safety denied" by returning ErrUnknownMethod when the
+// requested method ID is absent from the catalog's method index.
 func TestProvider_UnknownMethodID(t *testing.T) {
 	p, err := NewProvider(MustEmbeddedCatalog(), true)
 	if err != nil {

--- a/catalog/ebus_standard/testdata/nested/deeper/planted_vaillant_nested.go.txt
+++ b/catalog/ebus_standard/testdata/nested/deeper/planted_vaillant_nested.go.txt
@@ -1,0 +1,9 @@
+// Deeply nested planted namespace-isolation violation fixture. Mirrors
+// testdata/planted_vaillant_import.go.txt but lives at a multi-level path
+// to exercise the recursive-walk guarantee in
+// TestNamespaceIsolation_RecursiveWalk_CatchesNestedViolation.
+package ebus_standard_catalog
+
+import (
+	_ "github.com/Project-Helianthus/helianthus-ebusreg/vaillant/dhw"
+)

--- a/catalog/ebus_standard/testdata/planted_vaillant_import.go.txt
+++ b/catalog/ebus_standard/testdata/planted_vaillant_import.go.txt
@@ -1,0 +1,12 @@
+// Planted namespace-isolation violation fixture. This file is a .go.txt
+// (not .go) so the Go toolchain ignores it during normal builds. The M3
+// AC6 regression test `TestNamespaceIsolation_PlantedViolationCaught`
+// copies the fixture into a temp file and re-parses it through the same
+// import-scanner used on the real tree, asserting the scanner flags it.
+// That keeps the regression proof self-contained without any real build-
+// tag tagging of a compiled .go file that could drift.
+package ebus_standard_catalog
+
+import (
+	_ "github.com/Project-Helianthus/helianthus-ebusreg/vaillant/system"
+)

--- a/catalog/ebus_standard/testdata/provider_abi.golden.txt
+++ b/catalog/ebus_standard/testdata/provider_abi.golden.txt
@@ -1,0 +1,93 @@
+ebus_standard_catalog const AddressedBroadcast
+ebus_standard_catalog const AddressedDirect
+ebus_standard_catalog const AnswerNone
+ebus_standard_catalog const AnswerRequired
+ebus_standard_catalog const CallerContextSystemNMRuntime
+ebus_standard_catalog const CallerContextUserFacing
+ebus_standard_catalog const CanonicalPlanSHA256
+ebus_standard_catalog const CatalogVersion
+ebus_standard_catalog const DirectionRequest
+ebus_standard_catalog const DirectionResponse
+ebus_standard_catalog const DisableEnvVar
+ebus_standard_catalog const LengthPrefixByte
+ebus_standard_catalog const LengthPrefixFixed
+ebus_standard_catalog const LengthPrefixNone
+ebus_standard_catalog const LengthPrefixTypedPayload
+ebus_standard_catalog const Namespace
+ebus_standard_catalog const RoleInitiator
+ebus_standard_catalog const RoleOriginator
+ebus_standard_catalog const RoleResponder
+ebus_standard_catalog const SafetyBroadcast
+ebus_standard_catalog const SafetyDestructive
+ebus_standard_catalog const SafetyMemoryWrite
+ebus_standard_catalog const SafetyMutating
+ebus_standard_catalog const SafetyReadOnlyBusLoad
+ebus_standard_catalog const SafetyReadOnlySafe
+ebus_standard_catalog const SourceDeviceInfo
+ebus_standard_catalog const SourceEBUSStandardIdent
+ebus_standard_catalog const SourceOperatorSeed
+ebus_standard_catalog const SourcePassiveObservation
+ebus_standard_catalog const TelegramClassAddressed
+ebus_standard_catalog const TelegramClassBroadcast
+ebus_standard_catalog const TelegramClassControllerBroadcast
+ebus_standard_catalog const TelegramClassInitiatorInitiator
+ebus_standard_catalog func (*Provider) Identificationfunc (p *Provider) Identification(ctx context.Context) (IdentificationDescriptor, error)
+ebus_standard_catalog func (*Provider) Invokefunc (p *Provider) Invoke(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error)
+ebus_standard_catalog func (*Provider) IsEnabledfunc (p *Provider) IsEnabled() bool
+ebus_standard_catalog func (IdentityKey) IsCompletefunc (k IdentityKey) IsComplete() bool
+ebus_standard_catalog func (IdentityKey) PBValuefunc (k IdentityKey) PBValue() uint8
+ebus_standard_catalog func (IdentityKey) SBValuefunc (k IdentityKey) SBValue() uint8
+ebus_standard_catalog func (Service) PBValuefunc (s Service) PBValue() uint8
+ebus_standard_catalog func CompareIdentityfunc CompareIdentity(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord
+ebus_standard_catalog func ComputeContentSHA256func ComputeContentSHA256(data []byte) string
+ebus_standard_catalog func ComputeContentSHA256func ComputeContentSHA256(data []byte) string
+ebus_standard_catalog func EmbeddedYAMLfunc EmbeddedYAML() []byte
+ebus_standard_catalog func LoadCatalogfunc LoadCatalog(data []byte) (Catalog, error)
+ebus_standard_catalog func MustEmbeddedCatalogfunc MustEmbeddedCatalog() Catalog
+ebus_standard_catalog func NewProviderFromEnvfunc NewProviderFromEnv(cat Catalog) *Provider
+ebus_standard_catalog func NewProviderfunc NewProvider(cat Catalog, enabled bool) *Provider
+ebus_standard_catalog type AnswerPolicy = string
+ebus_standard_catalog type BroadcastOrAddressed = string
+ebus_standard_catalog type CallerContext = int
+ebus_standard_catalog type Catalog = struct { Namespace string `yaml:"namespace"` Version string `yaml:"version"` PlanSHA256 string `yaml:"plan_sha256"` Services []Service `yaml:"services"` // ContentSHA256 is the SHA-256 of the raw YAML bytes. It is populated // by the loader, not read from the YAML itself. ContentSHA256 string `yaml:"-"` }
+ebus_standard_catalog type Command = struct { ID string `yaml:"id"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Identity IdentityKey `yaml:"identity"` SafetyClass SafetyClass `yaml:"safety_class"` Request []Parameter `yaml:"request,omitempty"` Response []Parameter `yaml:"response,omitempty"` }
+ebus_standard_catalog type DeviceInfo = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string }
+ebus_standard_catalog type Direction = string
+ebus_standard_catalog type FieldProvenance = struct { Preferred string Sources []IdentitySourceValue Agreement bool }
+ebus_standard_catalog type IdentificationDescriptor = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string // Provenance fields per architecture doc 07-identity-provenance.md // (source=ebus_standard.identification, catalog version, decode // validity). Source string CatalogVersion string Valid bool }
+ebus_standard_catalog type IdentityKey = struct { Namespace string `yaml:"namespace"` // PB and SB are pointer-typed so the YAML loader can distinguish an // absent key (nil → ErrIncompleteIdentityKey) from an explicit zero // value (e.g. `pb: 0x00` is legitimate and must be accepted). PB *uint8 `yaml:"pb"` SB *uint8 `yaml:"sb"` SelectorPath string `yaml:"selector_path"` // nullable ("" = no selector) TelegramClass TelegramClass `yaml:"telegram_class"` Direction Direction `yaml:"direction"` RequestOrResponseRole RequestOrResponseRole `yaml:"request_or_response_role"` BroadcastOrAddressed BroadcastOrAddressed `yaml:"broadcast_or_addressed"` AnswerPolicy AnswerPolicy `yaml:"answer_policy"` LengthPrefixMode LengthPrefixMode `yaml:"length_prefix_mode"` SelectorDecoder string `yaml:"selector_decoder"` ServiceVariant string `yaml:"service_variant"` TransportCapabilityRequirements []string `yaml:"transport_capability_requirements"` Version string `yaml:"version"` }
+ebus_standard_catalog type IdentitySource = string
+ebus_standard_catalog type IdentitySourceValue = struct { Source IdentitySource Value string Valid bool }
+ebus_standard_catalog type LengthPrefixMode = string
+ebus_standard_catalog type Parameter = struct { Name string `yaml:"name"` Type string `yaml:"type"` Description string `yaml:"description,omitempty"` }
+ebus_standard_catalog type ProvenanceRecord = struct { Manufacturer FieldProvenance DeviceID FieldProvenance SoftwareVersion FieldProvenance HardwareVersion FieldProvenance }
+ebus_standard_catalog type Provider = struct { catalog Catalog methodIdx map[string]Command enabled bool }
+ebus_standard_catalog type RequestOrResponseRole = string
+ebus_standard_catalog type SafetyClass = string
+ebus_standard_catalog type Service = struct { PB *uint8 `yaml:"pb"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Commands []Command `yaml:"commands"` }
+ebus_standard_catalog type TelegramClass = string
+ebus_standard_catalog var ErrAmbiguousLengthSelector
+ebus_standard_catalog var ErrCatalogMissingServices
+ebus_standard_catalog var ErrDuplicateIdentityKey
+ebus_standard_catalog var ErrIncompleteIdentityKey
+ebus_standard_catalog var ErrInvalidNamespace
+ebus_standard_catalog var ErrProviderDisabled
+ebus_standard_catalog var ErrSafetyClassDenied
+ebus_standard_catalog var ErrServiceMissingCommands
+ebus_standard_catalog var ErrServiceMissingPB
+ebus_standard_catalog var ErrServicePBMismatch
+ebus_standard_catalog var ErrTinyGoUnsupported
+ebus_standard_catalog var ErrUnknownEnumValue
+ebus_standard_catalog var ErrUnknownMethod
+ebus_standard_catalog var ErrUnknownSafetyClass
+safetypolicy const Broadcast
+safetypolicy const CallerSystemNMRuntime
+safetypolicy const CallerUserFacing
+safetypolicy const Destructive
+safetypolicy const MemoryWrite
+safetypolicy const Mutating
+safetypolicy const ReadOnlyBusLoad
+safetypolicy const ReadOnlySafe
+safetypolicy func Allowfunc Allow(class Class, caller Caller) bool
+safetypolicy type Caller = int
+safetypolicy type Class = string

--- a/catalog/ebus_standard/testdata/provider_abi.golden.txt
+++ b/catalog/ebus_standard/testdata/provider_abi.golden.txt
@@ -31,31 +31,31 @@ ebus_standard_catalog const TelegramClassAddressed
 ebus_standard_catalog const TelegramClassBroadcast
 ebus_standard_catalog const TelegramClassControllerBroadcast
 ebus_standard_catalog const TelegramClassInitiatorInitiator
-ebus_standard_catalog func (*Provider) Identificationfunc (p *Provider) Identification(ctx context.Context) (IdentificationDescriptor, error)
-ebus_standard_catalog func (*Provider) Invokefunc (p *Provider) Invoke(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error)
-ebus_standard_catalog func (*Provider) IsEnabledfunc (p *Provider) IsEnabled() bool
-ebus_standard_catalog func (IdentityKey) IsCompletefunc (k IdentityKey) IsComplete() bool
-ebus_standard_catalog func (IdentityKey) PBValuefunc (k IdentityKey) PBValue() uint8
-ebus_standard_catalog func (IdentityKey) SBValuefunc (k IdentityKey) SBValue() uint8
-ebus_standard_catalog func (Service) PBValuefunc (s Service) PBValue() uint8
-ebus_standard_catalog func CompareIdentityfunc CompareIdentity(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord
-ebus_standard_catalog func ComputeContentSHA256func ComputeContentSHA256(data []byte) string
-ebus_standard_catalog func ComputeContentSHA256func ComputeContentSHA256(data []byte) string
-ebus_standard_catalog func EmbeddedYAMLfunc EmbeddedYAML() []byte
-ebus_standard_catalog func LoadCatalogfunc LoadCatalog(data []byte) (Catalog, error)
-ebus_standard_catalog func MustEmbeddedCatalogfunc MustEmbeddedCatalog() Catalog
-ebus_standard_catalog func NewProviderFromEnvfunc NewProviderFromEnv(cat Catalog) *Provider
-ebus_standard_catalog func NewProviderfunc NewProvider(cat Catalog, enabled bool) *Provider
+ebus_standard_catalog func (*Provider) Identificationfunc(ctx context.Context) (IdentificationDescriptor, error)
+ebus_standard_catalog func (*Provider) Invokefunc(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error)
+ebus_standard_catalog func (*Provider) IsEnabledfunc() bool
+ebus_standard_catalog func (IdentityKey) IsCompletefunc() bool
+ebus_standard_catalog func (IdentityKey) PBValuefunc() uint8
+ebus_standard_catalog func (IdentityKey) SBValuefunc() uint8
+ebus_standard_catalog func (Service) PBValuefunc() uint8
+ebus_standard_catalog func CompareIdentityfunc(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord
+ebus_standard_catalog func ComputeContentSHA256func(data []byte) string
+ebus_standard_catalog func ComputeContentSHA256func(data []byte) string
+ebus_standard_catalog func EmbeddedYAMLfunc() []byte
+ebus_standard_catalog func LoadCatalogfunc(data []byte) (Catalog, error)
+ebus_standard_catalog func MustEmbeddedCatalogfunc() Catalog
+ebus_standard_catalog func NewProviderFromEnvfunc(cat Catalog) (*Provider, error)
+ebus_standard_catalog func NewProviderfunc(cat Catalog, enabled bool) (*Provider, error)
 ebus_standard_catalog type AnswerPolicy = string
 ebus_standard_catalog type BroadcastOrAddressed = string
 ebus_standard_catalog type CallerContext = int
-ebus_standard_catalog type Catalog = struct { Namespace string `yaml:"namespace"` Version string `yaml:"version"` PlanSHA256 string `yaml:"plan_sha256"` Services []Service `yaml:"services"` // ContentSHA256 is the SHA-256 of the raw YAML bytes. It is populated // by the loader, not read from the YAML itself. ContentSHA256 string `yaml:"-"` }
+ebus_standard_catalog type Catalog = struct { Namespace string `yaml:"namespace"` Version string `yaml:"version"` PlanSHA256 string `yaml:"plan_sha256"` Services []Service `yaml:"services"` ContentSHA256 string `yaml:"-"` }
 ebus_standard_catalog type Command = struct { ID string `yaml:"id"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Identity IdentityKey `yaml:"identity"` SafetyClass SafetyClass `yaml:"safety_class"` Request []Parameter `yaml:"request,omitempty"` Response []Parameter `yaml:"response,omitempty"` }
 ebus_standard_catalog type DeviceInfo = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string }
 ebus_standard_catalog type Direction = string
 ebus_standard_catalog type FieldProvenance = struct { Preferred string Sources []IdentitySourceValue Agreement bool }
-ebus_standard_catalog type IdentificationDescriptor = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string // Provenance fields per architecture doc 07-identity-provenance.md // (source=ebus_standard.identification, catalog version, decode // validity). Source string CatalogVersion string Valid bool }
-ebus_standard_catalog type IdentityKey = struct { Namespace string `yaml:"namespace"` // PB and SB are pointer-typed so the YAML loader can distinguish an // absent key (nil → ErrIncompleteIdentityKey) from an explicit zero // value (e.g. `pb: 0x00` is legitimate and must be accepted). PB *uint8 `yaml:"pb"` SB *uint8 `yaml:"sb"` SelectorPath string `yaml:"selector_path"` // nullable ("" = no selector) TelegramClass TelegramClass `yaml:"telegram_class"` Direction Direction `yaml:"direction"` RequestOrResponseRole RequestOrResponseRole `yaml:"request_or_response_role"` BroadcastOrAddressed BroadcastOrAddressed `yaml:"broadcast_or_addressed"` AnswerPolicy AnswerPolicy `yaml:"answer_policy"` LengthPrefixMode LengthPrefixMode `yaml:"length_prefix_mode"` SelectorDecoder string `yaml:"selector_decoder"` ServiceVariant string `yaml:"service_variant"` TransportCapabilityRequirements []string `yaml:"transport_capability_requirements"` Version string `yaml:"version"` }
+ebus_standard_catalog type IdentificationDescriptor = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string Source string CatalogVersion string Valid bool }
+ebus_standard_catalog type IdentityKey = struct { Namespace string `yaml:"namespace"` PB *uint8 `yaml:"pb"` SB *uint8 `yaml:"sb"` SelectorPath string `yaml:"selector_path"` TelegramClass TelegramClass `yaml:"telegram_class"` Direction Direction `yaml:"direction"` RequestOrResponseRole RequestOrResponseRole `yaml:"request_or_response_role"` BroadcastOrAddressed BroadcastOrAddressed `yaml:"broadcast_or_addressed"` AnswerPolicy AnswerPolicy `yaml:"answer_policy"` LengthPrefixMode LengthPrefixMode `yaml:"length_prefix_mode"` SelectorDecoder string `yaml:"selector_decoder"` ServiceVariant string `yaml:"service_variant"` TransportCapabilityRequirements []string `yaml:"transport_capability_requirements"` Version string `yaml:"version"` }
 ebus_standard_catalog type IdentitySource = string
 ebus_standard_catalog type IdentitySourceValue = struct { Source IdentitySource Value string Valid bool }
 ebus_standard_catalog type LengthPrefixMode = string
@@ -69,6 +69,7 @@ ebus_standard_catalog type TelegramClass = string
 ebus_standard_catalog var ErrAmbiguousLengthSelector
 ebus_standard_catalog var ErrCatalogMissingServices
 ebus_standard_catalog var ErrDuplicateIdentityKey
+ebus_standard_catalog var ErrDuplicateMethodID
 ebus_standard_catalog var ErrIncompleteIdentityKey
 ebus_standard_catalog var ErrInvalidNamespace
 ebus_standard_catalog var ErrProviderDisabled
@@ -88,6 +89,6 @@ safetypolicy const MemoryWrite
 safetypolicy const Mutating
 safetypolicy const ReadOnlyBusLoad
 safetypolicy const ReadOnlySafe
-safetypolicy func Allowfunc Allow(class Class, caller Caller) bool
+safetypolicy func Allowfunc(class Class, caller Caller) bool
 safetypolicy type Caller = int
 safetypolicy type Class = string

--- a/catalog/ebus_standard/testdata/provider_abi.golden.txt
+++ b/catalog/ebus_standard/testdata/provider_abi.golden.txt
@@ -46,26 +46,26 @@ ebus_standard_catalog func LoadCatalogfunc(data []byte) (Catalog, error)
 ebus_standard_catalog func MustEmbeddedCatalogfunc() Catalog
 ebus_standard_catalog func NewProviderFromEnvfunc(cat Catalog) (*Provider, error)
 ebus_standard_catalog func NewProviderfunc(cat Catalog, enabled bool) (*Provider, error)
-ebus_standard_catalog type AnswerPolicy = string
-ebus_standard_catalog type BroadcastOrAddressed = string
-ebus_standard_catalog type CallerContext = int
-ebus_standard_catalog type Catalog = struct { Namespace string `yaml:"namespace"` Version string `yaml:"version"` PlanSHA256 string `yaml:"plan_sha256"` Services []Service `yaml:"services"` ContentSHA256 string `yaml:"-"` }
-ebus_standard_catalog type Command = struct { ID string `yaml:"id"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Identity IdentityKey `yaml:"identity"` SafetyClass SafetyClass `yaml:"safety_class"` Request []Parameter `yaml:"request,omitempty"` Response []Parameter `yaml:"response,omitempty"` }
-ebus_standard_catalog type DeviceInfo = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string }
-ebus_standard_catalog type Direction = string
-ebus_standard_catalog type FieldProvenance = struct { Preferred string Sources []IdentitySourceValue Agreement bool }
-ebus_standard_catalog type IdentificationDescriptor = struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string Source string CatalogVersion string Valid bool }
-ebus_standard_catalog type IdentityKey = struct { Namespace string `yaml:"namespace"` PB *uint8 `yaml:"pb"` SB *uint8 `yaml:"sb"` SelectorPath string `yaml:"selector_path"` TelegramClass TelegramClass `yaml:"telegram_class"` Direction Direction `yaml:"direction"` RequestOrResponseRole RequestOrResponseRole `yaml:"request_or_response_role"` BroadcastOrAddressed BroadcastOrAddressed `yaml:"broadcast_or_addressed"` AnswerPolicy AnswerPolicy `yaml:"answer_policy"` LengthPrefixMode LengthPrefixMode `yaml:"length_prefix_mode"` SelectorDecoder string `yaml:"selector_decoder"` ServiceVariant string `yaml:"service_variant"` TransportCapabilityRequirements []string `yaml:"transport_capability_requirements"` Version string `yaml:"version"` }
-ebus_standard_catalog type IdentitySource = string
-ebus_standard_catalog type IdentitySourceValue = struct { Source IdentitySource Value string Valid bool }
-ebus_standard_catalog type LengthPrefixMode = string
-ebus_standard_catalog type Parameter = struct { Name string `yaml:"name"` Type string `yaml:"type"` Description string `yaml:"description,omitempty"` }
-ebus_standard_catalog type ProvenanceRecord = struct { Manufacturer FieldProvenance DeviceID FieldProvenance SoftwareVersion FieldProvenance HardwareVersion FieldProvenance }
-ebus_standard_catalog type Provider = struct { catalog Catalog methodIdx map[string]Command enabled bool }
-ebus_standard_catalog type RequestOrResponseRole = string
-ebus_standard_catalog type SafetyClass = string
-ebus_standard_catalog type Service = struct { PB *uint8 `yaml:"pb"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Commands []Command `yaml:"commands"` }
-ebus_standard_catalog type TelegramClass = string
+ebus_standard_catalog type AnswerPolicy string
+ebus_standard_catalog type BroadcastOrAddressed string
+ebus_standard_catalog type CallerContext int
+ebus_standard_catalog type Catalog struct { Namespace string `yaml:"namespace"` Version string `yaml:"version"` PlanSHA256 string `yaml:"plan_sha256"` Services []Service `yaml:"services"` ContentSHA256 string `yaml:"-"` }
+ebus_standard_catalog type Command struct { ID string `yaml:"id"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Identity IdentityKey `yaml:"identity"` SafetyClass SafetyClass `yaml:"safety_class"` Request []Parameter `yaml:"request,omitempty"` Response []Parameter `yaml:"response,omitempty"` }
+ebus_standard_catalog type DeviceInfo struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string }
+ebus_standard_catalog type Direction string
+ebus_standard_catalog type FieldProvenance struct { Preferred string Sources []IdentitySourceValue Agreement bool }
+ebus_standard_catalog type IdentificationDescriptor struct { Manufacturer string DeviceID string SoftwareVersion string HardwareVersion string Source string CatalogVersion string Valid bool }
+ebus_standard_catalog type IdentityKey struct { Namespace string `yaml:"namespace"` PB *uint8 `yaml:"pb"` SB *uint8 `yaml:"sb"` SelectorPath string `yaml:"selector_path"` TelegramClass TelegramClass `yaml:"telegram_class"` Direction Direction `yaml:"direction"` RequestOrResponseRole RequestOrResponseRole `yaml:"request_or_response_role"` BroadcastOrAddressed BroadcastOrAddressed `yaml:"broadcast_or_addressed"` AnswerPolicy AnswerPolicy `yaml:"answer_policy"` LengthPrefixMode LengthPrefixMode `yaml:"length_prefix_mode"` SelectorDecoder string `yaml:"selector_decoder"` ServiceVariant string `yaml:"service_variant"` TransportCapabilityRequirements []string `yaml:"transport_capability_requirements"` Version string `yaml:"version"` }
+ebus_standard_catalog type IdentitySource string
+ebus_standard_catalog type IdentitySourceValue struct { Source IdentitySource Value string Valid bool }
+ebus_standard_catalog type LengthPrefixMode string
+ebus_standard_catalog type Parameter struct { Name string `yaml:"name"` Type string `yaml:"type"` Description string `yaml:"description,omitempty"` }
+ebus_standard_catalog type ProvenanceRecord struct { Manufacturer FieldProvenance DeviceID FieldProvenance SoftwareVersion FieldProvenance HardwareVersion FieldProvenance }
+ebus_standard_catalog type Provider struct { catalog Catalog methodIdx map[string]Command enabled bool }
+ebus_standard_catalog type RequestOrResponseRole string
+ebus_standard_catalog type SafetyClass string
+ebus_standard_catalog type Service struct { PB *uint8 `yaml:"pb"` Name string `yaml:"name"` Description string `yaml:"description,omitempty"` Commands []Command `yaml:"commands"` }
+ebus_standard_catalog type TelegramClass string
 ebus_standard_catalog var ErrAmbiguousLengthSelector
 ebus_standard_catalog var ErrCatalogMissingServices
 ebus_standard_catalog var ErrDuplicateIdentityKey
@@ -90,5 +90,5 @@ safetypolicy const Mutating
 safetypolicy const ReadOnlyBusLoad
 safetypolicy const ReadOnlySafe
 safetypolicy func Allowfunc(class Class, caller Caller) bool
-safetypolicy type Caller = int
-safetypolicy type Class = string
+safetypolicy type Caller int
+safetypolicy type Class string

--- a/catalog/ebus_standard/testdata/provider_abi.golden.txt
+++ b/catalog/ebus_standard/testdata/provider_abi.golden.txt
@@ -69,6 +69,7 @@ ebus_standard_catalog var ErrAmbiguousLengthSelector
 ebus_standard_catalog var ErrCatalogMissingServices
 ebus_standard_catalog var ErrDuplicateIdentityKey
 ebus_standard_catalog var ErrDuplicateMethodID
+ebus_standard_catalog var ErrEmptyMethodID
 ebus_standard_catalog var ErrIncompleteIdentityKey
 ebus_standard_catalog var ErrInvalidNamespace
 ebus_standard_catalog var ErrProviderDisabled

--- a/catalog/ebus_standard/testdata/provider_abi.golden.txt
+++ b/catalog/ebus_standard/testdata/provider_abi.golden.txt
@@ -40,7 +40,6 @@ ebus_standard_catalog func (IdentityKey) SBValuefunc() uint8
 ebus_standard_catalog func (Service) PBValuefunc() uint8
 ebus_standard_catalog func CompareIdentityfunc(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord
 ebus_standard_catalog func ComputeContentSHA256func(data []byte) string
-ebus_standard_catalog func ComputeContentSHA256func(data []byte) string
 ebus_standard_catalog func EmbeddedYAMLfunc() []byte
 ebus_standard_catalog func LoadCatalogfunc(data []byte) (Catalog, error)
 ebus_standard_catalog func MustEmbeddedCatalogfunc() Catalog
@@ -77,7 +76,6 @@ ebus_standard_catalog var ErrSafetyClassDenied
 ebus_standard_catalog var ErrServiceMissingCommands
 ebus_standard_catalog var ErrServiceMissingPB
 ebus_standard_catalog var ErrServicePBMismatch
-ebus_standard_catalog var ErrTinyGoUnsupported
 ebus_standard_catalog var ErrUnknownEnumValue
 ebus_standard_catalog var ErrUnknownMethod
 ebus_standard_catalog var ErrUnknownSafetyClass

--- a/catalog/ebus_standard/testdata/provider_abi.golden.txt
+++ b/catalog/ebus_standard/testdata/provider_abi.golden.txt
@@ -31,20 +31,20 @@ ebus_standard_catalog const TelegramClassAddressed
 ebus_standard_catalog const TelegramClassBroadcast
 ebus_standard_catalog const TelegramClassControllerBroadcast
 ebus_standard_catalog const TelegramClassInitiatorInitiator
-ebus_standard_catalog func (*Provider) Identificationfunc(ctx context.Context) (IdentificationDescriptor, error)
-ebus_standard_catalog func (*Provider) Invokefunc(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error)
-ebus_standard_catalog func (*Provider) IsEnabledfunc() bool
-ebus_standard_catalog func (IdentityKey) IsCompletefunc() bool
-ebus_standard_catalog func (IdentityKey) PBValuefunc() uint8
-ebus_standard_catalog func (IdentityKey) SBValuefunc() uint8
-ebus_standard_catalog func (Service) PBValuefunc() uint8
-ebus_standard_catalog func CompareIdentityfunc(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord
-ebus_standard_catalog func ComputeContentSHA256func(data []byte) string
-ebus_standard_catalog func EmbeddedYAMLfunc() []byte
-ebus_standard_catalog func LoadCatalogfunc(data []byte) (Catalog, error)
-ebus_standard_catalog func MustEmbeddedCatalogfunc() Catalog
-ebus_standard_catalog func NewProviderFromEnvfunc(cat Catalog) (*Provider, error)
-ebus_standard_catalog func NewProviderfunc(cat Catalog, enabled bool) (*Provider, error)
+ebus_standard_catalog func (*Provider) Identification(ctx context.Context) (IdentificationDescriptor, error)
+ebus_standard_catalog func (*Provider) Invoke(ctx context.Context, methodID string, params map[string]any, caller CallerContext) (map[string]any, error)
+ebus_standard_catalog func (*Provider) IsEnabled() bool
+ebus_standard_catalog func (IdentityKey) IsComplete() bool
+ebus_standard_catalog func (IdentityKey) PBValue() uint8
+ebus_standard_catalog func (IdentityKey) SBValue() uint8
+ebus_standard_catalog func (Service) PBValue() uint8
+ebus_standard_catalog func CompareIdentity(existing DeviceInfo, desc IdentificationDescriptor) ProvenanceRecord
+ebus_standard_catalog func ComputeContentSHA256(data []byte) string
+ebus_standard_catalog func EmbeddedYAML() []byte
+ebus_standard_catalog func LoadCatalog(data []byte) (Catalog, error)
+ebus_standard_catalog func MustEmbeddedCatalog() Catalog
+ebus_standard_catalog func NewProvider(cat Catalog, enabled bool) (*Provider, error)
+ebus_standard_catalog func NewProviderFromEnv(cat Catalog) (*Provider, error)
 ebus_standard_catalog type AnswerPolicy string
 ebus_standard_catalog type BroadcastOrAddressed string
 ebus_standard_catalog type CallerContext int
@@ -87,6 +87,6 @@ safetypolicy const MemoryWrite
 safetypolicy const Mutating
 safetypolicy const ReadOnlyBusLoad
 safetypolicy const ReadOnlySafe
-safetypolicy func Allowfunc(class Class, caller Caller) bool
+safetypolicy func Allow(class Class, caller Caller) bool
 safetypolicy type Caller int
 safetypolicy type Class string


### PR DESCRIPTION
## Summary
M3 milestone of `ebus-standard-l7-services-w16-26.implementing`. Generic provider consuming the M2 catalog with identity provenance, disable switch, and three operator-approved robustness additions (ABI snapshot, namespace-isolation guard, invoke-boundary safety enforcement).

## Paired doc PR
[M3_DOC_COMPANION in helianthus-docs-ebus#269](https://github.com/Project-Helianthus/helianthus-docs-ebus/pull/269) — merges FIRST (anchors contract); this PR merges AFTER.

## Canonical
- Meta-issue: [Project-Helianthus/helianthus-execution-plans#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14)
- Issue: [#122](https://github.com/Project-Helianthus/helianthus-ebusreg/issues/122)
- Canonical-SHA256: `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`
- Deps merged: M1_TYPES (ebusgo#137 `3964e341`), M2_CATALOG (ebusreg#121 `ae05a98a`)

## Acceptance criteria satisfied

### Canonical plan M3
- [x] AC1 Generic provider — catalog-driven method surface via M2 catalog (`LoadCatalog`/`MustEmbeddedCatalog`); no per-device hard-coding
- [x] AC2 Identification descriptor method — `{manufacturer, device_id, software_version, hardware_version}` with provenance; does NOT mutate DeviceInfo
- [x] AC3 Identity provenance — disagreements retained with source labels; deterministic precedence; verified by `provider_provenance_test.go`
- [x] AC4 Disable switch — `EBUS_STANDARD_PROVIDER_ENABLED` env var, default=enabled; blast radius confined to ebus_standard; returns `ErrProviderDisabled` when flipped

### Operator scope additions (all 3)
- [x] AC5 CONTRACT_ABI_SNAPSHOT_TEST — `provider_abi_snapshot_test.go` + `testdata/provider_abi.golden.txt`; `-update` flag AND `UPDATE=1` env var supported; diff message instructs fixture refresh + rationale
- [x] AC6 BUILD_TIME_NAMESPACE_ISOLATION_GUARD — **option (a) `internal/` package discipline**. `catalog/ebus_standard/internal/safetypolicy/` holds the invoke-boundary gate (structurally unreachable from `vaillant/...` per Go internal rules). Static-import scanner (`provider_namespace_isolation_test.go`) enforces reverse direction; planted-fixture test (`testdata/planted_vaillant_import.go.txt`) asserts scanner is not a no-op.
- [x] AC7 INVOKE_BOUNDARY_SAFETY_CLASS_ENFORCEMENT_TEST — `provider_safety_enforcement_test.go` covers 4 denied classes (`mutating`/`destructive`/`broadcast`/`memory_write`) → `ErrSafetyClassDenied`, plus allowed baselines

## TDD strict — RED commit evidence
- RED commit: `6518862` `test(ebus_standard/provider): RED for M3 provider + ABI + isolation + safety-class enforcement`
- RED CI: `not_triggered_by_branch_push` (repo workflow fires only on push-to-main and pull_request; PR-open will fire on the squash-diff) — local evidence: `go test ./catalog/ebus_standard/...` FAILED at RED with stub panic/nil paths on every new test; confirmed before PHASE 3 impl started

## Files (9 new)
Implementation:
- `catalog/ebus_standard/provider.go`
- `catalog/ebus_standard/internal/safetypolicy/safetypolicy.go`

Tests:
- `provider_test.go`, `provider_safety_enforcement_test.go`, `provider_provenance_test.go`, `provider_abi_snapshot_test.go`, `provider_namespace_isolation_test.go`

Testdata:
- `provider_abi.golden.txt`, `planted_vaillant_import.go.txt`

No external files modified.

## Notable scope observation (M3 self-contained)

M1_TYPES (ebusgo `protocol/ebus_standard/types`) is not yet picked up in this repo's pinned `go.mod` revision. M3 provider is self-contained: catalog `Parameter` struct suffices for the dispatch surface. `Invoke` returns a descriptor stub with `executed=false` for allowed methods — wire-level decode lands once ebusgo types are published and `go.mod` is bumped (future work, natural fit for M4_GATEWAY_MCP or a follow-up dep bump).

This is consistent with plan scope — M3 is "provider generation from catalog + safety enforcement + provenance"; wire-level decoding is downstream.

## Gates
- TDD: strict (RED commit `6518862` + local-RED substitute evidence; CI fires on PR-open)
- Doc-gate: anchored by [helianthus-docs-ebus#269](https://github.com/Project-Helianthus/helianthus-docs-ebus/pull/269) (merges first)
- Transport-gate: N/A
- Smoke: none (offline Go tests)
- Local CI: pass — see commit status `ci/local` on `d9bfd06`

## Merge ordering
This PR merges AFTER M3_DOC_COMPANION (#269) merges in docs-ebus.

Tracks cruise-run [#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14). Closes #122.