### PR TITLE
feat(registry): M1_EBUSREG_DIRECTED_SCAN — ScanDirected API (cruise-run #20)

### DIFF
--- a/registry/scan.go
+++ b/registry/scan.go
@@ -23,6 +23,17 @@ const (
 
 var errScanResponsePayload = errors.New("scan: invalid response payload")
 
+// ErrScanDirectedEmptyTargets is returned by ScanDirected when it is
+// invoked with a nil or empty targets slice. ScanDirected requires an
+// explicit, bounded target list; the historical full-range fall-through
+// that Scan performs when targets is nil is deliberately not available
+// via this API.
+//
+// See AD10 in
+// helianthus-execution-plans/startup-admission-discovery-w17-26.locked/
+// 12-decision-matrix.md for the directed-scan contract.
+var ErrScanDirectedEmptyTargets = errors.New("scan: directed scan requires explicit non-empty targets")
+
 type ScanBus interface {
 	Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error)
 }
@@ -33,6 +44,34 @@ const scanCollisionMaxPasses = 3
 // frames/second; 100 ms per probe uses ~10 % of bus capacity for scanning
 // while leaving 90 % for semantic B524 polling traffic.
 const scanProbeDelay = 100 * time.Millisecond
+
+// ScanDirected performs a 07 04 identification scan over an explicit,
+// bounded set of targets. Unlike Scan, it refuses to fall through to
+// DefaultScanTargets: callers MUST supply a non-empty targets slice.
+// Nil or empty input returns ErrScanDirectedEmptyTargets and the bus is
+// not touched.
+//
+// Behaviour when targets is non-empty is identical to Scan. The same
+// target-capability rules apply (FrameTypeForTarget, initiator-capable
+// exclusion, SYN/ESC via FrameTypeUnknown), dedupe is consistent, and
+// the collision-retry loop is shared.
+//
+// This API is intended for startup admission on non-ebusd-tcp direct
+// transports where the gateway MUST probe only promoted suspects —
+// never the full 0x01..0xFD address range. Callers on the ebusd-tcp
+// sanctioned bounded-retry path should continue to use Scan directly
+// so that Scan(ctx, bus, registry, source, nil) retains its
+// fall-through semantics.
+//
+// See
+// helianthus-execution-plans/startup-admission-discovery-w17-26.locked/
+// 12-decision-matrix.md#ad10 for the directed-scan contract.
+func ScanDirected(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byte, targets []byte) ([]DeviceEntry, error) {
+	if len(targets) == 0 {
+		return nil, ErrScanDirectedEmptyTargets
+	}
+	return Scan(ctx, bus, registry, source, targets)
+}
 
 // Scan performs a 07 04 identification scan over the provided targets.
 func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byte, targets []byte) ([]DeviceEntry, error) {

--- a/registry/scan_directed_test.go
+++ b/registry/scan_directed_test.go
@@ -1,0 +1,144 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// TestScanDirectedRejectsNilTargets confirms that ScanDirected refuses
+// to fall through to DefaultScanTargets when given nil input. AD10 in
+// startup-admission-discovery-w17-26 requires this: startup admission
+// on non-ebusd-tcp direct transports MUST never emit a full-range scan.
+func TestScanDirectedRejectsNilTargets(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{}
+	entries, err := ScanDirected(context.Background(), bus, registry, 0x71, nil)
+	if !errors.Is(err, ErrScanDirectedEmptyTargets) {
+		t.Fatalf("expected ErrScanDirectedEmptyTargets, got err=%v", err)
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries on error, got %d", len(entries))
+	}
+	if len(bus.calls) != 0 {
+		t.Fatalf("expected zero bus traffic on nil targets; got %d frames (this would defeat the directed-scan contract)", len(bus.calls))
+	}
+}
+
+// TestScanDirectedRejectsEmptyTargets mirrors the nil case for an
+// explicitly empty non-nil slice, which must also be refused.
+func TestScanDirectedRejectsEmptyTargets(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{}
+	entries, err := ScanDirected(context.Background(), bus, registry, 0x71, []byte{})
+	if !errors.Is(err, ErrScanDirectedEmptyTargets) {
+		t.Fatalf("expected ErrScanDirectedEmptyTargets, got err=%v", err)
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries on error, got %d", len(entries))
+	}
+	if len(bus.calls) != 0 {
+		t.Fatalf("expected zero bus traffic on empty targets; got %d frames", len(bus.calls))
+	}
+}
+
+// TestScanDirectedFiltersInitiatorCapableAndSYNESCTargets verifies the
+// directed API honors the same target-capability rules as the legacy
+// Scan: initiator-capable addresses and SYN (0xAA) / ESC (0xA9) are
+// never probed even if the caller erroneously includes them. Per AD10
+// filtering must be "consistent with scan.go:64-67".
+func TestScanDirectedFiltersInitiatorCapableAndSYNESCTargets(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{}
+	// Include a realistic target (0x08 BAI), SYN (0xAA), ESC (0xA9), and
+	// an initiator-capable address (0x00). Directed scan should only
+	// probe 0x08.
+	_, err := ScanDirected(context.Background(), bus, registry, 0x71, []byte{0x08, 0xAA, 0xA9, 0x00})
+	// ErrNoSuchDevice is expected from mockScanBus for unhandled targets;
+	// we're asserting against the send-side, not the response-side.
+	_ = err
+
+	for _, frame := range bus.calls {
+		switch frame.Target {
+		case 0xAA:
+			t.Errorf("filter leak: directed scan sent frame to SYN (0xAA)")
+		case 0xA9:
+			t.Errorf("filter leak: directed scan sent frame to ESC (0xA9)")
+		case 0x00:
+			t.Errorf("filter leak: directed scan sent frame to initiator-capable address 0x00")
+		}
+	}
+}
+
+// TestScanDirectedEquivalentToScanOnNonEmptyTargets pins the invariant
+// that ScanDirected and Scan produce identical wire traffic (same
+// frame set, same order) when given identical non-empty targets.
+// This is the directed API's compatibility contract: it is a
+// refusal-to-default wrapper, not a behavioral fork.
+func TestScanDirectedEquivalentToScanOnNonEmptyTargets(t *testing.T) {
+	targets := []byte{0x08, 0x15, 0x26}
+
+	regA := NewDeviceRegistry(nil)
+	busA := &mockScanBus{}
+	_, _ = Scan(context.Background(), busA, regA, 0x71, targets)
+
+	regB := NewDeviceRegistry(nil)
+	busB := &mockScanBus{}
+	_, _ = ScanDirected(context.Background(), busB, regB, 0x71, targets)
+
+	if len(busA.calls) != len(busB.calls) {
+		t.Fatalf("frame-count divergence: Scan=%d ScanDirected=%d", len(busA.calls), len(busB.calls))
+	}
+	for i := range busA.calls {
+		a, b := busA.calls[i], busB.calls[i]
+		if a.Source != b.Source || a.Target != b.Target || a.Primary != b.Primary || a.Secondary != b.Secondary {
+			t.Errorf("frame %d divergence: Scan=%+v ScanDirected=%+v", i, a, b)
+		}
+	}
+}
+
+// TestScanNilTargetsStillFallsThroughToDefault is the regression guard
+// for the ebusd-tcp sanctioned bounded-retry path. Introducing
+// ScanDirected MUST NOT silently alter Scan's historical fall-through
+// semantics — external tooling and the ebusd-tcp adapter rely on it.
+func TestScanNilTargetsStillFallsThroughToDefault(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{}
+	_, _ = Scan(context.Background(), bus, registry, 0x71, nil)
+	if len(bus.calls) == 0 {
+		t.Fatalf("regression: Scan(nil) emitted zero frames — fall-through to DefaultScanTargets is broken")
+	}
+	// Spot check: at least one frame should target a known slave-range
+	// address that DefaultScanTargets includes (e.g. 0x08 BAI).
+	sentToBAI := false
+	for _, frame := range bus.calls {
+		if frame.Target == 0x08 {
+			sentToBAI = true
+			break
+		}
+	}
+	if !sentToBAI {
+		t.Errorf("regression: Scan(nil) fall-through did not probe 0x08 (BAI); DefaultScanTargets may be broken")
+	}
+}
+
+// TestScanDirectedDeduplicatesTargets verifies that duplicate target
+// addresses in the caller's list are deduplicated (reusing the same
+// dedupeScanTargets logic as Scan) so the directed API cannot be
+// tricked into probing the same address multiple times per pass.
+func TestScanDirectedDeduplicatesTargets(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	bus := &mockScanBus{
+		responses: map[byte]*protocol.Frame{},
+	}
+	_, _ = ScanDirected(context.Background(), bus, registry, 0x71, []byte{0x08, 0x08, 0x08, 0x15, 0x15})
+	// With two distinct capable targets, the first pass should emit
+	// at most 2 frames (mockScanBus returns ErrNoSuchDevice so no
+	// retry pass fires; the collision-retry loop needs collided or
+	// retried addresses, and ErrNoSuchDevice is neither).
+	if len(bus.calls) > 2 {
+		t.Errorf("expected ≤2 frames after dedupe, got %d: %+v", len(bus.calls), bus.calls)
+	}
+}


### PR DESCRIPTION
Closes #126
Cruise-run meta-issue: Project-Helianthus/helianthus-execution-plans#20
Milestone: \`M1_EBUSREG_DIRECTED_SCAN\` (complexity=3)
Plan: [\`startup-admission-discovery-w17-26.locked/\`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/startup-admission-discovery-w17-26.locked) (Canonical SHA256 \`9e4b32d2b2b382ed9bad7f4098c63488c7b0e9da7fbec2a22ea10a76124eaee7\`)

## Summary

New \`ScanDirected(ctx, bus, registry, source, targets)\` API with \`ErrScanDirectedEmptyTargets\` sentinel. Refuses the nil/empty fall-through that \`Scan\` permits for the ebusd-tcp sanctioned bounded-retry path. Intended for startup-admission callers on non-ebusd-tcp direct transports (ENH, ENS, UDP-plain, TCP-plain) that MUST probe only promoted-suspect addresses.

## Behaviour

| Input | Behaviour |
|---|---|
| \`ScanDirected(..., nil)\` | returns \`ErrScanDirectedEmptyTargets\`; zero bus traffic |
| \`ScanDirected(..., []byte{})\` | returns \`ErrScanDirectedEmptyTargets\`; zero bus traffic |
| \`ScanDirected(..., [targets...])\` | delegates to \`Scan\`; identical filtering/dedup/retry |
| \`Scan(..., nil)\` **UNCHANGED** | falls through to \`DefaultScanTargets()\` (ebusd-tcp retry) |

## Acceptance (M1 per plan)

- [x] New directed API requires explicit non-empty targets, returns sentinel error on nil/empty
- [x] Filters non-target-capable addresses consistent with \`registry/scan.go:64-67\` (initiator-capable, SYN, ESC excluded)
- [x] Existing \`Scan(..., nil)\` semantics unchanged
- [x] Tests cover: empty-target rejection (nil + empty slice), invalid-target filtering (0x00 / 0xAA / 0xA9), compatibility preservation (Scan vs ScanDirected equivalence), regression guard on \`Scan(nil)\` fall-through, dedup consistency
- [x] No new public types (only \`ScanDirected\` function + \`ErrScanDirectedEmptyTargets\` sentinel)
- [x] Local CI green (\`go test ./...\`)

## Implements AD10 (locked decision)

> \"Explicit-target scan rejects nil or empty target lists and consistently filters non-target-capable addresses, including initiator-capable addresses and unknown symbols such as SYN or ESC, before sending probes.\"

## Role-Inversion Note

M1 was routed to Codex under role-inversion. The \`mcp__codex__codex\` MCP connection closed twice during this cruise run (known instability per MEMORY.md). To avoid blocking cruise-control flow on a complexity-3 narrow change, the orchestrator (main Claude session) authored the implementation directly. AD20 different-AI-identity compliance is preserved at review time: **this PR's code review MUST be performed by Codex-fresh** (different identity from the primary developer).

Machine-readable AD20 trailer:
\`\`\`
primary_developer_ai_identity: claude-code-orchestrator
secondary_reviewer_ai_identity: codex-gpt-5.4
\`\`\`

## Merge gating (per cruise-run plan)

This PR must NOT merge until:
- [ ] \`helianthus-docs-ebus#287\` (M0 doc-gate) is **merged to main** (M1 merge_depends_on=[M0]; M0-APPROVED required per AD18 Tier 2 — note: although AD18 Tier 1 was scoped to gateway PRs, M1 merge_depends_on=[M0] as written in plan applies strict gating)
- [ ] Codex-fresh review approves (AD20 second-reviewer identity requirement)
- [ ] Local CI green on the rebase SHA

PR is pushed as draft; will be marked ready-for-review after Codex-fresh approval or operator decision.

## Test Results (local)

\`\`\`
=== RUN   TestScanDirectedRejectsNilTargets
--- PASS: TestScanDirectedRejectsNilTargets (0.00s)
=== RUN   TestScanDirectedRejectsEmptyTargets
--- PASS: TestScanDirectedRejectsEmptyTargets (0.00s)
=== RUN   TestScanDirectedFiltersInitiatorCapableAndSYNESCTargets
--- PASS: TestScanDirectedFiltersInitiatorCapableAndSYNESCTargets (0.10s)
=== RUN   TestScanDirectedEquivalentToScanOnNonEmptyTargets
--- PASS: TestScanDirectedEquivalentToScanOnNonEmptyTargets (0.61s)
=== RUN   TestScanNilTargetsStillFallsThroughToDefault
--- PASS: TestScanNilTargetsStillFallsThroughToDefault (23.02s)
=== RUN   TestScanDirectedDeduplicatesTargets
--- PASS: TestScanDirectedDeduplicatesTargets (0.20s)
PASS
ok  	github.com/Project-Helianthus/helianthus-ebusreg/registry	24.435s

Full suite (go test ./...): ALL PASS
\`\`\`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)