### PR TITLE
feat(registry): M0B + M1 + M5A + M5 — AddressSlot/AddressTable + LookupSlot + AliasAddresses + static seed table (RED→GREEN)

### DIFF
--- a/registry/address_slot.go
+++ b/registry/address_slot.go
@@ -1,0 +1,120 @@
+package registry
+
+import "time"
+
+type SlotRole int
+
+const (
+	SlotRoleUnknown SlotRole = iota
+	SlotRoleMaster
+	SlotRoleSlave
+)
+
+type DiscoverySource int
+
+const (
+	DiscoverySourceUnknown DiscoverySource = iota
+	DiscoverySourcePassiveObserved
+	DiscoverySourceStaticSeed
+	DiscoverySourceActiveConfirmed
+)
+
+type VerificationState int
+
+const (
+	VerificationStateUnknown VerificationState = iota
+	VerificationStateCandidate
+	VerificationStateCorroborated
+	VerificationStateIdentityConfirmed
+)
+
+type AddressSlot struct {
+	Addr              byte
+	Role              SlotRole
+	DiscoverySource   DiscoverySource
+	VerificationState VerificationState
+	Device            *deviceEntry
+	FirstObservedAt   time.Time
+	LastObservedAt    time.Time
+}
+
+type BusFace struct {
+	Addr              byte
+	Role              SlotRole
+	DiscoverySource   DiscoverySource
+	VerificationState VerificationState
+	AccessProtocols   []string
+}
+
+func (s *AddressSlot) Address() byte {
+	if s == nil {
+		return 0
+	}
+	if s.Device != nil {
+		return s.Device.Address()
+	}
+	return s.Addr
+}
+
+func (s *AddressSlot) Addresses() []byte {
+	if s == nil || s.Device == nil {
+		return nil
+	}
+	return s.Device.Addresses()
+}
+
+func (s *AddressSlot) Manufacturer() string {
+	if s == nil || s.Device == nil {
+		return ""
+	}
+	return s.Device.Manufacturer()
+}
+
+func (s *AddressSlot) DeviceID() string {
+	if s == nil || s.Device == nil {
+		return ""
+	}
+	return s.Device.DeviceID()
+}
+
+func (s *AddressSlot) SerialNumber() string {
+	if s == nil || s.Device == nil {
+		return ""
+	}
+	return s.Device.SerialNumber()
+}
+
+func (s *AddressSlot) MacAddress() string {
+	if s == nil || s.Device == nil {
+		return ""
+	}
+	return s.Device.MacAddress()
+}
+
+func (s *AddressSlot) SoftwareVersion() string {
+	if s == nil || s.Device == nil {
+		return ""
+	}
+	return s.Device.SoftwareVersion()
+}
+
+func (s *AddressSlot) HardwareVersion() string {
+	if s == nil || s.Device == nil {
+		return ""
+	}
+	return s.Device.HardwareVersion()
+}
+
+func (s *AddressSlot) Planes() []Plane {
+	if s == nil || s.Device == nil {
+		return nil
+	}
+	return s.Device.Planes()
+}
+
+func (s *AddressSlot) Projections() []Projection {
+	if s == nil || s.Device == nil {
+		return nil
+	}
+	return s.Device.Projections()
+}

--- a/registry/address_table_test.go
+++ b/registry/address_table_test.go
@@ -68,24 +68,20 @@ func TestAddressSlotAliasing(t *testing.T) {
 	registry := NewDeviceRegistry(nil)
 	registry.Register(DeviceInfo{
 		Address:         0xF1,
-		Manufacturer:    "vaillant",
-		DeviceID:        "NETX3",
-		SerialNumber:    "NETX3",
+		Manufacturer:    "Vaillant",
+		DeviceID:        "NETX3-A",
+		SerialNumber:    "SN-A",
 		SoftwareVersion: "1.0",
 		HardwareVersion: "1.0",
 	})
 	registry.Register(DeviceInfo{
 		Address:         0xF6,
-		Manufacturer:    "vaillant",
-		DeviceID:        "NETX3",
-		SerialNumber:    "NETX3",
+		Manufacturer:    "Vaillant",
+		DeviceID:        "NETX3-B",
+		SerialNumber:    "SN-B",
 		SoftwareVersion: "1.0",
 		HardwareVersion: "1.0",
 	})
-
-	if err := registry.AliasAddresses(0xF1, 0xF6); err != nil {
-		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
-	}
 
 	var masterSlot *AddressSlot
 	var ok bool
@@ -97,6 +93,22 @@ func TestAddressSlotAliasing(t *testing.T) {
 	slaveSlot, ok = registry.Lookup(0xF6)
 	if !ok {
 		t.Fatalf("Lookup(0xF6) ok = false; want true")
+	}
+	if masterSlot.Device == slaveSlot.Device {
+		t.Fatalf("pre-alias slots share Device = %p; want distinct devices", masterSlot.Device)
+	}
+
+	if err := registry.AliasAddresses(0xF1, 0xF6); err != nil {
+		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
+	}
+
+	masterSlot, ok = registry.Lookup(0xF1)
+	if !ok {
+		t.Fatalf("Lookup(0xF1) after alias ok = false; want true")
+	}
+	slaveSlot, ok = registry.Lookup(0xF6)
+	if !ok {
+		t.Fatalf("Lookup(0xF6) after alias ok = false; want true")
 	}
 	if masterSlot.Device == nil {
 		t.Fatalf("Lookup(0xF1).Device = nil; want aliased device")

--- a/registry/address_table_test.go
+++ b/registry/address_table_test.go
@@ -1,0 +1,153 @@
+package registry
+
+import "testing"
+
+/*
+RED tests for cruise plan address-table-registry-w19-26 M0B — these reference
+M1 types/funcs that intentionally don't exist yet.
+*/
+
+func TestAddressSlotLookupParity(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+
+	registered08 := registry.Register(DeviceInfo{
+		Address:         0x08,
+		Manufacturer:    "vaillant",
+		DeviceID:        "BAI00",
+		SerialNumber:    "NETX3-BOILER",
+		SoftwareVersion: "1.0",
+		HardwareVersion: "2.0",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "vaillant",
+		DeviceID:        "BASV2",
+		SerialNumber:    "NETX3-BASV2",
+		SoftwareVersion: "1.1",
+		HardwareVersion: "2.1",
+	})
+
+	var slot *AddressSlot
+	var ok bool
+	slot, ok = registry.Lookup(0x08)
+	if !ok {
+		t.Fatalf("Lookup(0x08) ok = false; want true")
+	}
+	if slot == nil {
+		t.Fatalf("Lookup(0x08) slot = nil; want AddressSlot")
+	}
+
+	unset, ok := registry.Lookup(0xAA)
+	if ok {
+		t.Fatalf("Lookup(0xAA) ok = true; want false")
+	}
+	if unset != nil {
+		t.Fatalf("Lookup(0xAA) slot = %v; want nil", unset)
+	}
+
+	var iterated08 DeviceEntry
+	registry.Iterate(func(entry DeviceEntry) bool {
+		if entry.Address() == 0x08 {
+			iterated08 = entry
+			return false
+		}
+		return true
+	})
+	if iterated08 == nil {
+		t.Fatalf("Iterate did not return registered address 0x08")
+	}
+	if iterated08 != registered08 {
+		t.Fatalf("legacy iteration entry = %p; want Register return %p", iterated08, registered08)
+	}
+	if slot.Device != registered08 {
+		t.Fatalf("slot.Device = %p; want legacy DeviceEntry %p", slot.Device, registered08)
+	}
+}
+
+func TestAddressSlotAliasing(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0xF1,
+		Manufacturer:    "vaillant",
+		DeviceID:        "NETX3",
+		SerialNumber:    "NETX3",
+		SoftwareVersion: "1.0",
+		HardwareVersion: "1.0",
+	})
+	registry.Register(DeviceInfo{
+		Address:         0xF6,
+		Manufacturer:    "vaillant",
+		DeviceID:        "NETX3",
+		SerialNumber:    "NETX3",
+		SoftwareVersion: "1.0",
+		HardwareVersion: "1.0",
+	})
+
+	if err := registry.AliasAddresses(0xF1, 0xF6); err != nil {
+		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
+	}
+
+	var masterSlot *AddressSlot
+	var ok bool
+	masterSlot, ok = registry.Lookup(0xF1)
+	if !ok {
+		t.Fatalf("Lookup(0xF1) ok = false; want true")
+	}
+	var slaveSlot *AddressSlot
+	slaveSlot, ok = registry.Lookup(0xF6)
+	if !ok {
+		t.Fatalf("Lookup(0xF6) ok = false; want true")
+	}
+	if masterSlot.Device == nil {
+		t.Fatalf("Lookup(0xF1).Device = nil; want aliased device")
+	}
+	if masterSlot.Device != slaveSlot.Device {
+		t.Fatalf("NETX3 slots are not aliased: 0xF1=%p 0xF6=%p", masterSlot.Device, slaveSlot.Device)
+	}
+}
+
+func TestAddressSlotInternalFields(t *testing.T) {
+	registry := NewDeviceRegistry(nil)
+	registry.Register(DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "vaillant",
+		DeviceID:        "BASV2",
+		SerialNumber:    "BASV2-IDENTITY",
+		SoftwareVersion: "3.0",
+		HardwareVersion: "4.0",
+	})
+
+	wantSource := DiscoverySourceActiveConfirmed
+	wantVerification := VerificationStateIdentityConfirmed
+
+	var slot *AddressSlot
+	var ok bool
+	slot, ok = registry.Lookup(0x15)
+	if !ok {
+		t.Fatalf("Lookup(0x15) ok = false; want true")
+	}
+	if slot == nil {
+		t.Fatalf("Lookup(0x15) slot = nil; want AddressSlot")
+	}
+	if slot.Addr != 0x15 {
+		t.Fatalf("slot.Addr = 0x%02X; want 0x15", slot.Addr)
+	}
+	if slot.DiscoverySource != wantSource {
+		t.Fatalf("slot.DiscoverySource = %v; want %v", slot.DiscoverySource, wantSource)
+	}
+	if slot.VerificationState != wantVerification {
+		t.Fatalf("slot.VerificationState = %v; want %v", slot.VerificationState, wantVerification)
+	}
+	if slot.Device == nil {
+		t.Fatalf("slot.Device = nil; want confirmed device")
+	}
+	if len(slot.Device.Faces) == 0 {
+		t.Fatalf("slot.Device.Faces is empty; want at least one bus face")
+	}
+	for _, face := range slot.Device.Faces {
+		if face.Addr == 0x15 {
+			return
+		}
+	}
+	t.Fatalf("slot.Device.Faces does not include address 0x15: %+v", slot.Device.Faces)
+}

--- a/registry/address_table_test.go
+++ b/registry/address_table_test.go
@@ -29,7 +29,7 @@ func TestAddressSlotLookupParity(t *testing.T) {
 
 	var slot *AddressSlot
 	var ok bool
-	slot, ok = registry.Lookup(0x08)
+	slot, ok = registry.LookupSlot(0x08)
 	if !ok {
 		t.Fatalf("Lookup(0x08) ok = false; want true")
 	}
@@ -37,7 +37,7 @@ func TestAddressSlotLookupParity(t *testing.T) {
 		t.Fatalf("Lookup(0x08) slot = nil; want AddressSlot")
 	}
 
-	unset, ok := registry.Lookup(0xAA)
+	unset, ok := registry.LookupSlot(0xAA)
 	if ok {
 		t.Fatalf("Lookup(0xAA) ok = true; want false")
 	}
@@ -85,12 +85,12 @@ func TestAddressSlotAliasing(t *testing.T) {
 
 	var masterSlot *AddressSlot
 	var ok bool
-	masterSlot, ok = registry.Lookup(0xF1)
+	masterSlot, ok = registry.LookupSlot(0xF1)
 	if !ok {
 		t.Fatalf("Lookup(0xF1) ok = false; want true")
 	}
 	var slaveSlot *AddressSlot
-	slaveSlot, ok = registry.Lookup(0xF6)
+	slaveSlot, ok = registry.LookupSlot(0xF6)
 	if !ok {
 		t.Fatalf("Lookup(0xF6) ok = false; want true")
 	}
@@ -102,11 +102,11 @@ func TestAddressSlotAliasing(t *testing.T) {
 		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
 	}
 
-	masterSlot, ok = registry.Lookup(0xF1)
+	masterSlot, ok = registry.LookupSlot(0xF1)
 	if !ok {
 		t.Fatalf("Lookup(0xF1) after alias ok = false; want true")
 	}
-	slaveSlot, ok = registry.Lookup(0xF6)
+	slaveSlot, ok = registry.LookupSlot(0xF6)
 	if !ok {
 		t.Fatalf("Lookup(0xF6) after alias ok = false; want true")
 	}
@@ -134,7 +134,7 @@ func TestAddressSlotInternalFields(t *testing.T) {
 
 	var slot *AddressSlot
 	var ok bool
-	slot, ok = registry.Lookup(0x15)
+	slot, ok = registry.LookupSlot(0x15)
 	if !ok {
 		t.Fatalf("Lookup(0x15) ok = false; want true")
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"sync"
+	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/schema"
 )
@@ -57,11 +58,12 @@ type FrameTemplate interface {
 }
 
 type DeviceRegistry struct {
-	mu        sync.RWMutex
-	providers []PlaneProvider
-	entries   map[byte]*deviceEntry
-	identity  map[string]*deviceEntry
-	order     []*deviceEntry
+	mu           sync.RWMutex
+	providers    []PlaneProvider
+	entries      map[byte]*deviceEntry
+	addressTable [256]*AddressSlot
+	identity     map[string]*deviceEntry
+	order        []*deviceEntry
 }
 
 func NewDeviceRegistry(providers []PlaneProvider) *DeviceRegistry {
@@ -195,6 +197,8 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 		r.identity[identityKey] = entry
 	}
 	r.entries[info.Address] = entry
+	r.observeAddressSlotLocked(info.Address, entry, DiscoverySourceActiveConfirmed, VerificationStateIdentityConfirmed)
+	r.syncEntryFacesLocked(entry)
 
 	return entry
 }
@@ -280,14 +284,48 @@ func hasConflictingModelSignature(incoming DeviceInfo, existing DeviceInfo) bool
 	return incomingDeviceID != existingDeviceID || incomingSoftware != existingSoftware || incomingHardware != existingHardware
 }
 
-func (r *DeviceRegistry) Lookup(address byte) (DeviceEntry, bool) {
+func (r *DeviceRegistry) Lookup(address byte) (*AddressSlot, bool) {
 	r.mu.RLock()
-	entry, ok := r.entries[address]
-	r.mu.RUnlock()
-	if !ok {
+	defer r.mu.RUnlock()
+
+	slot := r.addressTable[address]
+	if slot == nil {
 		return nil, false
 	}
-	return entry, true
+	if slot.Device != nil {
+		primary := slot.Device.Address()
+		if primarySlot := r.addressTable[primary]; primarySlot != nil && primarySlot.Device == slot.Device {
+			slot = primarySlot
+		}
+	}
+	return slot, true
+}
+
+func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	slotA := r.ensureAddressSlotLocked(a)
+	slotB := r.ensureAddressSlotLocked(b)
+
+	switch {
+	case slotA.Device != nil:
+		slotB.Device = slotA.Device
+		if !containsAddress(slotA.Device.addresses, b) {
+			slotA.Device.addresses = append(slotA.Device.addresses, b)
+		}
+		r.entries[b] = slotA.Device
+		r.syncEntryFacesLocked(slotA.Device)
+	case slotB.Device != nil:
+		slotA.Device = slotB.Device
+		if !containsAddress(slotB.Device.addresses, a) {
+			slotB.Device.addresses = append(slotB.Device.addresses, a)
+		}
+		r.entries[a] = slotB.Device
+		r.syncEntryFacesLocked(slotB.Device)
+	}
+
+	return nil
 }
 
 func (r *DeviceRegistry) Iterate(fn func(DeviceEntry) bool) {
@@ -311,6 +349,9 @@ func (r *DeviceRegistry) detachAddressLocked(entry *deviceEntry, address byte) {
 		return
 	}
 	delete(r.entries, address)
+	if slot := r.addressTable[address]; slot != nil && slot.Device == entry {
+		r.addressTable[address] = nil
+	}
 	if !containsAddress(entry.addresses, address) {
 		return
 	}
@@ -327,6 +368,52 @@ func (r *DeviceRegistry) detachAddressLocked(entry *deviceEntry, address byte) {
 		entry.primaryAddress = entry.addresses[0]
 		entry.info.Address = entry.primaryAddress
 	}
+	r.syncEntryFacesLocked(entry)
+}
+
+func (r *DeviceRegistry) ensureAddressSlotLocked(address byte) *AddressSlot {
+	slot := r.addressTable[address]
+	if slot == nil {
+		slot = &AddressSlot{Addr: address}
+		r.addressTable[address] = slot
+	}
+	return slot
+}
+
+func (r *DeviceRegistry) observeAddressSlotLocked(address byte, entry *deviceEntry, source DiscoverySource, state VerificationState) {
+	now := time.Now()
+	slot := r.ensureAddressSlotLocked(address)
+	slot.Device = entry
+	if slot.DiscoverySource < source {
+		slot.DiscoverySource = source
+	}
+	if slot.VerificationState < state {
+		slot.VerificationState = state
+	}
+	if slot.FirstObservedAt.IsZero() {
+		slot.FirstObservedAt = now
+	}
+	slot.LastObservedAt = now
+}
+
+func (r *DeviceRegistry) syncEntryFacesLocked(entry *deviceEntry) {
+	if entry == nil {
+		return
+	}
+	faces := make([]BusFace, 0, len(entry.addresses))
+	for _, address := range entry.addresses {
+		slot := r.ensureAddressSlotLocked(address)
+		if slot.Device == nil {
+			slot.Device = entry
+		}
+		faces = append(faces, BusFace{
+			Addr:              address,
+			Role:              slot.Role,
+			DiscoverySource:   slot.DiscoverySource,
+			VerificationState: slot.VerificationState,
+		})
+	}
+	entry.Faces = faces
 }
 
 type deviceEntry struct {
@@ -339,6 +426,7 @@ type deviceEntry struct {
 	projections    []Projection
 	index          CanonicalIndex
 	indexErr       error
+	Faces          []BusFace
 }
 
 func (d *deviceEntry) Address() byte {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -297,9 +297,13 @@ func (r *DeviceRegistry) Lookup(address byte) (DeviceEntry, bool) {
 	return entry, true
 }
 
-// LookupSlot returns the AddressSlot for the given address (M1 address-
-// table accessor), with role/source/confidence metadata that Lookup
-// does not expose.
+// LookupSlot returns the AddressSlot for the requested address (M1
+// address-table accessor), with the slot's own role/source/confidence
+// metadata. When the address is aliased to a multi-address device, the
+// returned slot.Device pointer is shared with the primary slot, but
+// slot.Addr/Role/DiscoverySource/VerificationState describe the
+// REQUESTED address — callers inspecting per-address metadata get the
+// per-slot view (Codex P2: return-the-requested-address-slot).
 func (r *DeviceRegistry) LookupSlot(address byte) (*AddressSlot, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -307,12 +311,6 @@ func (r *DeviceRegistry) LookupSlot(address byte) (*AddressSlot, bool) {
 	slot := r.addressTable[address]
 	if slot == nil {
 		return nil, false
-	}
-	if slot.Device != nil {
-		primary := slot.Device.Address()
-		if primarySlot := r.addressTable[primary]; primarySlot != nil && primarySlot.Device == slot.Device {
-			slot = primarySlot
-		}
 	}
 	return slot, true
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -310,19 +310,51 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 
 	switch {
 	case slotA.Device != nil:
-		slotB.Device = slotA.Device
-		if !containsAddress(slotA.Device.addresses, b) {
-			slotA.Device.addresses = append(slotA.Device.addresses, b)
+		canonical := slotA.Device
+		if secondary := slotB.Device; secondary != nil && secondary != canonical {
+			secondary.addresses = removeAddress(secondary.addresses, b)
+			if len(secondary.addresses) == 0 {
+				if secondary.identityKey != "" {
+					delete(r.identity, secondary.identityKey)
+				}
+				r.order = removeEntry(r.order, secondary)
+			} else {
+				if secondary.primaryAddress == b {
+					secondary.primaryAddress = secondary.addresses[0]
+					secondary.info.Address = secondary.primaryAddress
+				}
+				r.syncEntryFacesLocked(secondary)
+			}
 		}
-		r.entries[b] = slotA.Device
-		r.syncEntryFacesLocked(slotA.Device)
+		slotB.Device = canonical
+		if !containsAddress(canonical.addresses, b) {
+			canonical.addresses = append(canonical.addresses, b)
+		}
+		r.entries[b] = canonical
+		r.syncEntryFacesLocked(canonical)
 	case slotB.Device != nil:
-		slotA.Device = slotB.Device
-		if !containsAddress(slotB.Device.addresses, a) {
-			slotB.Device.addresses = append(slotB.Device.addresses, a)
+		canonical := slotB.Device
+		if secondary := slotA.Device; secondary != nil && secondary != canonical {
+			secondary.addresses = removeAddress(secondary.addresses, a)
+			if len(secondary.addresses) == 0 {
+				if secondary.identityKey != "" {
+					delete(r.identity, secondary.identityKey)
+				}
+				r.order = removeEntry(r.order, secondary)
+			} else {
+				if secondary.primaryAddress == a {
+					secondary.primaryAddress = secondary.addresses[0]
+					secondary.info.Address = secondary.primaryAddress
+				}
+				r.syncEntryFacesLocked(secondary)
+			}
 		}
-		r.entries[a] = slotB.Device
-		r.syncEntryFacesLocked(slotB.Device)
+		slotA.Device = canonical
+		if !containsAddress(canonical.addresses, a) {
+			canonical.addresses = append(canonical.addresses, a)
+		}
+		r.entries[a] = canonical
+		r.syncEntryFacesLocked(canonical)
 	}
 
 	return nil

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -284,7 +284,23 @@ func hasConflictingModelSignature(incoming DeviceInfo, existing DeviceInfo) bool
 	return incomingDeviceID != existingDeviceID || incomingSoftware != existingSoftware || incomingHardware != existingHardware
 }
 
-func (r *DeviceRegistry) Lookup(address byte) (*AddressSlot, bool) {
+// Lookup returns the canonical *DeviceEntry for the given address, or
+// (nil, false) if no device occupies that slot. Preserved (signature
+// unchanged) so existing callers continue to compile.
+func (r *DeviceRegistry) Lookup(address byte) (DeviceEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.entries[address]
+	if !ok {
+		return nil, false
+	}
+	return entry, true
+}
+
+// LookupSlot returns the AddressSlot for the given address (M1 address-
+// table accessor), with role/source/confidence metadata that Lookup
+// does not expose.
+func (r *DeviceRegistry) LookupSlot(address byte) (*AddressSlot, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/vaillant/productids/seed_table_test.go
+++ b/vaillant/productids/seed_table_test.go
@@ -14,9 +14,9 @@ func TestStaticSeedTable_NETX3_OwnsThreeAddresses(t *testing.T) {
 	entry := findStaticSeedEntry(t, productids.LoadSeedTable(true), "Vaillant", "NETX3")
 
 	assertSeedAddresses(t, entry.Addresses, []productids.SeedAddressEntry{
-		{Addr: 0xF1, Role: "master", Confidence: "candidate"},
-		{Addr: 0xF6, Role: "slave", Confidence: "candidate"},
-		{Addr: 0x04, Role: "slave", Confidence: "candidate"},
+		{Addr: 0xF1, Role: "initiator", Confidence: "candidate"},
+		{Addr: 0xF6, Role: "target", Confidence: "candidate"},
+		{Addr: 0x04, Role: "target", Confidence: "candidate"},
 	})
 }
 
@@ -24,8 +24,8 @@ func TestStaticSeedTable_BASV2_OwnsTwoAddresses(t *testing.T) {
 	entry := findStaticSeedEntry(t, productids.LoadSeedTable(true), "Vaillant", "BASV2")
 
 	assertSeedAddresses(t, entry.Addresses, []productids.SeedAddressEntry{
-		{Addr: 0x15, Role: "slave", Confidence: "candidate"},
-		{Addr: 0xEC, Role: "slave", Confidence: "candidate"},
+		{Addr: 0x15, Role: "target", Confidence: "candidate"},
+		{Addr: 0xEC, Role: "target", Confidence: "candidate"},
 	})
 }
 

--- a/vaillant/productids/seed_table_test.go
+++ b/vaillant/productids/seed_table_test.go
@@ -1,0 +1,76 @@
+package productids_test
+
+// RED tests for cruise plan address-table-registry-w19-26 M0B/productids — references M5A LoadSeedTable that intentionally doesn't exist yet.
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/productids"
+)
+
+const staticSeedSource = "vaillant_static_seed_w19_26"
+
+func TestStaticSeedTable_NETX3_OwnsThreeAddresses(t *testing.T) {
+	entry := findStaticSeedEntry(t, productids.LoadSeedTable(true), "Vaillant", "NETX3")
+
+	assertSeedAddresses(t, entry.Addresses, []productids.SeedAddressEntry{
+		{Addr: 0xF1, Role: "master", Confidence: "candidate"},
+		{Addr: 0xF6, Role: "slave", Confidence: "candidate"},
+		{Addr: 0x04, Role: "slave", Confidence: "candidate"},
+	})
+}
+
+func TestStaticSeedTable_BASV2_OwnsTwoAddresses(t *testing.T) {
+	entry := findStaticSeedEntry(t, productids.LoadSeedTable(true), "Vaillant", "BASV2")
+
+	assertSeedAddresses(t, entry.Addresses, []productids.SeedAddressEntry{
+		{Addr: 0x15, Role: "slave", Confidence: "candidate"},
+		{Addr: 0xEC, Role: "slave", Confidence: "candidate"},
+	})
+}
+
+func TestStaticSeedTable_FeatureFlagDefaultFalse(t *testing.T) {
+	if got := productids.LoadSeedTable(false); len(got) != 0 {
+		t.Fatalf("expected disabled static seed table to be empty, got %d entries", len(got))
+	}
+}
+
+func TestStaticSeedEntry_Source(t *testing.T) {
+	entries := productids.LoadSeedTable(true)
+	if len(entries) == 0 {
+		t.Fatal("expected enabled static seed table to return entries")
+	}
+
+	for _, entry := range entries {
+		if entry.Source != staticSeedSource {
+			t.Fatalf("expected Source %q, got %q", staticSeedSource, entry.Source)
+		}
+	}
+}
+
+func findStaticSeedEntry(t *testing.T, entries []productids.StaticSeedEntry, manufacturer, deviceID string) productids.StaticSeedEntry {
+	t.Helper()
+
+	for _, entry := range entries {
+		if entry.Manufacturer == manufacturer && entry.DeviceID == deviceID {
+			return entry
+		}
+	}
+
+	t.Fatalf("expected static seed entry for Manufacturer=%q DeviceID=%q", manufacturer, deviceID)
+	return productids.StaticSeedEntry{}
+}
+
+func assertSeedAddresses(t *testing.T, got, want []productids.SeedAddressEntry) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d seed addresses, got %d: %#v", len(want), len(got), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("address[%d]: expected %#v, got %#v", i, want[i], got[i])
+		}
+	}
+}

--- a/vaillant/productids/seed_table_test.go
+++ b/vaillant/productids/seed_table_test.go
@@ -1,6 +1,6 @@
 package productids_test
 
-// RED tests for cruise plan address-table-registry-w19-26 M0B/productids — references M5A LoadSeedTable that intentionally doesn't exist yet.
+// Tests verify the M5A LoadSeedTable + M5 NETX3/BASV2 seed entries; both implemented in this branch.
 
 import (
 	"testing"

--- a/vaillant/productids/static_seeds.go
+++ b/vaillant/productids/static_seeds.go
@@ -1,0 +1,44 @@
+package productids
+
+type StaticSeedEntry struct {
+	Manufacturer string
+	DeviceID     string
+	Addresses    []SeedAddressEntry
+	Source       string
+}
+
+type SeedAddressEntry struct {
+	Addr       byte
+	Role       string
+	Confidence string
+}
+
+const staticSeedSource = "vaillant_static_seed_w19_26"
+
+func LoadSeedTable(enabled bool) []StaticSeedEntry {
+	if !enabled {
+		return nil
+	}
+
+	return []StaticSeedEntry{
+		{
+			Manufacturer: "Vaillant",
+			DeviceID:     "NETX3",
+			Source:       staticSeedSource,
+			Addresses: []SeedAddressEntry{
+				{Addr: 0xF1, Role: "master", Confidence: "candidate"},
+				{Addr: 0xF6, Role: "slave", Confidence: "candidate"},
+				{Addr: 0x04, Role: "slave", Confidence: "candidate"},
+			},
+		},
+		{
+			Manufacturer: "Vaillant",
+			DeviceID:     "BASV2",
+			Source:       staticSeedSource,
+			Addresses: []SeedAddressEntry{
+				{Addr: 0x15, Role: "slave", Confidence: "candidate"},
+				{Addr: 0xEC, Role: "slave", Confidence: "candidate"},
+			},
+		},
+	}
+}

--- a/vaillant/productids/static_seeds.go
+++ b/vaillant/productids/static_seeds.go
@@ -26,9 +26,9 @@ func LoadSeedTable(enabled bool) []StaticSeedEntry {
 			DeviceID:     "NETX3",
 			Source:       staticSeedSource,
 			Addresses: []SeedAddressEntry{
-				{Addr: 0xF1, Role: "master", Confidence: "candidate"},
-				{Addr: 0xF6, Role: "slave", Confidence: "candidate"},
-				{Addr: 0x04, Role: "slave", Confidence: "candidate"},
+				{Addr: 0xF1, Role: "initiator", Confidence: "candidate"},
+				{Addr: 0xF6, Role: "target", Confidence: "candidate"},
+				{Addr: 0x04, Role: "target", Confidence: "candidate"},
 			},
 		},
 		{
@@ -36,8 +36,8 @@ func LoadSeedTable(enabled bool) []StaticSeedEntry {
 			DeviceID:     "BASV2",
 			Source:       staticSeedSource,
 			Addresses: []SeedAddressEntry{
-				{Addr: 0x15, Role: "slave", Confidence: "candidate"},
-				{Addr: 0xEC, Role: "slave", Confidence: "candidate"},
+				{Addr: 0x15, Role: "target", Confidence: "candidate"},
+				{Addr: 0xEC, Role: "target", Confidence: "candidate"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

M0B_TDD_GATE/ebusreg of cruise plan [`address-table-registry-w19-26.locked`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/address-table-registry-w19-26.locked) (meta-issue [helianthus-execution-plans#23](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/23)).

Adds intentionally-failing ("RED") tests pinning the M1 acceptance criteria. Per AD09 strict TDD mode, M1 cannot start until cruise-dev-supervise observes RED state on this PR. **DO NOT MERGE** until M1 turns these GREEN.

## RED state

`go test ./registry/...` fails at compile with:
- `undefined: AddressSlot`
- `registry.AliasAddresses undefined`
- `undefined: DiscoverySourceActiveConfirmed`
- `undefined: VerificationStateIdentityConfirmed`

These references intentionally name M1's not-yet-existing types/funcs.

## Tests authored

- `TestAddressSlotLookupParity` — `Lookup(addr)` returns `(*AddressSlot, bool)`
- `TestAddressSlotAliasing` — `r.AliasAddresses(0xF1, 0xF6)` shares device pointer
- `TestAddressSlotInternalFields` — slot.Addr / DiscoverySource / VerificationState / Device.Faces

Cross-references AD01, AD02, AD09, AD15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)