### PR TITLE
feat(registry)!: M-C6c — remove DeviceEntry.Address() (BREAKING)

### DIFF
--- a/registry/address_by_role_test.go
+++ b/registry/address_by_role_test.go
@@ -86,17 +86,20 @@ func TestAddressByRole_FallsBackToAddressClassWhenRoleUnknown(t *testing.T) {
 	}
 }
 
-// TestPrimaryDisplayAddress_MatchesAddress asserts the new method is
-// equivalent to Address() for now (M-C6a is additive; M-C6c removes
-// Address). Same primary returned.
-func TestPrimaryDisplayAddress_MatchesAddress(t *testing.T) {
+// TestPrimaryDisplayAddress_ReturnsRegisteredAddress asserts the
+// display API returns the originally registered byte for an entry
+// with a single face. Phase C M-C6c: the legacy Address() method
+// has been removed; PrimaryDisplayAddress is the canonical display
+// path for log/UI surfaces and must continue to return a stable
+// representative byte.
+func TestPrimaryDisplayAddress_ReturnsRegisteredAddress(t *testing.T) {
 	t.Parallel()
 
 	reg := NewDeviceRegistry(nil)
 	reg.Register(DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
 	entry, _ := reg.Lookup(0x15)
 
-	if got, want := entry.PrimaryDisplayAddress(), entry.Address(); got != want {
-		t.Errorf("PrimaryDisplayAddress() = 0x%02X; want %02X (matches Address)", got, want)
+	if got := entry.PrimaryDisplayAddress(); got != 0x15 {
+		t.Errorf("PrimaryDisplayAddress() = 0x%02X; want 0x15", got)
 	}
 }

--- a/registry/address_slot.go
+++ b/registry/address_slot.go
@@ -46,20 +46,19 @@ type BusFace struct {
 	AccessProtocols   []string
 }
 
-func (s *AddressSlot) Address() byte {
+// PrimaryDisplayAddress returns the slot's display address —
+// the wrapped Device's PrimaryDisplayAddress when present, otherwise
+// the slot's own Addr. Phase C M-C6c: replaces the removed
+// AddressSlot.Address() method (which had identical semantics but
+// conflated display vs. routing intent).
+func (s *AddressSlot) PrimaryDisplayAddress() byte {
 	if s == nil {
 		return 0
 	}
 	if s.Device != nil {
-		return s.Device.Address()
+		return s.Device.PrimaryDisplayAddress()
 	}
 	return s.Addr
-}
-
-// PrimaryDisplayAddress mirrors AddressSlot.Address — slot-as-DeviceEntry
-// view forwards the existing primary semantic.
-func (s *AddressSlot) PrimaryDisplayAddress() byte {
-	return s.Address()
 }
 
 // AddressByRole forwards to the wrapped Device's AddressByRole; falls

--- a/registry/address_table_test.go
+++ b/registry/address_table_test.go
@@ -47,7 +47,7 @@ func TestAddressSlotLookupParity(t *testing.T) {
 
 	var iterated08 DeviceEntry
 	registry.Iterate(func(entry DeviceEntry) bool {
-		if entry.Address() == 0x08 {
+		if entry.PrimaryDisplayAddress() == 0x08 {
 			iterated08 = entry
 			return false
 		}

--- a/registry/identity_merge_test.go
+++ b/registry/identity_merge_test.go
@@ -36,9 +36,9 @@ func TestIdentityMerge_FourAddressesSameSerial(t *testing.T) {
 			t.Fatalf("Lookup(0x%02X) ok=false", addr)
 		}
 		if primary == 0 {
-			primary = entry.Address()
-		} else if entry.Address() != primary {
-			t.Fatalf("0x%02X primary=0x%02X; want 0x%02X (all same SerialNumber should alias)", addr, entry.Address(), primary)
+			primary = entry.PrimaryDisplayAddress()
+		} else if entry.PrimaryDisplayAddress() != primary {
+			t.Fatalf("0x%02X primary=0x%02X; want 0x%02X (all same SerialNumber should alias)", addr, entry.PrimaryDisplayAddress(), primary)
 		}
 	}
 
@@ -71,8 +71,8 @@ func TestIdentityMerge_DistinctSerialsStaySeparate(t *testing.T) {
 
 	bai, _ := reg.Lookup(0x08)
 	basv2, _ := reg.Lookup(0x15)
-	if bai.Address() == basv2.Address() {
-		t.Fatalf("distinct identities unexpectedly aliased: BAI primary=0x%02X, BASV2 primary=0x%02X", bai.Address(), basv2.Address())
+	if bai.PrimaryDisplayAddress() == basv2.PrimaryDisplayAddress() {
+		t.Fatalf("distinct identities unexpectedly aliased: BAI primary=0x%02X, BASV2 primary=0x%02X", bai.PrimaryDisplayAddress(), basv2.PrimaryDisplayAddress())
 	}
 }
 
@@ -89,15 +89,15 @@ func TestIdentityMerge_LateEnrichmentAliasesPriorEntry(t *testing.T) {
 	// Step 1: 0xF6 known via active scan with full identity.
 	reg.Register(DeviceInfo{Address: 0xF6, Manufacturer: "Vaillant", DeviceID: "NETX3", SerialNumber: "SN-NETX3"})
 	pre, _ := reg.Lookup(0xF6)
-	if pre.Address() != 0xF6 {
-		t.Fatalf("setup: 0xF6 primary = 0x%02X; want 0xF6", pre.Address())
+	if pre.PrimaryDisplayAddress() != 0xF6 {
+		t.Fatalf("setup: 0xF6 primary = 0x%02X; want 0xF6", pre.PrimaryDisplayAddress())
 	}
 
 	// Step 2: 0xF1 inserted passively via inserter (no identity yet).
 	reg.Register(DeviceInfo{Address: 0xF1})
 	mid, _ := reg.Lookup(0xF1)
-	if mid.Address() == 0xF6 {
-		t.Fatalf("0xF1 unexpectedly aliased to 0xF6 with no identity match: primary=0x%02X", mid.Address())
+	if mid.PrimaryDisplayAddress() == 0xF6 {
+		t.Fatalf("0xF1 unexpectedly aliased to 0xF6 with no identity match: primary=0x%02X", mid.PrimaryDisplayAddress())
 	}
 
 	// Step 3: enrichment learns 0xF1's identity (e.g. via probe) — same
@@ -106,9 +106,9 @@ func TestIdentityMerge_LateEnrichmentAliasesPriorEntry(t *testing.T) {
 
 	post0xF1, _ := reg.Lookup(0xF1)
 	post0xF6, _ := reg.Lookup(0xF6)
-	if post0xF1.Address() != post0xF6.Address() {
+	if post0xF1.PrimaryDisplayAddress() != post0xF6.PrimaryDisplayAddress() {
 		t.Fatalf("after late enrichment, 0xF1 primary=0x%02X 0xF6 primary=0x%02X; want same primary",
-			post0xF1.Address(), post0xF6.Address())
+			post0xF1.PrimaryDisplayAddress(), post0xF6.PrimaryDisplayAddress())
 	}
 
 	addrs := post0xF1.Addresses()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,22 +19,19 @@ type DeviceInfo struct {
 }
 
 type DeviceEntry interface {
-	// Address returns the canonical primary address.
-	//
-	// Deprecated (Phase C M-C6 — pending REMOVAL): the value returned
-	// for an aliased canonical pair (e.g. BAI 0x03↔0x08) is the first
-	// registered byte, which may be the initiator role byte when the
-	// caller's intent is to address the target role byte. Use
-	// AddressByRole(SlotRole) for routing-correct lookups (M2S writers
-	// pass SlotRoleSlave; M2M passes SlotRoleMaster — these enum
-	// values use eBUS-spec normative names) and
-	// PrimaryDisplayAddress() for log/UI display where any address is
-	// acceptable. After all callers migrate, Address() will be removed.
-	Address() byte
 	// AddressByRole returns the first BusFace address whose Role
 	// matches the requested SlotRole. Returns (0, false) when no face
 	// matches. Used by routing code to address the correct byte for
 	// the intended frame type (per AddressClass taxonomy).
+	//
+	// Phase C M-C6c: replaces the previous ambiguous Address() method,
+	// which conflated the "show me a representative byte" use case
+	// (now PrimaryDisplayAddress) with the "give me the routing-
+	// correct byte for this frame type" use case (this method). The
+	// removed method silently returned the initiator byte for an
+	// aliased canonical pair (e.g. BAI 0x03↔0x08), causing M2S writes
+	// to mis-route to the initiator side. AddressByRole forces
+	// callers to declare their intent.
 	AddressByRole(role SlotRole) (byte, bool)
 	// PrimaryDisplayAddress returns a representative address for log /
 	// UI display. May be initiator OR target for aliased pairs; do
@@ -541,20 +538,20 @@ type deviceEntry struct {
 	Faces          []BusFace
 }
 
-func (d *deviceEntry) Address() byte {
+// PrimaryDisplayAddress returns a representative address for log/UI
+// display. Returns the canonical primary if set, otherwise the
+// originally registered info.Address. Use this for log lines,
+// MCP/GraphQL device.address fields, UI labels — anywhere the value
+// is shown to humans rather than written to the wire. For wire
+// routing, use AddressByRole(SlotRole) which is class-aware.
+//
+// Phase C M-C6c: replaces deviceEntry.Address(), whose name conflated
+// display and routing semantics for aliased canonical pairs.
+func (d *deviceEntry) PrimaryDisplayAddress() byte {
 	if d.primaryAddress != 0 {
 		return d.primaryAddress
 	}
 	return d.info.Address
-}
-
-// PrimaryDisplayAddress returns the same value as Address but with
-// "display, not routing" semantics expressed in the name. Use this for
-// log lines, MCP/GraphQL device.address fields, UI labels — anywhere
-// the value is shown to humans rather than written to the wire. For
-// wire routing, use AddressByRole(SlotRole) which is class-aware.
-func (d *deviceEntry) PrimaryDisplayAddress() byte {
-	return d.Address()
 }
 
 // AddressByRole returns the first BusFace address whose Role matches.

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -179,7 +179,7 @@ func TestDeviceRegistry_RegisterLookupIterate(t *testing.T) {
 
 	addresses := make([]byte, 0)
 	registry.Iterate(func(entry DeviceEntry) bool {
-		addresses = append(addresses, entry.Address())
+		addresses = append(addresses, entry.PrimaryDisplayAddress())
 		return true
 	})
 	if len(addresses) != 2 {
@@ -238,7 +238,7 @@ func TestDeviceRegistry_IterateStops(t *testing.T) {
 
 	addresses := make([]byte, 0)
 	registry.Iterate(func(entry DeviceEntry) bool {
-		addresses = append(addresses, entry.Address())
+		addresses = append(addresses, entry.PrimaryDisplayAddress())
 		return len(addresses) < 2
 	})
 
@@ -335,8 +335,8 @@ func TestDeviceRegistry_AliasAddressesShareCanonicalEntry(t *testing.T) {
 	if entry08 != entry09 {
 		t.Fatalf("expected aliases to resolve to the same device entry")
 	}
-	if entry08.Address() != 0x08 {
-		t.Fatalf("canonical address = %02x; want 08", entry08.Address())
+	if entry08.PrimaryDisplayAddress() != 0x08 {
+		t.Fatalf("canonical address = %02x; want 08", entry08.PrimaryDisplayAddress())
 	}
 	if !slices.Equal(entry08.Addresses(), []byte{0x08, 0x09}) {
 		t.Fatalf("addresses = %v; want [8 9]", entry08.Addresses())
@@ -344,7 +344,7 @@ func TestDeviceRegistry_AliasAddressesShareCanonicalEntry(t *testing.T) {
 
 	addresses := make([]byte, 0)
 	registry.Iterate(func(entry DeviceEntry) bool {
-		addresses = append(addresses, entry.Address())
+		addresses = append(addresses, entry.PrimaryDisplayAddress())
 		return true
 	})
 	if !slices.Equal(addresses, []byte{0x08}) {

--- a/registry/scan.go
+++ b/registry/scan.go
@@ -190,7 +190,7 @@ func Scan(ctx context.Context, bus ScanBus, registry *DeviceRegistry, source byt
 				alias.Address = target
 				entry = registry.Register(alias)
 			}
-			canonicalAddress := entry.Address()
+			canonicalAddress := entry.PrimaryDisplayAddress()
 			if _, ok := registered[canonicalAddress]; !ok {
 				registered[canonicalAddress] = struct{}{}
 				entries = append(entries, entry)

--- a/registry/scan_test.go
+++ b/registry/scan_test.go
@@ -542,8 +542,8 @@ func TestScanReusesSerialAcrossAliasAddressesByIdentity(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
-	if entries[0].Address() != 0x30 {
-		t.Fatalf("canonical address = %02x; want 30", entries[0].Address())
+	if entries[0].PrimaryDisplayAddress() != 0x30 {
+		t.Fatalf("canonical address = %02x; want 30", entries[0].PrimaryDisplayAddress())
 	}
 	if !slices.Equal(entries[0].Addresses(), []byte{0x30, 0x31, 0x20}) {
 		t.Fatalf("addresses = %v; want [48 49 32]", entries[0].Addresses())
@@ -553,8 +553,8 @@ func TestScanReusesSerialAcrossAliasAddressesByIdentity(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected alias 0x31 to be registered")
 	}
-	if entry.Address() != 0x30 {
-		t.Fatalf("lookup canonical address = %02x; want 30", entry.Address())
+	if entry.PrimaryDisplayAddress() != 0x30 {
+		t.Fatalf("lookup canonical address = %02x; want 30", entry.PrimaryDisplayAddress())
 	}
 	if entry.SerialNumber() != "21-22-09-0020184848-0082-005409-N4" {
 		t.Fatalf("serial number = %q; want preserved value", entry.SerialNumber())
@@ -624,8 +624,8 @@ func TestScanDeduplicatesAliasAddressesIntoSingleEntry(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 canonical entry, got %d", len(entries))
 	}
-	if entries[0].Address() != 0x08 {
-		t.Fatalf("canonical address = %02x; want 08", entries[0].Address())
+	if entries[0].PrimaryDisplayAddress() != 0x08 {
+		t.Fatalf("canonical address = %02x; want 08", entries[0].PrimaryDisplayAddress())
 	}
 	if !slices.Equal(entries[0].Addresses(), []byte{0x08, 0x09}) {
 		t.Fatalf("addresses = %v; want [8 9]", entries[0].Addresses())
@@ -635,8 +635,8 @@ func TestScanDeduplicatesAliasAddressesIntoSingleEntry(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected alias address 0x09 lookup")
 	}
-	if entry.Address() != 0x08 {
-		t.Fatalf("lookup canonical address = %02x; want 08", entry.Address())
+	if entry.PrimaryDisplayAddress() != 0x08 {
+		t.Fatalf("lookup canonical address = %02x; want 08", entry.PrimaryDisplayAddress())
 	}
 }
 
@@ -670,8 +670,8 @@ func TestScanRegistersQueriedAliasWhenResponseSourceRepeats(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 canonical entry, got %d", len(entries))
 	}
-	if entries[0].Address() != 0x15 {
-		t.Fatalf("canonical address = %02x; want 15", entries[0].Address())
+	if entries[0].PrimaryDisplayAddress() != 0x15 {
+		t.Fatalf("canonical address = %02x; want 15", entries[0].PrimaryDisplayAddress())
 	}
 	if !slices.Equal(entries[0].Addresses(), []byte{0x15, 0xEC}) {
 		t.Fatalf("addresses = %v; want [21 236]", entries[0].Addresses())
@@ -681,8 +681,8 @@ func TestScanRegistersQueriedAliasWhenResponseSourceRepeats(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected alias address 0xEC lookup")
 	}
-	if entry.Address() != 0x15 {
-		t.Fatalf("lookup canonical address = %02x; want 15", entry.Address())
+	if entry.PrimaryDisplayAddress() != 0x15 {
+		t.Fatalf("lookup canonical address = %02x; want 15", entry.PrimaryDisplayAddress())
 	}
 }
 

--- a/registry/service_projection.go
+++ b/registry/service_projection.go
@@ -83,8 +83,8 @@ func ProjectDeviceEntry(entry DeviceEntry) (ServiceDeviceView, error) {
 	sortServicePlanes(projectedPlanes)
 
 	return ServiceDeviceView{
-		Address:         entry.Address(),
-		Addresses:       normalizeProjectedAddresses(entry.Address(), entry.Addresses()),
+		Address:         entry.PrimaryDisplayAddress(),
+		Addresses:       normalizeProjectedAddresses(entry.PrimaryDisplayAddress(), entry.Addresses()),
 		Manufacturer:    entry.Manufacturer(),
 		DeviceID:        entry.DeviceID(),
 		SerialNumber:    entry.SerialNumber(),

--- a/registry/service_projection_test.go
+++ b/registry/service_projection_test.go
@@ -57,18 +57,17 @@ type projectionTestEntry struct {
 	projections     []Projection
 }
 
-func (entry projectionTestEntry) Address() byte                       { return entry.address }
 func (entry projectionTestEntry) AddressByRole(SlotRole) (byte, bool) { return entry.address, true }
 func (entry projectionTestEntry) PrimaryDisplayAddress() byte         { return entry.address }
 func (entry projectionTestEntry) Addresses() []byte                   { return append([]byte(nil), entry.addresses...) }
-func (entry projectionTestEntry) Manufacturer() string      { return entry.manufacturer }
-func (entry projectionTestEntry) DeviceID() string          { return entry.deviceID }
-func (entry projectionTestEntry) SerialNumber() string      { return entry.serialNumber }
-func (entry projectionTestEntry) MacAddress() string        { return entry.macAddress }
-func (entry projectionTestEntry) SoftwareVersion() string   { return entry.softwareVersion }
-func (entry projectionTestEntry) HardwareVersion() string   { return entry.hardwareVersion }
-func (entry projectionTestEntry) Planes() []Plane           { return entry.planes }
-func (entry projectionTestEntry) Projections() []Projection { return entry.projections }
+func (entry projectionTestEntry) Manufacturer() string                { return entry.manufacturer }
+func (entry projectionTestEntry) DeviceID() string                    { return entry.deviceID }
+func (entry projectionTestEntry) SerialNumber() string                { return entry.serialNumber }
+func (entry projectionTestEntry) MacAddress() string                  { return entry.macAddress }
+func (entry projectionTestEntry) SoftwareVersion() string             { return entry.softwareVersion }
+func (entry projectionTestEntry) HardwareVersion() string             { return entry.hardwareVersion }
+func (entry projectionTestEntry) Planes() []Plane                     { return entry.planes }
+func (entry projectionTestEntry) Projections() []Projection           { return entry.projections }
 
 type projectionTestIterator struct {
 	entries []DeviceEntry

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -5,7 +5,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 echo "==> terminology gate"
-if grep -RInwi --exclude-dir=.git -E 'm[a]ster|s[l]ave' .; then
+# Phase C M-C6: AddressByRole(SlotRole) test documents the eBUS-spec
+# SlotRoleMaster/SlotRoleSlave enum values. Mirrors the exclusion in
+# .github/workflows/ci.yml so local CI matches GH Actions semantics.
+if git grep -nIwiE 'm[a]ster|s[l]ave' -- \
+    ':!vendor/' \
+    ':!registry/address_by_role_test.go'; then
   echo "Found legacy terminology."
   exit 1
 fi


### PR DESCRIPTION
## Summary

Phase C M-C6c. Completes AD30: REMOVE the ambiguous `DeviceEntry.Address()` method, leaving routing callers with `AddressByRole(SlotRole)` (M2S/M2M intent declared) and display callers with `PrimaryDisplayAddress()` (log/UI semantics).

## Why

`Address()` silently returned the initiator byte for an aliased canonical pair (e.g. BAI 0x03↔0x08), causing M2S writes to mis-route to the initiator side. `AddressByRole` forces every caller to declare its intent, and the build break is the safety net that catches any caller M-C6b missed.

## Changes

**Interface / impl** (registry/registry.go, registry/address_slot.go):
- Removed `DeviceEntry.Address() byte`.
- Removed `*deviceEntry.Address()`.
- Removed `*AddressSlot.Address()`.
- `*deviceEntry.PrimaryDisplayAddress()` now returns the canonical primary directly (no `Address()` indirection).
- `*AddressSlot.PrimaryDisplayAddress()` forwards to wrapped Device's `PrimaryDisplayAddress` directly.

**In-tree callers** (registry/scan.go, registry/service_projection.go):
- All migrated to `PrimaryDisplayAddress()` (display semantics).

**Tests**:
- All test assertions migrated to `PrimaryDisplayAddress()`.
- `projectionTestEntry` mock drops the `Address()` stub.
- Rewrote `TestPrimaryDisplayAddress_MatchesAddress` as `TestPrimaryDisplayAddress_ReturnsRegisteredAddress` (positive assertion against the registered byte instead of comparing against the now-removed method).

**scripts/ci_local.sh**:
- Terminology gate switched to `git grep` with the same exclusion set as `.github/workflows/ci.yml`. Brings local CI in line with GH Actions: `registry/address_by_role_test.go` documents the eBUS-spec `SlotRoleMaster`/`SlotRoleSlave` enum values (the comments explaining each test must use the spec terms) and is excluded from the legacy-terminology check, mirroring the GH workflow.

## Caller-impact analysis

**helianthus-ebusgateway**: PR #576 (M-C6b) migrated all Address() call sites to `PrimaryDisplayAddress()` plus the new `TargetAddressForRouting` / `EntryContainsAddress` helpers. Bumping ebusgateway's go.mod to this commit verifies no caller was missed (build break is the test). Dry-run with local go.mod replace pointing at this branch is clean.

## Test plan

- [x] go build ./... — clean
- [x] go vet ./... — clean
- [x] go test -race -count=1 ./... — full suite green
- [x] scripts/ci_local.sh — exit 0 (no overrides needed)
- [x] helianthus-ebusgateway dry-run with this branch via go.mod replace — `go build ./...` and `go test ./...` clean (after PR #576 merges)

## Dependent PRs

- helianthus-ebusgateway #576 (M-C6b — caller migration). Merge order: ebusgateway #576 first, then this PR. After this merges, ebusgateway needs a follow-up bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)