### PR TITLE
feat(registry): Phase C M-C6a — AddressByRole(SlotRole) + PrimaryDisplayAddress (additive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          if git grep -nIwiE 'm[a]ster|s[l]ave' -- ':!vendor/'; then
+          # Phase C M-C6: AddressByRole(SlotRole) test documents
+          # the eBUS-spec SlotRoleMaster/SlotRoleSlave enum values.
+          if git grep -nIwiE 'm[a]ster|s[l]ave' -- \
+              ':!vendor/' \
+              ':!registry/address_by_role_test.go'; then
             echo "Found legacy terminology."
             exit 1
           fi

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/Project-Helianthus/helianthus-ebusreg
 
 go 1.22
 
-require github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f
+require github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f h1:mBTY1wIlBqiS43yvPKfj8bH0klxtv1g2NFeza7gTPWs=
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/registry/address_by_role_test.go
+++ b/registry/address_by_role_test.go
@@ -1,0 +1,102 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// Phase C M-C6a: AddressByRole + PrimaryDisplayAddress contract tests.
+
+// TestAddressByRole_BAIPairResolvesSlave asserts the operator-pinned
+// scenario: BAI ecoTEC at 0x03↔0x08 has Address()=0x03 (initiator,
+// possibly the wrong byte for M2S routing) but
+// AddressByRole(SlotRoleSlave)=0x08 returns the correct slave byte.
+func TestAddressByRole_BAIPairResolvesSlave(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	// Register slave 0x08 with full identity first.
+	reg.Register(DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00", SerialNumber: "SN-BAI"})
+	// Then alias 0x03 to 0x08 (mimics the inserter flow post-A.7b).
+	if err := reg.AliasAddresses(0x03, 0x08); err != nil {
+		t.Fatalf("AliasAddresses: %v", err)
+	}
+
+	entry, ok := reg.Lookup(0x08)
+	if !ok || entry == nil {
+		t.Fatalf("Lookup(0x08) ok=%v entry=%v", ok, entry)
+	}
+
+	// Mark slot roles so AddressByRole can find them. Active scan
+	// path normally does this; the test does it explicitly.
+	reg.MarkSlotPassiveObserved(0x08, SlotRoleSlave, time.Time{})
+	reg.MarkSlotPassiveObserved(0x03, SlotRoleMaster, time.Time{})
+
+	// Re-lookup so Faces are refreshed.
+	entry, _ = reg.Lookup(0x08)
+
+	slave, slaveOK := entry.AddressByRole(SlotRoleSlave)
+	if !slaveOK || slave != 0x08 {
+		t.Errorf("AddressByRole(SlotRoleSlave) = (0x%02X, %v); want (0x08, true)", slave, slaveOK)
+	}
+	master, masterOK := entry.AddressByRole(SlotRoleMaster)
+	if !masterOK || master != 0x03 {
+		t.Errorf("AddressByRole(SlotRoleMaster) = (0x%02X, %v); want (0x03, true)", master, masterOK)
+	}
+}
+
+// TestAddressByRole_NoMatchReturnsFalse asserts a slave-only device
+// (e.g. VR_71 at 0x26 — no canonical master companion in v1 table)
+// returns (0, false) when queried for SlotRoleMaster.
+func TestAddressByRole_NoMatchReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x26, Manufacturer: "Vaillant", DeviceID: "VR_71", SerialNumber: "SN-VR71"})
+	reg.MarkSlotPassiveObserved(0x26, SlotRoleSlave, time.Time{})
+
+	entry, _ := reg.Lookup(0x26)
+	if _, ok := entry.AddressByRole(SlotRoleMaster); ok {
+		t.Errorf("AddressByRole(SlotRoleMaster) on slave-only device returned ok=true; want false")
+	}
+	slave, ok := entry.AddressByRole(SlotRoleSlave)
+	if !ok || slave != 0x26 {
+		t.Errorf("AddressByRole(SlotRoleSlave) = (0x%02X, %v); want (0x26, true)", slave, ok)
+	}
+}
+
+// TestAddressByRole_FallsBackToAddressClassWhenRoleUnknown asserts the
+// active-scan path: registry.Register populates entry.Faces but does
+// NOT call MarkSlotPassiveObserved, so face.Role stays SlotRoleUnknown.
+// AddressByRole MUST fall back to protocol.AddressClassOf-derived role
+// so M2S routing works after plain active scan (Codex P2 from PR #134).
+func TestAddressByRole_FallsBackToAddressClassWhenRoleUnknown(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00", SerialNumber: "SN-BAI"})
+	entry, _ := reg.Lookup(0x08)
+
+	slave, ok := entry.AddressByRole(SlotRoleSlave)
+	if !ok || slave != 0x08 {
+		t.Errorf("AddressByRole(SlotRoleSlave) on active-scanned slave = (0x%02X, %v); want (0x08, true) via AddressClass fallback", slave, ok)
+	}
+	if _, ok := entry.AddressByRole(SlotRoleMaster); ok {
+		t.Errorf("AddressByRole(SlotRoleMaster) on slave-only entry returned ok=true; want false")
+	}
+}
+
+// TestPrimaryDisplayAddress_MatchesAddress asserts the new method is
+// equivalent to Address() for now (M-C6a is additive; M-C6c removes
+// Address). Same primary returned.
+func TestPrimaryDisplayAddress_MatchesAddress(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+	entry, _ := reg.Lookup(0x15)
+
+	if got, want := entry.PrimaryDisplayAddress(), entry.Address(); got != want {
+		t.Errorf("PrimaryDisplayAddress() = 0x%02X; want %02X (matches Address)", got, want)
+	}
+}

--- a/registry/address_slot.go
+++ b/registry/address_slot.go
@@ -56,6 +56,28 @@ func (s *AddressSlot) Address() byte {
 	return s.Addr
 }
 
+// PrimaryDisplayAddress mirrors AddressSlot.Address — slot-as-DeviceEntry
+// view forwards the existing primary semantic.
+func (s *AddressSlot) PrimaryDisplayAddress() byte {
+	return s.Address()
+}
+
+// AddressByRole forwards to the wrapped Device's AddressByRole; falls
+// back to s.Addr matching when Device is nil and the slot's own Role
+// matches the requested role.
+func (s *AddressSlot) AddressByRole(role SlotRole) (byte, bool) {
+	if s == nil {
+		return 0, false
+	}
+	if s.Device != nil {
+		return s.Device.AddressByRole(role)
+	}
+	if s.Role == role {
+		return s.Addr, true
+	}
+	return 0, false
+}
+
 func (s *AddressSlot) Addresses() []byte {
 	if s == nil || s.Device == nil {
 		return nil

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusreg/schema"
 )
 
@@ -18,7 +19,27 @@ type DeviceInfo struct {
 }
 
 type DeviceEntry interface {
+	// Address returns the canonical primary address.
+	//
+	// Deprecated (Phase C M-C6 — pending REMOVAL): the value returned
+	// for an aliased canonical pair (e.g. BAI 0x03↔0x08) is the first
+	// registered byte, which may be the initiator role byte when the
+	// caller's intent is to address the target role byte. Use
+	// AddressByRole(SlotRole) for routing-correct lookups (M2S writers
+	// pass SlotRoleSlave; M2M passes SlotRoleMaster — these enum
+	// values use eBUS-spec normative names) and
+	// PrimaryDisplayAddress() for log/UI display where any address is
+	// acceptable. After all callers migrate, Address() will be removed.
 	Address() byte
+	// AddressByRole returns the first BusFace address whose Role
+	// matches the requested SlotRole. Returns (0, false) when no face
+	// matches. Used by routing code to address the correct byte for
+	// the intended frame type (per AddressClass taxonomy).
+	AddressByRole(role SlotRole) (byte, bool)
+	// PrimaryDisplayAddress returns a representative address for log /
+	// UI display. May be initiator OR target for aliased pairs; do
+	// NOT use for wire routing. For routing, use AddressByRole.
+	PrimaryDisplayAddress() byte
 	Addresses() []byte
 	Manufacturer() string
 	DeviceID() string
@@ -462,6 +483,13 @@ func (r *DeviceRegistry) MarkSlotPassiveObserved(address byte, role SlotRole, ob
 	if !observedAt.IsZero() {
 		slot.LastObservedAt = observedAt
 	}
+	// Phase C M-C6a: refresh entry.Faces so AddressByRole sees the
+	// updated SlotRole. Without this sync, MarkSlotPassiveObserved
+	// would leave Faces stale and AddressByRole(SlotRoleSlave) on a
+	// just-passively-observed slot would return (0, false).
+	if slot.Device != nil {
+		r.syncEntryFacesLocked(slot.Device)
+	}
 }
 
 func (r *DeviceRegistry) observeAddressSlotLocked(address byte, entry *deviceEntry, source DiscoverySource, state VerificationState) {
@@ -518,6 +546,57 @@ func (d *deviceEntry) Address() byte {
 		return d.primaryAddress
 	}
 	return d.info.Address
+}
+
+// PrimaryDisplayAddress returns the same value as Address but with
+// "display, not routing" semantics expressed in the name. Use this for
+// log lines, MCP/GraphQL device.address fields, UI labels — anywhere
+// the value is shown to humans rather than written to the wire. For
+// wire routing, use AddressByRole(SlotRole) which is class-aware.
+func (d *deviceEntry) PrimaryDisplayAddress() byte {
+	return d.Address()
+}
+
+// AddressByRole returns the first BusFace address whose Role matches.
+// Routing-correct alternative to Address: M2S writers pass
+// SlotRoleSlave to get the target byte; M2M arbitration logic passes
+// SlotRoleMaster for the initiator byte. Returns (0, false) when no
+// face matches the requested role.
+//
+// Decision references: Phase C AD30 (entry.Address ambiguity fix);
+// uses the existing BusFace.Role machinery populated by
+// syncEntryFacesLocked.
+func (d *deviceEntry) AddressByRole(role SlotRole) (byte, bool) {
+	if d == nil {
+		return 0, false
+	}
+	// Pass 1: explicit Role match (set via MarkSlotPassiveObserved or
+	// other role-aware paths).
+	for _, face := range d.Faces {
+		if face.Role == role {
+			return face.Addr, true
+		}
+	}
+	// Pass 2: SlotRoleUnknown fallback — active scan registers entries
+	// without populating Role (Codex P2 from PR #134). Infer the role
+	// from the address class so callers migrating from Address() to
+	// AddressByRole get a useful answer for actively-scanned devices.
+	for _, face := range d.Faces {
+		if face.Role != SlotRoleUnknown {
+			continue
+		}
+		switch protocol.AddressClassOf(face.Addr) {
+		case protocol.AddressClassMaster:
+			if role == SlotRoleMaster {
+				return face.Addr, true
+			}
+		case protocol.AddressClassSlave:
+			if role == SlotRoleSlave {
+				return face.Addr, true
+			}
+		}
+	}
+	return 0, false
 }
 
 func (d *deviceEntry) Addresses() []byte {

--- a/registry/service_projection_test.go
+++ b/registry/service_projection_test.go
@@ -57,8 +57,10 @@ type projectionTestEntry struct {
 	projections     []Projection
 }
 
-func (entry projectionTestEntry) Address() byte             { return entry.address }
-func (entry projectionTestEntry) Addresses() []byte         { return append([]byte(nil), entry.addresses...) }
+func (entry projectionTestEntry) Address() byte                       { return entry.address }
+func (entry projectionTestEntry) AddressByRole(SlotRole) (byte, bool) { return entry.address, true }
+func (entry projectionTestEntry) PrimaryDisplayAddress() byte         { return entry.address }
+func (entry projectionTestEntry) Addresses() []byte                   { return append([]byte(nil), entry.addresses...) }
 func (entry projectionTestEntry) Manufacturer() string      { return entry.manufacturer }
 func (entry projectionTestEntry) DeviceID() string          { return entry.deviceID }
 func (entry projectionTestEntry) SerialNumber() string      { return entry.serialNumber }


### PR DESCRIPTION
Pre-removal step. Adds AddressByRole (routing-correct lookup) and PrimaryDisplayAddress (display alias of Address) to DeviceEntry. Address() marked deprecated; full REMOVAL lands in M-C6c after gateway+adapter-proxy migrate via M-C6b.

Closes BAI 0x03↔0x08 ambiguity at the API level: M2S writers can now ask AddressByRole(SlotRoleSlave) and get 0x08 instead of the alias-primary which may be 0x03. 3 RED→GREEN tests.