### PR TITLE
fix(registry): P0 — preserve secondary identity in AliasAddresses

### DIFF
--- a/registry/alias_identity_preservation_test.go
+++ b/registry/alias_identity_preservation_test.go
@@ -10,7 +10,7 @@ import "testing"
 //
 // Regression scenario from live observation 2026-05-08: BASV2
 // actively scanned at 0x15 with full identity, then bus traffic
-// from BASV2 master 0x10 caused the inserter to call
+// from BASV2 initiator 0x10 caused the inserter to call
 // Register({Address: 0x10}) creating an empty entry, followed by
 // AliasAddresses(0x10, 0x15). Pre-fix, this destroyed BASV2's
 // identity row (delete(r.identity, key) + removeEntry(r.order,
@@ -134,6 +134,65 @@ func TestAliasAddresses_PreservesCanonicalIdentity(t *testing.T) {
 	if entry.Manufacturer() != "Vaillant" || entry.DeviceID() != "BAI00" || entry.SerialNumber() != "SN-BAI-001" {
 		t.Errorf("Lookup(0x03) lost identity: mfr=%q devID=%q serial=%q",
 			entry.Manufacturer(), entry.DeviceID(), entry.SerialNumber())
+	}
+}
+
+// TestAliasAddresses_PreservesSurvivingSecondaryIdentity asserts the
+// case where the secondary entry has MORE THAN the aliased address
+// (e.g. 0x15 + 0x16 share serial; aliasing empty 0x10 to 0x15
+// preserves the secondary at 0x16 with intact identity row in
+// r.identity). This is the Codex P2 follow-up on PR #136 (2026-05-08):
+// pre-fix, absorbIdentityLocked moved identityKey to canonical and
+// cleared secondary's, leaving the surviving-secondary entry without
+// an identity row → lookupByIdentity could not resolve to it.
+func TestAliasAddresses_PreservesSurvivingSecondaryIdentity(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+
+	// Register a multi-face entry: 0x15 + 0x16 share Serial.
+	reg.Register(DeviceInfo{
+		Address:      0x15,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		SerialNumber: "SN-MULTI-001",
+	})
+	reg.Register(DeviceInfo{
+		Address:      0x16,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		SerialNumber: "SN-MULTI-001",
+	})
+	// At this point: identity-merge collapsed 0x15 + 0x16 into one
+	// entry with addresses=[0x15, 0x16].
+
+	// Plant an empty entry at 0x10.
+	reg.Register(DeviceInfo{Address: 0x10})
+
+	// Alias 0x10 ↔ 0x15. Pre-fix this incorrectly stripped the
+	// (0x15, 0x16)-merged entry's identityKey because absorb fired
+	// before the addresses[]==nil check.
+	if err := reg.AliasAddresses(0x10, 0x15); err != nil {
+		t.Fatalf("AliasAddresses error = %v", err)
+	}
+
+	// Lookup by serial must still resolve. The entry it resolves to
+	// is implementation-specific (could be the merged-onto-canonical
+	// or the surviving-secondary), but identity must be intact.
+	by, ok := reg.lookupByIdentity(DeviceInfo{Manufacturer: "Vaillant", DeviceID: "BASV2", SerialNumber: "SN-MULTI-001"})
+	if !ok {
+		t.Fatalf("lookupByIdentity by SN-MULTI-001 = false; want resolvable")
+	}
+	if by.Manufacturer() != "Vaillant" || by.SerialNumber() != "SN-MULTI-001" {
+		t.Errorf("identity lost: mfr=%q serial=%q", by.Manufacturer(), by.SerialNumber())
+	}
+	// 0x16 must remain reachable via direct lookup with same identity.
+	entry16, ok := reg.Lookup(0x16)
+	if !ok {
+		t.Fatalf("Lookup(0x16) = false; want entry")
+	}
+	if entry16.SerialNumber() != "SN-MULTI-001" {
+		t.Errorf("0x16 lost SerialNumber: got %q; want SN-MULTI-001", entry16.SerialNumber())
 	}
 }
 

--- a/registry/alias_identity_preservation_test.go
+++ b/registry/alias_identity_preservation_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 // TestAliasAddresses_PreservesSecondaryIdentity asserts that when
 // AliasAddresses(a, b) is called and slotA.Device is an empty
@@ -102,6 +105,59 @@ func TestAliasAddresses_PreservesSecondaryIdentity(t *testing.T) {
 	})
 	if count != 1 {
 		t.Errorf("registry entry count = %d; want 1 (merged BASV2)", count)
+	}
+}
+
+// TestAliasAddresses_PreservesDistinctIdentityKeys asserts that
+// when canonical and secondary entries have DIFFERENT identityKeys
+// (e.g. canonical has a MAC-derived key, secondary has a
+// serial-derived key), the merge re-points secondary's key at
+// canonical in r.identity rather than deleting it. After the alias,
+// both keys must resolve to the merged entry. (Codex P2 round-3
+// finding 2026-05-08 on PR #136.)
+func TestAliasAddresses_PreservesDistinctIdentityKeys(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+
+	// Canonical at 0x10: identity by MAC only (no serial).
+	reg.Register(DeviceInfo{
+		Address:      0x10,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		MacAddress:   "AA:BB:CC:DD:EE:01",
+	})
+	// Secondary at 0x15: identity by Serial only (no mac).
+	reg.Register(DeviceInfo{
+		Address:      0x15,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		SerialNumber: "SN-DISTINCT-001",
+	})
+
+	if err := reg.AliasAddresses(0x10, 0x15); err != nil {
+		t.Fatalf("AliasAddresses error = %v", err)
+	}
+
+	// Both lookup paths must resolve.
+	byMac, ok := reg.lookupByIdentity(DeviceInfo{Manufacturer: "Vaillant", DeviceID: "BASV2", MacAddress: "AA:BB:CC:DD:EE:01"})
+	if !ok {
+		t.Fatalf("lookupByIdentity by MAC = false; want resolvable")
+	}
+	bySerial, ok := reg.lookupByIdentity(DeviceInfo{Manufacturer: "Vaillant", DeviceID: "BASV2", SerialNumber: "SN-DISTINCT-001"})
+	if !ok {
+		t.Fatalf("lookupByIdentity by Serial = false; want resolvable")
+	}
+	// Both must point at the same entry.
+	if byMac.MacAddress() != "AA:BB:CC:DD:EE:01" {
+		t.Errorf("by-MAC resolution: mac=%q; want AA:BB:CC:DD:EE:01", byMac.MacAddress())
+	}
+	if bySerial.SerialNumber() != "SN-DISTINCT-001" {
+		t.Errorf("by-Serial resolution: serial=%q; want SN-DISTINCT-001", bySerial.SerialNumber())
+	}
+	// Same set of addresses (canonical + secondary's address).
+	if !reflect.DeepEqual(byMac.Addresses(), bySerial.Addresses()) {
+		t.Errorf("merge mismatch: byMac.Addresses=%v bySerial.Addresses=%v", byMac.Addresses(), bySerial.Addresses())
 	}
 }
 

--- a/registry/alias_identity_preservation_test.go
+++ b/registry/alias_identity_preservation_test.go
@@ -1,0 +1,182 @@
+package registry
+
+import "testing"
+
+// TestAliasAddresses_PreservesSecondaryIdentity asserts that when
+// AliasAddresses(a, b) is called and slotA.Device is an empty
+// passive-observed entry while slotB.Device is identity-bearing
+// (manufacturer + deviceID + serialNumber set), the merged entry
+// retains the identity from the secondary side.
+//
+// Regression scenario from live observation 2026-05-08: BASV2
+// actively scanned at 0x15 with full identity, then bus traffic
+// from BASV2 master 0x10 caused the inserter to call
+// Register({Address: 0x10}) creating an empty entry, followed by
+// AliasAddresses(0x10, 0x15). Pre-fix, this destroyed BASV2's
+// identity row (delete(r.identity, key) + removeEntry(r.order,
+// secondary)) and the canonical entry retained empty info.
+//
+// Post-fix (P0): absorbIdentityLocked promotes secondary's
+// non-empty fields onto canonical, then secondary is removed
+// without losing the identity.
+func TestAliasAddresses_PreservesSecondaryIdentity(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+
+	// Step 1: register the identity-bearing entry at 0x15 (active scan path).
+	reg.Register(DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SerialNumber:    "SN-BASV2-001",
+		SoftwareVersion: "0204",
+		HardwareVersion: "0102",
+	})
+
+	// Step 2: register a bare passive observation at 0x10 (gateway
+	// inserter path: Register({Address: 0x10}) with no identity).
+	reg.Register(DeviceInfo{Address: 0x10})
+
+	// Step 3: alias the canonical pair (gateway calls
+	// AliasAddresses(initiator, target)).
+	if err := reg.AliasAddresses(0x10, 0x15); err != nil {
+		t.Fatalf("AliasAddresses(0x10, 0x15) error = %v", err)
+	}
+
+	// Both lookups must return the same entry with full identity.
+	for _, addr := range []byte{0x10, 0x15} {
+		entry, ok := reg.Lookup(addr)
+		if !ok {
+			t.Fatalf("Lookup(0x%02X) = false; want entry", addr)
+		}
+		if got := entry.Manufacturer(); got != "Vaillant" {
+			t.Errorf("Lookup(0x%02X).Manufacturer() = %q; want \"Vaillant\"", addr, got)
+		}
+		if got := entry.DeviceID(); got != "BASV2" {
+			t.Errorf("Lookup(0x%02X).DeviceID() = %q; want \"BASV2\"", addr, got)
+		}
+		if got := entry.SerialNumber(); got != "SN-BASV2-001" {
+			t.Errorf("Lookup(0x%02X).SerialNumber() = %q; want \"SN-BASV2-001\"", addr, got)
+		}
+		if got := entry.SoftwareVersion(); got != "0204" {
+			t.Errorf("Lookup(0x%02X).SoftwareVersion() = %q; want \"0204\"", addr, got)
+		}
+		if got := entry.HardwareVersion(); got != "0102" {
+			t.Errorf("Lookup(0x%02X).HardwareVersion() = %q; want \"0102\"", addr, got)
+		}
+	}
+
+	// Both addresses must appear in the merged entry's address set.
+	entry, _ := reg.Lookup(0x10)
+	addresses := entry.Addresses()
+	have10, have15 := false, false
+	for _, a := range addresses {
+		if a == 0x10 {
+			have10 = true
+		}
+		if a == 0x15 {
+			have15 = true
+		}
+	}
+	if !have10 || !have15 {
+		t.Errorf("merged Addresses() = %v; want both 0x10 and 0x15", addresses)
+	}
+
+	// Identity-by-SerialNumber lookup must still resolve to the
+	// merged entry (not orphaned by the previous identityKey
+	// deletion).
+	by, ok := reg.lookupByIdentity(DeviceInfo{Manufacturer: "Vaillant", DeviceID: "BASV2", SerialNumber: "SN-BASV2-001"})
+	if !ok {
+		t.Fatalf("lookupByIdentity by SerialNumber = false; want entry")
+	}
+	if by.Manufacturer() != "Vaillant" || by.SerialNumber() != "SN-BASV2-001" {
+		t.Errorf("lookupByIdentity returned unexpected entry: mfr=%q serial=%q", by.Manufacturer(), by.SerialNumber())
+	}
+
+	// Iterate must show exactly one entry (the merged one).
+	count := 0
+	reg.Iterate(func(e DeviceEntry) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Errorf("registry entry count = %d; want 1 (merged BASV2)", count)
+	}
+}
+
+// TestAliasAddresses_PreservesCanonicalIdentity asserts the
+// symmetric case: canonical (slotA) is identity-bearing, secondary
+// (slotB) is empty. The original behavior already worked here
+// because the empty secondary has nothing to lose, but the test
+// pins the invariant against future regressions.
+func TestAliasAddresses_PreservesCanonicalIdentity(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+
+	reg.Register(DeviceInfo{
+		Address:      0x08,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BAI00",
+		SerialNumber: "SN-BAI-001",
+	})
+	reg.Register(DeviceInfo{Address: 0x03})
+
+	if err := reg.AliasAddresses(0x08, 0x03); err != nil {
+		t.Fatalf("AliasAddresses(0x08, 0x03) error = %v", err)
+	}
+
+	entry, ok := reg.Lookup(0x03)
+	if !ok {
+		t.Fatalf("Lookup(0x03) = false; want entry")
+	}
+	if entry.Manufacturer() != "Vaillant" || entry.DeviceID() != "BAI00" || entry.SerialNumber() != "SN-BAI-001" {
+		t.Errorf("Lookup(0x03) lost identity: mfr=%q devID=%q serial=%q",
+			entry.Manufacturer(), entry.DeviceID(), entry.SerialNumber())
+	}
+}
+
+// TestAliasAddresses_BothEmpty exercises the no-identity case
+// (e.g. NETX3 0xF1↔0xF6 both passively observed before any active
+// scan succeeds for either face). The merge must still group the
+// addresses; identity stays empty until a future Register or
+// enrichment populates it.
+func TestAliasAddresses_BothEmpty(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0xF1})
+	reg.Register(DeviceInfo{Address: 0xF6})
+
+	if err := reg.AliasAddresses(0xF1, 0xF6); err != nil {
+		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
+	}
+
+	for _, addr := range []byte{0xF1, 0xF6} {
+		entry, ok := reg.Lookup(addr)
+		if !ok {
+			t.Fatalf("Lookup(0x%02X) = false; want entry", addr)
+		}
+		if entry.Manufacturer() != "" {
+			t.Errorf("Lookup(0x%02X).Manufacturer() = %q; want empty (no identity yet)", addr, entry.Manufacturer())
+		}
+	}
+
+	// Subsequent active scan registers identity for one face;
+	// identity-merge through the canonical-pair alias should
+	// propagate it onto the merged entry.
+	reg.Register(DeviceInfo{
+		Address:      0xF6,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+		SerialNumber: "SN-NETX3-001",
+	})
+	entry, _ := reg.Lookup(0xF1)
+	if entry.Manufacturer() != "Vaillant" {
+		t.Errorf("after Register(0xF6, NETX3), Lookup(0xF1).Manufacturer() = %q; want \"Vaillant\"", entry.Manufacturer())
+	}
+	if entry.SerialNumber() != "SN-NETX3-001" {
+		t.Errorf("after Register(0xF6, NETX3), Lookup(0xF1).SerialNumber() = %q; want \"SN-NETX3-001\"", entry.SerialNumber())
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -344,18 +344,18 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	case slotA.Device != nil:
 		canonical := slotA.Device
 		if secondary := slotB.Device; secondary != nil && secondary != canonical {
-			// Post-Phase-C P0: promote secondary's identity onto
-			// canonical before discarding it. absorbIdentityLocked
-			// copies non-empty info/planes/projections/index from
-			// the secondary onto the canonical (only when canonical
-			// fields are empty) — does NOT touch identityKey.
-			r.absorbIdentityLocked(canonical, secondary)
 			secondary.addresses = removeAddress(secondary.addresses, b)
 			if len(secondary.addresses) == 0 {
-				// Secondary is fully removed: transfer its
-				// identityKey binding to canonical (when canonical
-				// has none) before deleting from r.identity. This
-				// is the BASV2 / NETX3 scenario.
+				// Secondary is fully removed: this is the BASV2 /
+				// NETX3 scenario where the identity-bearing entry
+				// becomes orphaned. Promote secondary's identity
+				// fields onto canonical (only when canonical's
+				// fields are empty) and transfer the r.identity
+				// binding. (Codex P2 round-2 finding 2026-05-08 on
+				// PR #136: absorb must NOT fire when secondary
+				// survives, otherwise canonical and the surviving
+				// secondary expose duplicate identity.)
+				r.absorbIdentityLocked(canonical, secondary)
 				if secondary.identityKey != "" {
 					if canonical.identityKey == "" {
 						canonical.identityKey = secondary.identityKey
@@ -369,10 +369,11 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 				// Secondary survives at remaining addresses (e.g.
 				// 0x15 + 0x16 with same identity, then alias 0x10
 				// to 0x15 → secondary still owns 0x16 with the
-				// original identity). DO NOT transfer identityKey
-				// — secondary keeps its identity row, canonical
-				// gets its own via Register's identity-merge path
-				// later. (Codex P2 finding 2026-05-08 on PR #136.)
+				// original identity). DO NOT absorb identity onto
+				// canonical and DO NOT transfer identityKey:
+				// secondary keeps its r.identity row + manufacturer
+				// fields, canonical gets identity via Register's
+				// identity-merge path on a future write.
 				if secondary.primaryAddress == b {
 					secondary.primaryAddress = secondary.addresses[0]
 					secondary.info.Address = secondary.primaryAddress
@@ -389,10 +390,10 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	case slotB.Device != nil:
 		canonical := slotB.Device
 		if secondary := slotA.Device; secondary != nil && secondary != canonical {
-			// Post-Phase-C P0: symmetric case. See slotA branch.
-			r.absorbIdentityLocked(canonical, secondary)
+			// Symmetric case. See slotA branch.
 			secondary.addresses = removeAddress(secondary.addresses, a)
 			if len(secondary.addresses) == 0 {
+				r.absorbIdentityLocked(canonical, secondary)
 				if secondary.identityKey != "" {
 					if canonical.identityKey == "" {
 						canonical.identityKey = secondary.identityKey

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -201,7 +201,17 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	}
 
 	if entry.identityKey != "" && entry.identityKey != identityKey {
-		delete(r.identity, entry.identityKey)
+		// P0 round-6 (Codex P2 follow-up 2026-05-08): instead of
+		// deleting the old primary key, re-point it at this entry
+		// and track it as an alias. Without this, a Register call
+		// that promotes a serial-derived key to primary while the
+		// previous primary was MAC-derived would orphan the MAC
+		// lookup path even though the entry still has the MAC in
+		// info.MacAddress. Now `lookupByIdentity` by either key
+		// continues to resolve to the merged entry, and
+		// detachAddressLocked cleans up both via identityKeyAliases.
+		r.identity[entry.identityKey] = entry
+		entry.identityKeyAliases = appendUniqueString(entry.identityKeyAliases, entry.identityKey)
 	}
 	entry.info = storedInfo
 	entry.physical = physical

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -379,7 +379,15 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 						// SerialNumber() was visible on the merged
 						// entry but lookupByIdentity-by-serial could
 						// not find it.)
+						//
+						// Track the alias key on canonical so
+						// detachAddressLocked can clean it up if the
+						// merged entry is later removed. Without
+						// this, the orphan key would resolve to a
+						// removed *deviceEntry until r.identity gets
+						// rebuilt. (Codex P2 round-4 finding.)
 						r.identity[secondary.identityKey] = canonical
+						canonical.identityKeyAliases = appendUniqueString(canonical.identityKeyAliases, secondary.identityKey)
 					}
 				}
 				r.order = removeEntry(r.order, secondary)
@@ -435,7 +443,15 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 						// SerialNumber() was visible on the merged
 						// entry but lookupByIdentity-by-serial could
 						// not find it.)
+						//
+						// Track the alias key on canonical so
+						// detachAddressLocked can clean it up if the
+						// merged entry is later removed. Without
+						// this, the orphan key would resolve to a
+						// removed *deviceEntry until r.identity gets
+						// rebuilt. (Codex P2 round-4 finding.)
 						r.identity[secondary.identityKey] = canonical
+						canonical.identityKeyAliases = appendUniqueString(canonical.identityKeyAliases, secondary.identityKey)
 					}
 				}
 				r.order = removeEntry(r.order, secondary)
@@ -456,6 +472,18 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	}
 
 	return nil
+}
+
+// appendUniqueString returns dst with s appended if not already
+// present. Used to track identity-key aliases on a deviceEntry
+// without duplication.
+func appendUniqueString(dst []string, s string) []string {
+	for _, existing := range dst {
+		if existing == s {
+			return dst
+		}
+	}
+	return append(dst, s)
 }
 
 // absorbIdentityLocked copies non-empty identity-bearing fields and
@@ -567,6 +595,21 @@ func (r *DeviceRegistry) detachAddressLocked(entry *deviceEntry, address byte) {
 		if entry.identityKey != "" {
 			delete(r.identity, entry.identityKey)
 		}
+		// P0 round-4 (Codex P2 follow-up 2026-05-08): also drop any
+		// identityKeyAliases that AliasAddresses re-pointed at this
+		// entry. Without this cleanup, orphan keys remain in
+		// r.identity resolving to a removed *deviceEntry and a
+		// later Register({key}) would attach to an entry no longer
+		// in r.order.
+		for _, alias := range entry.identityKeyAliases {
+			if alias == "" {
+				continue
+			}
+			if r.identity[alias] == entry {
+				delete(r.identity, alias)
+			}
+		}
+		entry.identityKeyAliases = nil
 		r.order = removeEntry(r.order, entry)
 		return
 	}
@@ -672,12 +715,22 @@ type deviceEntry struct {
 	addresses      []byte
 	physical       physicalIdentity
 	identityKey    string
-	info           DeviceInfo
-	planes         []Plane
-	projections    []Projection
-	index          CanonicalIndex
-	indexErr       error
-	Faces          []BusFace
+	// identityKeyAliases tracks ADDITIONAL r.identity keys that
+	// resolve to this entry beyond its own identityKey. Populated by
+	// AliasAddresses when canonical and removed-secondary had distinct
+	// identity keys (e.g. canonical=MAC-keyed, secondary=serial-keyed)
+	// and the secondary's key is re-pointed at canonical instead of
+	// being deleted. detachAddressLocked iterates this slice to clean
+	// up r.identity bindings when the merged entry is removed,
+	// preventing orphan keys from resolving to a removed *deviceEntry.
+	// (Codex P2 round-4 finding 2026-05-08 on PR #136.)
+	identityKeyAliases []string
+	info               DeviceInfo
+	planes             []Plane
+	projections        []Projection
+	index              CanonicalIndex
+	indexErr           error
+	Faces              []BusFace
 }
 
 // PrimaryDisplayAddress returns a representative address for log/UI

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -345,26 +345,34 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 		canonical := slotA.Device
 		if secondary := slotB.Device; secondary != nil && secondary != canonical {
 			// Post-Phase-C P0: promote secondary's identity onto
-			// canonical before discarding it. Without this, when an
-			// identity-bearing entry is the secondary side of an
-			// alias merge (e.g. BASV2 actively scanned at 0x15 with
-			// full identity, then an empty passive entry created at
-			// 0x10 by the gateway's address_table_inserter triggers
-			// AliasAddresses(0x10, 0x15) — slotA=empty, slotB=BASV2),
-			// the secondary's manufacturer / deviceID / serialNumber
-			// would be lost as `delete(r.identity, secondary.identityKey)`
-			// and `removeEntry(r.order, secondary)` excise the
-			// identity-bearing entry. absorbIdentityLocked copies any
-			// non-empty info / planes / projections / index from the
-			// secondary onto the canonical and re-keys r.identity.
+			// canonical before discarding it. absorbIdentityLocked
+			// copies non-empty info/planes/projections/index from
+			// the secondary onto the canonical (only when canonical
+			// fields are empty) — does NOT touch identityKey.
 			r.absorbIdentityLocked(canonical, secondary)
 			secondary.addresses = removeAddress(secondary.addresses, b)
 			if len(secondary.addresses) == 0 {
+				// Secondary is fully removed: transfer its
+				// identityKey binding to canonical (when canonical
+				// has none) before deleting from r.identity. This
+				// is the BASV2 / NETX3 scenario.
 				if secondary.identityKey != "" {
-					delete(r.identity, secondary.identityKey)
+					if canonical.identityKey == "" {
+						canonical.identityKey = secondary.identityKey
+						r.identity[canonical.identityKey] = canonical
+					} else {
+						delete(r.identity, secondary.identityKey)
+					}
 				}
 				r.order = removeEntry(r.order, secondary)
 			} else {
+				// Secondary survives at remaining addresses (e.g.
+				// 0x15 + 0x16 with same identity, then alias 0x10
+				// to 0x15 → secondary still owns 0x16 with the
+				// original identity). DO NOT transfer identityKey
+				// — secondary keeps its identity row, canonical
+				// gets its own via Register's identity-merge path
+				// later. (Codex P2 finding 2026-05-08 on PR #136.)
 				if secondary.primaryAddress == b {
 					secondary.primaryAddress = secondary.addresses[0]
 					secondary.info.Address = secondary.primaryAddress
@@ -381,12 +389,17 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	case slotB.Device != nil:
 		canonical := slotB.Device
 		if secondary := slotA.Device; secondary != nil && secondary != canonical {
-			// Post-Phase-C P0: see comment above. Symmetric case.
+			// Post-Phase-C P0: symmetric case. See slotA branch.
 			r.absorbIdentityLocked(canonical, secondary)
 			secondary.addresses = removeAddress(secondary.addresses, a)
 			if len(secondary.addresses) == 0 {
 				if secondary.identityKey != "" {
-					delete(r.identity, secondary.identityKey)
+					if canonical.identityKey == "" {
+						canonical.identityKey = secondary.identityKey
+						r.identity[canonical.identityKey] = canonical
+					} else {
+						delete(r.identity, secondary.identityKey)
+					}
 				}
 				r.order = removeEntry(r.order, secondary)
 			} else {
@@ -457,16 +470,17 @@ func (r *DeviceRegistry) absorbIdentityLocked(dst, src *deviceEntry) {
 	if dst.physical == emptyPhysical && src.physical != emptyPhysical {
 		dst.physical = src.physical
 	}
-	if dst.identityKey == "" && src.identityKey != "" {
-		// Re-key r.identity: src is about to be removed by
-		// AliasAddresses, so attach the key to dst and clear src's
-		// identityKey to prevent AliasAddresses' subsequent
-		// `delete(r.identity, secondary.identityKey)` from removing
-		// the freshly-attached binding.
-		dst.identityKey = src.identityKey
-		r.identity[dst.identityKey] = dst
-		src.identityKey = ""
-	}
+	// NOTE: identityKey transfer is intentionally NOT done here.
+	// absorbIdentityLocked runs BEFORE AliasAddresses removes
+	// `b`/`a` from src.addresses, so we don't yet know whether src
+	// will survive (multiple addresses → survives at remaining face)
+	// or be fully removed (only the aliased address → removed). The
+	// caller (AliasAddresses) handles identityKey transfer in the
+	// "secondary fully removed" branch only — see the comment at
+	// the call site. This avoids the live-validation P2 finding
+	// where surviving multi-address secondaries lost their identity
+	// map binding because absorb prematurely moved identityKey.
+	//
 	// Adopt planes / projections / index if dst has none. These
 	// derive from info; absorbing them avoids re-running providers.
 	if len(dst.planes) == 0 && len(src.planes) > 0 {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -344,6 +344,20 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	case slotA.Device != nil:
 		canonical := slotA.Device
 		if secondary := slotB.Device; secondary != nil && secondary != canonical {
+			// Post-Phase-C P0: promote secondary's identity onto
+			// canonical before discarding it. Without this, when an
+			// identity-bearing entry is the secondary side of an
+			// alias merge (e.g. BASV2 actively scanned at 0x15 with
+			// full identity, then an empty passive entry created at
+			// 0x10 by the gateway's address_table_inserter triggers
+			// AliasAddresses(0x10, 0x15) — slotA=empty, slotB=BASV2),
+			// the secondary's manufacturer / deviceID / serialNumber
+			// would be lost as `delete(r.identity, secondary.identityKey)`
+			// and `removeEntry(r.order, secondary)` excise the
+			// identity-bearing entry. absorbIdentityLocked copies any
+			// non-empty info / planes / projections / index from the
+			// secondary onto the canonical and re-keys r.identity.
+			r.absorbIdentityLocked(canonical, secondary)
 			secondary.addresses = removeAddress(secondary.addresses, b)
 			if len(secondary.addresses) == 0 {
 				if secondary.identityKey != "" {
@@ -367,6 +381,8 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	case slotB.Device != nil:
 		canonical := slotB.Device
 		if secondary := slotA.Device; secondary != nil && secondary != canonical {
+			// Post-Phase-C P0: see comment above. Symmetric case.
+			r.absorbIdentityLocked(canonical, secondary)
 			secondary.addresses = removeAddress(secondary.addresses, a)
 			if len(secondary.addresses) == 0 {
 				if secondary.identityKey != "" {
@@ -390,6 +406,81 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 	}
 
 	return nil
+}
+
+// absorbIdentityLocked copies non-empty identity-bearing fields and
+// derived state from src onto dst when dst's corresponding fields are
+// empty. Re-keys r.identity[dst.identityKey] = dst when a new
+// identityKey is adopted from src. Holds r.mu (caller's responsibility).
+//
+// Phase post-C P0: introduced to fix AliasAddresses identity loss
+// (see live observation on 2026-05-08: BASV2 0x10↔0x15 + NETX3
+// 0xF1↔0xF6 pairs aliased correctly but with manufacturer="" because
+// the identity-bearing target-face entry was the secondary in the
+// merge).
+//
+// Fields absorbed (only when dst's value is empty/zero AND src's value
+// is non-empty):
+//   - info.Manufacturer, info.DeviceID, info.SerialNumber, info.MacAddress
+//   - info.SoftwareVersion, info.HardwareVersion
+//   - physical (only if dst's physicalIdentity is zero)
+//   - identityKey (re-keyed in r.identity)
+//   - planes, projections, index, indexErr (only when dst has none)
+//
+// This function does NOT touch addresses or primaryAddress — those are
+// owned by the caller (AliasAddresses) since the merge's address-graph
+// semantics are independent of identity.
+func (r *DeviceRegistry) absorbIdentityLocked(dst, src *deviceEntry) {
+	if dst == nil || src == nil || dst == src {
+		return
+	}
+	if dst.info.Manufacturer == "" && src.info.Manufacturer != "" {
+		dst.info.Manufacturer = src.info.Manufacturer
+	}
+	if dst.info.DeviceID == "" && src.info.DeviceID != "" {
+		dst.info.DeviceID = src.info.DeviceID
+	}
+	if dst.info.SerialNumber == "" && src.info.SerialNumber != "" {
+		dst.info.SerialNumber = src.info.SerialNumber
+	}
+	if dst.info.MacAddress == "" && src.info.MacAddress != "" {
+		dst.info.MacAddress = src.info.MacAddress
+	}
+	if dst.info.SoftwareVersion == "" && src.info.SoftwareVersion != "" {
+		dst.info.SoftwareVersion = src.info.SoftwareVersion
+	}
+	if dst.info.HardwareVersion == "" && src.info.HardwareVersion != "" {
+		dst.info.HardwareVersion = src.info.HardwareVersion
+	}
+	// Adopt physicalIdentity + identityKey if dst has neither and src has both.
+	emptyPhysical := physicalIdentity{}
+	if dst.physical == emptyPhysical && src.physical != emptyPhysical {
+		dst.physical = src.physical
+	}
+	if dst.identityKey == "" && src.identityKey != "" {
+		// Re-key r.identity: src is about to be removed by
+		// AliasAddresses, so attach the key to dst and clear src's
+		// identityKey to prevent AliasAddresses' subsequent
+		// `delete(r.identity, secondary.identityKey)` from removing
+		// the freshly-attached binding.
+		dst.identityKey = src.identityKey
+		r.identity[dst.identityKey] = dst
+		src.identityKey = ""
+	}
+	// Adopt planes / projections / index if dst has none. These
+	// derive from info; absorbing them avoids re-running providers.
+	if len(dst.planes) == 0 && len(src.planes) > 0 {
+		dst.planes = src.planes
+	}
+	if len(dst.projections) == 0 && len(src.projections) > 0 {
+		dst.projections = src.projections
+	}
+	if dst.index.canonicalByID == nil && src.index.canonicalByID != nil {
+		dst.index = src.index
+	}
+	if dst.indexErr == nil && src.indexErr != nil {
+		dst.indexErr = src.indexErr
+	}
 }
 
 func (r *DeviceRegistry) Iterate(fn func(DeviceEntry) bool) {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -357,11 +357,29 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 				// secondary expose duplicate identity.)
 				r.absorbIdentityLocked(canonical, secondary)
 				if secondary.identityKey != "" {
-					if canonical.identityKey == "" {
+					switch canonical.identityKey {
+					case "":
+						// Canonical had no key; adopt secondary's
+						// as canonical's primary key.
 						canonical.identityKey = secondary.identityKey
 						r.identity[canonical.identityKey] = canonical
-					} else {
-						delete(r.identity, secondary.identityKey)
+					case secondary.identityKey:
+						// Same key already bound; ensure the row
+						// points to canonical (defensive).
+						r.identity[canonical.identityKey] = canonical
+					default:
+						// Distinct keys (e.g. canonical has a MAC-
+						// derived key, secondary has a serial-derived
+						// key). Re-point secondary's key at canonical
+						// so future lookupByIdentity calls on EITHER
+						// key resolve to the merged entry. Do NOT
+						// delete — that would orphan the lookup path.
+						// (Codex P2 round-3 finding 2026-05-08 on
+						// PR #136: previously the delete here meant
+						// SerialNumber() was visible on the merged
+						// entry but lookupByIdentity-by-serial could
+						// not find it.)
+						r.identity[secondary.identityKey] = canonical
 					}
 				}
 				r.order = removeEntry(r.order, secondary)
@@ -395,11 +413,29 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 			if len(secondary.addresses) == 0 {
 				r.absorbIdentityLocked(canonical, secondary)
 				if secondary.identityKey != "" {
-					if canonical.identityKey == "" {
+					switch canonical.identityKey {
+					case "":
+						// Canonical had no key; adopt secondary's
+						// as canonical's primary key.
 						canonical.identityKey = secondary.identityKey
 						r.identity[canonical.identityKey] = canonical
-					} else {
-						delete(r.identity, secondary.identityKey)
+					case secondary.identityKey:
+						// Same key already bound; ensure the row
+						// points to canonical (defensive).
+						r.identity[canonical.identityKey] = canonical
+					default:
+						// Distinct keys (e.g. canonical has a MAC-
+						// derived key, secondary has a serial-derived
+						// key). Re-point secondary's key at canonical
+						// so future lookupByIdentity calls on EITHER
+						// key resolve to the merged entry. Do NOT
+						// delete — that would orphan the lookup path.
+						// (Codex P2 round-3 finding 2026-05-08 on
+						// PR #136: previously the delete here meant
+						// SerialNumber() was visible on the merged
+						// entry but lookupByIdentity-by-serial could
+						// not find it.)
+						r.identity[secondary.identityKey] = canonical
 					}
 				}
 				r.order = removeEntry(r.order, secondary)


### PR DESCRIPTION
## Summary

Post-Phase-C P0 from the live HA validation report (2026-05-08). Closes the **identity-loss** regression where canonical-pair entries (BASV2 0x10↔0x15, NETX3 0xF1↔0xF6) aliased correctly but with empty manufacturer/deviceID/serialNumber.

## Mechanism (BASV2 case)

1. Active startup scan at 0x15 → \`Register({Vaillant, BASV2, SN})\` creates identity-bearing entry. \`r.identity[SN] = BASV2\`.
2. Passive M2A traffic from 0x10 → \`Register({Address: 0x10})\` (empty). \`r.entries[0x10] = empty\`.
3. Inserter calls \`AliasAddresses(0x10, 0x15)\`. Pre-fix: \`case slotA.Device != nil:\` runs with canonical=empty, secondary=BASV2. The code DELETES secondary from \`r.identity\` + \`r.order\`, leaving the empty entry as canonical for both 0x10 and 0x15. **BASV2 identity destroyed.**

## Fix

\`absorbIdentityLocked(dst, src)\` promotes non-empty identity-bearing fields and derived state from \`src\` (secondary) onto \`dst\` (canonical) before AliasAddresses removes secondary. Re-keys \`r.identity\` to point to \`dst\` and clears \`src.identityKey\` so the subsequent \`delete(r.identity, secondary.identityKey)\` doesn't unbind the freshly-attached canonical.

Fields absorbed (when \`dst\` empty + \`src\` non-empty):
- \`info.{Manufacturer, DeviceID, SerialNumber, MacAddress, SoftwareVersion, HardwareVersion}\`
- \`physical\`, \`identityKey\`
- \`planes\`, \`projections\`, \`index\`, \`indexErr\`

## Test plan

- [x] \`TestAliasAddresses_PreservesSecondaryIdentity\` — empty 0x10 + identity-bearing 0x15 + alias → merged retains identity, lookupByIdentity resolves
- [x] \`TestAliasAddresses_PreservesCanonicalIdentity\` — symmetric (slotA has identity)
- [x] \`TestAliasAddresses_BothEmpty\` — NETX3-style passive-only path, then Register populates identity through alias
- [x] \`go test -race -count=1 ./...\` — full suite green (no regressions)
- [x] \`scripts/ci_local.sh\` — exit 0

## Live impact

Once this merges + helianthus-ebusgateway bumps go.mod (separate PR P0-bump):
- BASV2 entry will retain \`mfr="Vaillant" devID="BASV2" serial=…\` after canonical-pair aliasing
- Same for NETX3 (once any face gets identity from active probe / static seed / enrichment)

## References

- Phase C live validation: 2026-05-08T04:35Z observation showed \`mfr=""\` on 0x10↔0x15 + 0xF6↔0xF1
- Caller: helianthus-ebusgateway/address_table_inserter.go:178-204 \`maybeAliasCanonicalCompanion\`
- Cruise plan: post-Phase-C P0 of 6-item batch (P0 → P5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)