### PR TITLE
SAS-09: ebusreg boundary proof

### DIFF
--- a/registry/scan_directed_test.go
+++ b/registry/scan_directed_test.go
@@ -110,7 +110,7 @@ func TestScanNilTargetsStillFallsThroughToDefault(t *testing.T) {
 	if len(bus.calls) == 0 {
 		t.Fatalf("regression: Scan(nil) emitted zero frames — fall-through to DefaultScanTargets is broken")
 	}
-	// Spot check: at least one frame should target a known slave-range
+	// Spot check: at least one frame should target a known responder-range
 	// address that DefaultScanTargets includes (e.g. 0x08 BAI).
 	sentToBAI := false
 	for _, frame := range bus.calls {


### PR DESCRIPTION
## What
SAS-09 boundary proof for source-address-selection-admission: keep source-selection authority out of ebusreg and fix the current terminology gate violation in the directed-scan test.

## Why
ebusreg should continue to own registry/identity/projection logic only. After ebusgo#145 merged the new source-selection API, ebusreg must not import or expose SourceAddressSelection/Join replacement concepts.

## Acceptance Criteria
- [x] No protocol Join API use in ebusreg
- [x] No SourceAddress/source-selection API use in ebusreg
- [x] Unit tests cover the implemented code
- [x] CI green
- [ ] Smoke test required: NO

## Dependencies
- Depends on Project-Helianthus/helianthus-ebusgo#145
- Tracks Project-Helianthus/helianthus-execution-plans#22

## Verification
- Boundary scan for exact protocol Join API use: no matches
- Boundary scan for SourceAddress/source-selection API use: no matches
- ./scripts/ci_local.sh: pass
