### PR TITLE
feat(registry): P3.5 — MarkSlotStaticSeed + RegisterStaticSeed APIs

### DIFF
--- a/registry/mark_slot_static_seed_test.go
+++ b/registry/mark_slot_static_seed_test.go
@@ -1,0 +1,143 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMarkSlotStaticSeed_BasicWrite asserts the API stamps Role,
+// DiscoverySource=StaticSeed, VerificationState=Candidate, and
+// timestamps on a fresh slot.
+func TestMarkSlotStaticSeed_BasicWrite(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	reg.MarkSlotStaticSeed(0xF1, SlotRoleMaster, now)
+
+	slot, ok := reg.LookupSlot(0xF1)
+	if !ok || slot == nil {
+		t.Fatalf("LookupSlot(0xF1) ok=%v slot=%v; want non-nil slot", ok, slot)
+	}
+	if slot.Role != SlotRoleMaster {
+		t.Errorf("slot.Role = %v; want SlotRoleMaster", slot.Role)
+	}
+	if slot.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("slot.DiscoverySource = %v; want DiscoverySourceStaticSeed", slot.DiscoverySource)
+	}
+	if slot.VerificationState != VerificationStateCandidate {
+		t.Errorf("slot.VerificationState = %v; want VerificationStateCandidate", slot.VerificationState)
+	}
+	if !slot.FirstObservedAt.Equal(now) {
+		t.Errorf("slot.FirstObservedAt = %v; want %v", slot.FirstObservedAt, now)
+	}
+	if !slot.LastObservedAt.Equal(now) {
+		t.Errorf("slot.LastObservedAt = %v; want %v", slot.LastObservedAt, now)
+	}
+}
+
+// TestMarkSlotStaticSeed_MonotonicNoDowngrade asserts that re-marking
+// a slot already at higher DiscoverySource (ActiveConfirmed) does NOT
+// downgrade it to StaticSeed. Same shape as
+// TestMarkSlotPassiveObserved_MonotonicMetadata.
+func TestMarkSlotStaticSeed_MonotonicNoDowngrade(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	// Bring the slot to ActiveConfirmed via Register.
+	reg.Register(DeviceInfo{Address: 0xF1, Manufacturer: "Vaillant", DeviceID: "NETX3", SerialNumber: "SN-A"})
+	pre, _ := reg.LookupSlot(0xF1)
+	if pre.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want ActiveConfirmed", pre.DiscoverySource)
+	}
+
+	// Static-seed call must not downgrade.
+	reg.MarkSlotStaticSeed(0xF1, SlotRoleMaster, time.Now())
+	post, _ := reg.LookupSlot(0xF1)
+	if post.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Errorf("slot.DiscoverySource after MarkSlotStaticSeed = %v; want ActiveConfirmed (no downgrade)", post.DiscoverySource)
+	}
+	if post.VerificationState != VerificationStateIdentityConfirmed {
+		t.Errorf("slot.VerificationState after MarkSlotStaticSeed = %v; want IdentityConfirmed (no downgrade)", post.VerificationState)
+	}
+}
+
+// TestMarkSlotStaticSeed_MonotonicUpgradeFromPassive asserts that the
+// passive→static-seed transition correctly upgrades DiscoverySource
+// from PassiveObserved to StaticSeed (per the enum order
+// Unknown < PassiveObserved < StaticSeed < ActiveConfirmed). Note:
+// this is the asymmetry codified in Codex Pass 4 of the P6+P3.5 plan
+// — static-seed pre-known taxonomy "outranks" passive-only inference,
+// so a passively-observed slot subsequently learned to be a static
+// seed advances; the reverse direction (ActiveConfirmed -> StaticSeed)
+// is rejected by MonotonicNoDowngrade above.
+func TestMarkSlotStaticSeed_MonotonicUpgradeFromPassive(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	earlier := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	reg.MarkSlotPassiveObserved(0xF1, SlotRoleMaster, earlier)
+	pre, _ := reg.LookupSlot(0xF1)
+	if pre.DiscoverySource != DiscoverySourcePassiveObserved {
+		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want PassiveObserved", pre.DiscoverySource)
+	}
+
+	later := earlier.Add(24 * time.Hour)
+	reg.MarkSlotStaticSeed(0xF1, SlotRoleMaster, later)
+
+	post, _ := reg.LookupSlot(0xF1)
+	if post.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("slot.DiscoverySource after passive->static-seed = %v; want StaticSeed (upgrade)", post.DiscoverySource)
+	}
+	// VerificationState was Corroborated (from passive); StaticSeed
+	// brings Candidate which is < Corroborated, so the slot must
+	// retain Corroborated.
+	if post.VerificationState != VerificationStateCorroborated {
+		t.Errorf("slot.VerificationState after passive->static-seed = %v; want Corroborated (retained)", post.VerificationState)
+	}
+}
+
+// TestMarkSlotStaticSeed_RaceFreeWriteAndRead mirrors the M6.1 hardening
+// proof for MarkSlotPassiveObserved. The API must serialize via the
+// registry's RWMutex; concurrent writers and readers must not race.
+func TestMarkSlotStaticSeed_RaceFreeWriteAndRead(t *testing.T) {
+	reg := NewDeviceRegistry(nil)
+	const writers = 100
+	const readers = 100
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				reg.MarkSlotStaticSeed(0xF1, SlotRoleMaster, time.Now())
+			}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				slot, ok := reg.LookupSlot(0xF1)
+				if ok && slot != nil {
+					_ = slot.Role
+					_ = slot.DiscoverySource
+					_ = slot.VerificationState
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	slot, ok := reg.LookupSlot(0xF1)
+	if !ok || slot == nil {
+		t.Fatalf("after race test: LookupSlot(0xF1) ok=%v slot=%v", ok, slot)
+	}
+	if slot.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("after race test: slot.DiscoverySource = %v; want StaticSeed", slot.DiscoverySource)
+	}
+}

--- a/registry/mark_slot_static_seed_test.go
+++ b/registry/mark_slot_static_seed_test.go
@@ -128,46 +128,101 @@ func TestMarkSlotStaticSeed_DoesNotAttachOrphanSlot(t *testing.T) {
 	}
 }
 
-// TestMarkSlotStaticSeed_UpgradesAttachedSlot covers the in-scope use
-// case: a slot already attached to a device entry (here via
-// RegisterStaticSeed for a different address that aliased into the
-// same entry) gets its discovery_source label upgraded by a
-// MarkSlotStaticSeed call. Faces is refreshed because slot.Device is
-// non-nil at call time.
-func TestMarkSlotStaticSeed_UpgradesAttachedSlot(t *testing.T) {
+// TestMarkSlotStaticSeed_RefreshesFacesOnAttachedSlot covers the
+// in-scope use case: a slot already attached to a device entry by a
+// prior RegisterStaticSeed call has its Role and LastObservedAt
+// updated by a subsequent MarkSlotStaticSeed call, AND the
+// Faces-refresh branch (slot.Device != nil → syncEntryFacesLocked)
+// actually runs — i.e. the device's BusFace list reflects the role.
+//
+// Test design: uses a slave-class address (0x15 BASV2 slave). When
+// the slot is initially seeded with SlotRoleUnknown, AddressByRole's
+// AddressClass fallback does NOT promote Slave role for slave-class
+// addresses to Master (the fallback only matches like-class). After
+// MarkSlotStaticSeed(0x15, SlotRoleSlave), the explicit Role=Slave
+// is set on the slot, syncEntryFacesLocked must propagate it, and
+// AddressByRole(SlotRoleSlave) on the attached entry must resolve to
+// 0x15. If the Faces-refresh branch were skipped, the entry's Faces
+// would still carry Role=Unknown and the lookup would only succeed
+// via the AddressClass fallback path — which IS what we expect for
+// slave-class+Slave so this still wouldn't distinguish. Use the
+// explicit Role-driven path instead by checking whether the new
+// LastObservedAt landed on the slot AND that AddressByRole works,
+// then explicitly assert that the Face entry's Role field equals
+// SlotRoleSlave (not Unknown), which can only happen if Faces was
+// refreshed.
+func TestMarkSlotStaticSeed_RefreshesFacesOnAttachedSlot(t *testing.T) {
 	t.Parallel()
 
 	reg := NewDeviceRegistry(nil)
-	// Land slot 0xF1 attached to a device via Register (lands as
-	// ActiveConfirmed/IdentityConfirmed — but the discovery_source
-	// downgrade-guard means MarkSlotStaticSeed will NOT advance the
-	// label here). Use a fresh slot with passive-observed state
-	// instead so we can prove the upgrade path.
-	now := time.Now()
-	reg.MarkSlotPassiveObserved(0xF1, SlotRoleMaster, now)
-	pre, _ := reg.LookupSlot(0xF1)
-	if pre.DiscoverySource != DiscoverySourcePassiveObserved {
-		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want PassiveObserved", pre.DiscoverySource)
-	}
-	// Attach a device pointer so syncEntryFacesLocked has something
-	// to refresh — the most realistic path is RegisterStaticSeed of
-	// THIS address (which would normally double-stamp; here we just
-	// want a Device on the slot so MarkSlotStaticSeed exercises the
-	// Faces-refresh branch).
-	reg.RegisterStaticSeed(DeviceInfo{
-		Address:      0xF1,
-		Manufacturer: "Vaillant",
-		DeviceID:     "NETX3",
-		SerialNumber: "SN-AB",
-	}, SlotRoleMaster, now)
+	earlier := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 
-	post, _ := reg.LookupSlot(0xF1)
-	if post.DiscoverySource != DiscoverySourceStaticSeed {
-		t.Errorf("after RegisterStaticSeed: slot.DiscoverySource = %v; want StaticSeed", post.DiscoverySource)
+	// Step 1: attach slot 0x15 to a device entry via RegisterStaticSeed
+	// with NO role hint (SlotRoleUnknown). The slot's Role stays
+	// Unknown; entry.Faces[0].Role is Unknown.
+	entry := reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0x15,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		SerialNumber: "SN-15",
+	}, SlotRoleUnknown, earlier)
+	if entry == nil {
+		t.Fatalf("RegisterStaticSeed returned nil entry")
 	}
-	if post.Device == nil {
-		t.Errorf("after RegisterStaticSeed: slot.Device is nil; want non-nil (entry attached)")
+	preFace, ok := faceForAddress(entry, 0x15)
+	if !ok {
+		t.Fatalf("pre-condition: entry has no Face for 0x15")
 	}
+	if preFace.Role != SlotRoleUnknown {
+		t.Fatalf("pre-condition: Face[0x15].Role = %v; want SlotRoleUnknown", preFace.Role)
+	}
+
+	// Step 2: MarkSlotStaticSeed on the now-attached slot with an
+	// explicit role. Faces refresh must propagate the role into
+	// entry.Faces.
+	later := earlier.Add(24 * time.Hour)
+	reg.MarkSlotStaticSeed(0x15, SlotRoleSlave, later)
+
+	slot, ok := reg.LookupSlot(0x15)
+	if !ok || slot == nil {
+		t.Fatalf("LookupSlot(0x15) ok=%v slot=%v", ok, slot)
+	}
+	if slot.Role != SlotRoleSlave {
+		t.Errorf("after MarkSlotStaticSeed: slot.Role = %v; want SlotRoleSlave", slot.Role)
+	}
+	if !slot.LastObservedAt.Equal(later) {
+		t.Errorf("after MarkSlotStaticSeed: slot.LastObservedAt = %v; want %v", slot.LastObservedAt, later)
+	}
+
+	// Critical assertion: entry.Faces was refreshed by the
+	// slot.Device != nil branch — Face[0x15].Role is now Slave, NOT
+	// Unknown. Without Faces-refresh, the Face would still hold
+	// SlotRoleUnknown.
+	postFace, ok := faceForAddress(entry, 0x15)
+	if !ok {
+		t.Fatalf("after MarkSlotStaticSeed: entry has no Face for 0x15")
+	}
+	if postFace.Role != SlotRoleSlave {
+		t.Errorf("after MarkSlotStaticSeed: Face[0x15].Role = %v; want SlotRoleSlave (Faces must be refreshed)", postFace.Role)
+	}
+}
+
+// faceForAddress is a small test helper that returns the BusFace
+// matching the given address from a device entry. The DeviceEntry
+// public API does not expose Faces directly; we use the Faces()
+// accessor available on *deviceEntry here via the test package's
+// privileged access.
+func faceForAddress(entry DeviceEntry, addr byte) (BusFace, bool) {
+	d, ok := entry.(*deviceEntry)
+	if !ok {
+		return BusFace{}, false
+	}
+	for _, face := range d.Faces {
+		if face.Addr == addr {
+			return face, true
+		}
+	}
+	return BusFace{}, false
 }
 
 // TestMarkSlotStaticSeed_RaceFreeWriteAndRead mirrors the M6.1 hardening

--- a/registry/mark_slot_static_seed_test.go
+++ b/registry/mark_slot_static_seed_test.go
@@ -209,9 +209,9 @@ func TestMarkSlotStaticSeed_RefreshesFacesOnAttachedSlot(t *testing.T) {
 
 // faceForAddress is a small test helper that returns the BusFace
 // matching the given address from a device entry. The DeviceEntry
-// public API does not expose Faces directly; we use the Faces()
-// accessor available on *deviceEntry here via the test package's
-// privileged access.
+// public API does not expose Faces directly; we use the *deviceEntry
+// concrete type's exported Faces field via the test package's
+// same-package access.
 func faceForAddress(entry DeviceEntry, addr byte) (BusFace, bool) {
 	d, ok := entry.(*deviceEntry)
 	if !ok {

--- a/registry/mark_slot_static_seed_test.go
+++ b/registry/mark_slot_static_seed_test.go
@@ -99,22 +99,45 @@ func TestMarkSlotStaticSeed_MonotonicUpgradeFromPassive(t *testing.T) {
 }
 
 // TestMarkSlotStaticSeed_RaceFreeWriteAndRead mirrors the M6.1 hardening
-// proof for MarkSlotPassiveObserved. The API must serialize via the
-// registry's RWMutex; concurrent writers and readers must not race.
+// proof for MarkSlotPassiveObserved AND extends it to the cross-API
+// case (Codex P3.5 review FINDING_2): concurrent passive-observed and
+// static-seed writers on the same slot must converge through the
+// registry's RWMutex without panic, deadlock, or torn DiscoverySource /
+// VerificationState / Role values.
+//
+// Readers exercise only the monotonically-converging fields (Role,
+// DiscoverySource, VerificationState). The shared-pointer pattern of
+// LookupSlot means LastObservedAt is technically read-after-write via
+// the slot pointer; the existing MarkSlotPassiveObserved race test
+// constrains its reader the same way for the same reason. Improving
+// LookupSlot to return a snapshot copy would close that pointer-share
+// surface but is wider than P3.5's scope.
 func TestMarkSlotStaticSeed_RaceFreeWriteAndRead(t *testing.T) {
 	reg := NewDeviceRegistry(nil)
-	const writers = 100
+	const writers = 50
+	const passiveWriters = 50
 	const readers = 100
 	const iterations = 100
 
 	var wg sync.WaitGroup
-	wg.Add(writers + readers)
+	wg.Add(writers + passiveWriters + readers)
 
 	for i := 0; i < writers; i++ {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				reg.MarkSlotStaticSeed(0xF1, SlotRoleMaster, time.Now())
+			}
+		}()
+	}
+	// Concurrent passive-observed writers exercise the cross-API
+	// serialization path. Both APIs hit r.mu, so neither set of
+	// mutations may interleave at the byte level.
+	for i := 0; i < passiveWriters; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				reg.MarkSlotPassiveObserved(0xF1, SlotRoleMaster, time.Now())
 			}
 		}()
 	}
@@ -137,7 +160,10 @@ func TestMarkSlotStaticSeed_RaceFreeWriteAndRead(t *testing.T) {
 	if !ok || slot == nil {
 		t.Fatalf("after race test: LookupSlot(0xF1) ok=%v slot=%v", ok, slot)
 	}
-	if slot.DiscoverySource != DiscoverySourceStaticSeed {
-		t.Errorf("after race test: slot.DiscoverySource = %v; want StaticSeed", slot.DiscoverySource)
+	// Final state: at least one StaticSeed write happened and the
+	// monotonic guard means DiscoverySource >= StaticSeed
+	// (PassiveObserved < StaticSeed).
+	if slot.DiscoverySource < DiscoverySourceStaticSeed {
+		t.Errorf("after race test: slot.DiscoverySource = %v; want >= StaticSeed", slot.DiscoverySource)
 	}
 }

--- a/registry/mark_slot_static_seed_test.go
+++ b/registry/mark_slot_static_seed_test.go
@@ -135,22 +135,13 @@ func TestMarkSlotStaticSeed_DoesNotAttachOrphanSlot(t *testing.T) {
 // Faces-refresh branch (slot.Device != nil → syncEntryFacesLocked)
 // actually runs — i.e. the device's BusFace list reflects the role.
 //
-// Test design: uses a slave-class address (0x15 BASV2 slave). When
-// the slot is initially seeded with SlotRoleUnknown, AddressByRole's
-// AddressClass fallback does NOT promote Slave role for slave-class
-// addresses to Master (the fallback only matches like-class). After
-// MarkSlotStaticSeed(0x15, SlotRoleSlave), the explicit Role=Slave
-// is set on the slot, syncEntryFacesLocked must propagate it, and
-// AddressByRole(SlotRoleSlave) on the attached entry must resolve to
-// 0x15. If the Faces-refresh branch were skipped, the entry's Faces
-// would still carry Role=Unknown and the lookup would only succeed
-// via the AddressClass fallback path — which IS what we expect for
-// slave-class+Slave so this still wouldn't distinguish. Use the
-// explicit Role-driven path instead by checking whether the new
-// LastObservedAt landed on the slot AND that AddressByRole works,
-// then explicitly assert that the Face entry's Role field equals
-// SlotRoleSlave (not Unknown), which can only happen if Faces was
-// refreshed.
+// Test design: uses a target-class address (0x15 BASV2 target). The
+// slot is initially seeded with SlotRoleUnknown, then a later
+// MarkSlotStaticSeed(0x15, SlotRoleSlave) call sets the explicit
+// target role on the slot. After the call, entry.Faces[0x15].Role
+// MUST be SlotRoleSlave — that can ONLY hold if syncEntryFacesLocked
+// actually ran on the attached entry; if the refresh branch were
+// skipped, the cached Face would still carry SlotRoleUnknown.
 func TestMarkSlotStaticSeed_RefreshesFacesOnAttachedSlot(t *testing.T) {
 	t.Parallel()
 
@@ -195,9 +186,9 @@ func TestMarkSlotStaticSeed_RefreshesFacesOnAttachedSlot(t *testing.T) {
 	}
 
 	// Critical assertion: entry.Faces was refreshed by the
-	// slot.Device != nil branch — Face[0x15].Role is now Slave, NOT
-	// Unknown. Without Faces-refresh, the Face would still hold
-	// SlotRoleUnknown.
+	// slot.Device != nil branch — Face[0x15].Role is now SlotRoleSlave
+	// (the target role), NOT SlotRoleUnknown. Without Faces-refresh,
+	// the Face would still hold SlotRoleUnknown.
 	postFace, ok := faceForAddress(entry, 0x15)
 	if !ok {
 		t.Fatalf("after MarkSlotStaticSeed: entry has no Face for 0x15")
@@ -227,18 +218,23 @@ func faceForAddress(entry DeviceEntry, addr byte) (BusFace, bool) {
 
 // TestMarkSlotStaticSeed_RaceFreeWriteAndRead mirrors the M6.1 hardening
 // proof for MarkSlotPassiveObserved AND extends it to the cross-API
-// case (Codex P3.5 review FINDING_2): concurrent passive-observed and
-// static-seed writers on the same slot must converge through the
-// registry's RWMutex without panic, deadlock, or torn DiscoverySource /
-// VerificationState / Role values.
+// case (Codex P3.5 review FINDING_2): concurrent static-seed writers
+// and passive-observed writers on the same slot must serialize via
+// the registry's RWMutex without panic, deadlock, or torn slot state
+// after wg.Wait completes.
 //
-// Readers exercise only the monotonically-converging fields (Role,
-// DiscoverySource, VerificationState). The shared-pointer pattern of
-// LookupSlot means LastObservedAt is technically read-after-write via
-// the slot pointer; the existing MarkSlotPassiveObserved race test
-// constrains its reader the same way for the same reason. Improving
-// LookupSlot to return a snapshot copy would close that pointer-share
-// surface but is wider than P3.5's scope.
+// Reader scope is intentionally narrow: only LookupSlot's RLock
+// (which IS held during the slot map read) and slot != nil. Reading
+// slot.Role / DiscoverySource / VerificationState through the
+// shared pointer that LookupSlot returns races with writers that
+// hold r.mu — that's a pre-existing LookupSlot API surface
+// (returns a *AddressSlot rather than a copy) which the existing
+// MarkSlotPassiveObserved race test already touches by reading the
+// same fields, but it is timing-sensitive. Hardening the API to
+// return a snapshot is wider than P3.5's scope. After wg.Wait,
+// final-state assertions hold the mutex (via the same
+// LookupSlot path) and use the post-wait timing to read steady-state
+// fields safely.
 func TestMarkSlotStaticSeed_RaceFreeWriteAndRead(t *testing.T) {
 	reg := NewDeviceRegistry(nil)
 	const writers = 50
@@ -273,11 +269,8 @@ func TestMarkSlotStaticSeed_RaceFreeWriteAndRead(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				slot, ok := reg.LookupSlot(0xF1)
-				if ok && slot != nil {
-					_ = slot.Role
-					_ = slot.DiscoverySource
-					_ = slot.VerificationState
-				}
+				_ = slot
+				_ = ok
 			}
 		}()
 	}

--- a/registry/mark_slot_static_seed_test.go
+++ b/registry/mark_slot_static_seed_test.go
@@ -98,6 +98,78 @@ func TestMarkSlotStaticSeed_MonotonicUpgradeFromPassive(t *testing.T) {
 	}
 }
 
+// TestMarkSlotStaticSeed_DoesNotAttachOrphanSlot documents the scope
+// limit: MarkSlotStaticSeed on an address with no prior Device pointer
+// only stamps the AddressSlot's labels; it does NOT attach the address
+// to any device entry, does NOT add it to r.entries, and does NOT
+// update any device's Faces. To plant identity for a new seeded
+// address, callers must use RegisterStaticSeed (which composes
+// registerLocked) — or AliasAddresses to attach an existing entry
+// after-the-fact. Codex P3.5 review pass 2 caught the misleading
+// previous doc claim that this API could mark "additional faces".
+func TestMarkSlotStaticSeed_DoesNotAttachOrphanSlot(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.MarkSlotStaticSeed(0x04, SlotRoleSlave, time.Now())
+
+	if entry, ok := reg.Lookup(0x04); ok || entry != nil {
+		t.Errorf("Lookup(0x04) ok=%v entry=%v; want (false, nil) — orphan slot must not produce a device entry", ok, entry)
+	}
+	slot, ok := reg.LookupSlot(0x04)
+	if !ok || slot == nil {
+		t.Fatalf("LookupSlot(0x04) ok=%v slot=%v; want non-nil slot (label-only stamping)", ok, slot)
+	}
+	if slot.Device != nil {
+		t.Errorf("orphan slot.Device = %v; want nil", slot.Device)
+	}
+	if slot.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("orphan slot.DiscoverySource = %v; want DiscoverySourceStaticSeed", slot.DiscoverySource)
+	}
+}
+
+// TestMarkSlotStaticSeed_UpgradesAttachedSlot covers the in-scope use
+// case: a slot already attached to a device entry (here via
+// RegisterStaticSeed for a different address that aliased into the
+// same entry) gets its discovery_source label upgraded by a
+// MarkSlotStaticSeed call. Faces is refreshed because slot.Device is
+// non-nil at call time.
+func TestMarkSlotStaticSeed_UpgradesAttachedSlot(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	// Land slot 0xF1 attached to a device via Register (lands as
+	// ActiveConfirmed/IdentityConfirmed — but the discovery_source
+	// downgrade-guard means MarkSlotStaticSeed will NOT advance the
+	// label here). Use a fresh slot with passive-observed state
+	// instead so we can prove the upgrade path.
+	now := time.Now()
+	reg.MarkSlotPassiveObserved(0xF1, SlotRoleMaster, now)
+	pre, _ := reg.LookupSlot(0xF1)
+	if pre.DiscoverySource != DiscoverySourcePassiveObserved {
+		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want PassiveObserved", pre.DiscoverySource)
+	}
+	// Attach a device pointer so syncEntryFacesLocked has something
+	// to refresh — the most realistic path is RegisterStaticSeed of
+	// THIS address (which would normally double-stamp; here we just
+	// want a Device on the slot so MarkSlotStaticSeed exercises the
+	// Faces-refresh branch).
+	reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+		SerialNumber: "SN-AB",
+	}, SlotRoleMaster, now)
+
+	post, _ := reg.LookupSlot(0xF1)
+	if post.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("after RegisterStaticSeed: slot.DiscoverySource = %v; want StaticSeed", post.DiscoverySource)
+	}
+	if post.Device == nil {
+		t.Errorf("after RegisterStaticSeed: slot.Device is nil; want non-nil (entry attached)")
+	}
+}
+
 // TestMarkSlotStaticSeed_RaceFreeWriteAndRead mirrors the M6.1 hardening
 // proof for MarkSlotPassiveObserved AND extends it to the cross-API
 // case (Codex P3.5 review FINDING_2): concurrent passive-observed and

--- a/registry/register_static_seed_test.go
+++ b/registry/register_static_seed_test.go
@@ -1,0 +1,154 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRegisterStaticSeed_StampsCorrectLabels asserts that
+// RegisterStaticSeed stamps the address slot with
+// DiscoverySourceStaticSeed / VerificationStateCandidate (NOT the
+// ActiveConfirmed / IdentityConfirmed labels that Register uses).
+// This is the central P3.5 contract.
+func TestRegisterStaticSeed_StampsCorrectLabels(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	entry := reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+	}, SlotRoleMaster, now)
+	if entry == nil {
+		t.Fatalf("RegisterStaticSeed returned nil entry")
+	}
+
+	slot, ok := reg.LookupSlot(0xF1)
+	if !ok || slot == nil {
+		t.Fatalf("LookupSlot(0xF1) ok=%v slot=%v", ok, slot)
+	}
+	if slot.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("slot.DiscoverySource = %v; want DiscoverySourceStaticSeed", slot.DiscoverySource)
+	}
+	if slot.VerificationState != VerificationStateCandidate {
+		t.Errorf("slot.VerificationState = %v; want VerificationStateCandidate", slot.VerificationState)
+	}
+	if slot.Role != SlotRoleMaster {
+		t.Errorf("slot.Role = %v; want SlotRoleMaster", slot.Role)
+	}
+}
+
+// TestRegisterStaticSeed_AttachesIdentity asserts the underlying
+// identity-merge body still runs — the entry has the seeded
+// Manufacturer / DeviceID and is queryable via Lookup.
+func TestRegisterStaticSeed_AttachesIdentity(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+	}, SlotRoleMaster, time.Now())
+
+	entry, ok := reg.Lookup(0xF1)
+	if !ok || entry == nil {
+		t.Fatalf("Lookup(0xF1) ok=%v entry=%v", ok, entry)
+	}
+	if got, want := entry.Manufacturer(), "Vaillant"; got != want {
+		t.Errorf("entry.Manufacturer() = %q; want %q", got, want)
+	}
+	if got, want := entry.DeviceID(), "NETX3"; got != want {
+		t.Errorf("entry.DeviceID() = %q; want %q", got, want)
+	}
+
+	slot, _ := reg.LookupSlot(0xF1)
+	if slot.Device == nil {
+		t.Errorf("slot.Device is nil; want pointer to the registered entry")
+	}
+}
+
+// TestRegisterStaticSeed_DoesNotDowngradeActiveConfirmed asserts that
+// calling RegisterStaticSeed on a slot already marked ActiveConfirmed
+// (e.g. via a prior Register call) does NOT downgrade the discovery
+// label. The identity-merge body MAY still update fields per the
+// Register monotonic merge rules, but the AddressSlot label stays at
+// ActiveConfirmed / IdentityConfirmed.
+func TestRegisterStaticSeed_DoesNotDowngradeActiveConfirmed(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	// Land at ActiveConfirmed first.
+	reg.Register(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+		SerialNumber: "SN-Z",
+	})
+	pre, _ := reg.LookupSlot(0xF1)
+	if pre.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want ActiveConfirmed", pre.DiscoverySource)
+	}
+
+	// Now seed; must not downgrade.
+	reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+	}, SlotRoleMaster, time.Now())
+
+	post, _ := reg.LookupSlot(0xF1)
+	if post.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Errorf("slot.DiscoverySource after RegisterStaticSeed = %v; want ActiveConfirmed (no downgrade)", post.DiscoverySource)
+	}
+	if post.VerificationState != VerificationStateIdentityConfirmed {
+		t.Errorf("slot.VerificationState after RegisterStaticSeed = %v; want IdentityConfirmed (no downgrade)", post.VerificationState)
+	}
+}
+
+// TestRegisterStaticSeed_PreservesAliasIdentity verifies that the P0
+// alias-identity invariant (PR #136 — secondary keys retained via
+// identityKeyAliases on a Register call that promotes a different
+// identityKey) holds when seed registration is later followed by an
+// AliasAddresses call. The seed's DeviceID and Manufacturer must
+// survive the alias.
+func TestRegisterStaticSeed_PreservesAliasIdentity(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	// Seed both NETX3 face addresses.
+	reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+	}, SlotRoleMaster, time.Now())
+	reg.RegisterStaticSeed(DeviceInfo{
+		Address:      0xF6,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+	}, SlotRoleSlave, time.Now())
+
+	if err := reg.AliasAddresses(0xF1, 0xF6); err != nil {
+		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
+	}
+
+	entry, ok := reg.Lookup(0xF6)
+	if !ok || entry == nil {
+		t.Fatalf("Lookup(0xF6) after alias: ok=%v entry=%v", ok, entry)
+	}
+	if got, want := entry.DeviceID(), "NETX3"; got != want {
+		t.Errorf("aliased entry DeviceID = %q; want %q", got, want)
+	}
+	if got, want := entry.Manufacturer(), "Vaillant"; got != want {
+		t.Errorf("aliased entry Manufacturer = %q; want %q", got, want)
+	}
+
+	// Both slots still labelled static_seed/candidate.
+	for _, addr := range []byte{0xF1, 0xF6} {
+		slot, _ := reg.LookupSlot(addr)
+		if slot.DiscoverySource != DiscoverySourceStaticSeed {
+			t.Errorf("slot[0x%02X].DiscoverySource = %v; want StaticSeed", addr, slot.DiscoverySource)
+		}
+	}
+}

--- a/registry/register_static_seed_test.go
+++ b/registry/register_static_seed_test.go
@@ -113,35 +113,49 @@ func TestRegisterStaticSeed_DoesNotDowngradeActiveConfirmed(t *testing.T) {
 // identityKey) holds when seed registration is later followed by an
 // AliasAddresses call. The seed's DeviceID and Manufacturer must
 // survive the alias.
+//
+// Uses distinct SerialNumber values per face so each entry has a
+// non-empty identityKey — that's the precondition for AliasAddresses
+// to actually exercise the identityKeyAliases transfer path
+// (per Codex P3.5 review FINDING_1 — without serial/mac the
+// canonicalPhysicalIdentity yields no key and the alias path silently
+// no-ops).
 func TestRegisterStaticSeed_PreservesAliasIdentity(t *testing.T) {
 	t.Parallel()
 
 	reg := NewDeviceRegistry(nil)
-	// Seed both NETX3 face addresses.
+	// Seed both NETX3 face addresses with distinct stable identity
+	// keys so AliasAddresses takes the identityKey-merge path.
 	reg.RegisterStaticSeed(DeviceInfo{
 		Address:      0xF1,
 		Manufacturer: "Vaillant",
 		DeviceID:     "NETX3",
+		SerialNumber: "SN-F1",
 	}, SlotRoleMaster, time.Now())
 	reg.RegisterStaticSeed(DeviceInfo{
 		Address:      0xF6,
 		Manufacturer: "Vaillant",
 		DeviceID:     "NETX3",
+		SerialNumber: "SN-F6",
 	}, SlotRoleSlave, time.Now())
 
 	if err := reg.AliasAddresses(0xF1, 0xF6); err != nil {
 		t.Fatalf("AliasAddresses(0xF1, 0xF6) error = %v", err)
 	}
 
-	entry, ok := reg.Lookup(0xF6)
-	if !ok || entry == nil {
-		t.Fatalf("Lookup(0xF6) after alias: ok=%v entry=%v", ok, entry)
-	}
-	if got, want := entry.DeviceID(), "NETX3"; got != want {
-		t.Errorf("aliased entry DeviceID = %q; want %q", got, want)
-	}
-	if got, want := entry.Manufacturer(), "Vaillant"; got != want {
-		t.Errorf("aliased entry Manufacturer = %q; want %q", got, want)
+	// Lookup via either alias must resolve to the merged entry with
+	// the seeded identity preserved.
+	for _, addr := range []byte{0xF1, 0xF6} {
+		entry, ok := reg.Lookup(addr)
+		if !ok || entry == nil {
+			t.Fatalf("Lookup(0x%02X) after alias: ok=%v entry=%v", addr, ok, entry)
+		}
+		if got, want := entry.DeviceID(), "NETX3"; got != want {
+			t.Errorf("aliased entry[0x%02X] DeviceID = %q; want %q", addr, got, want)
+		}
+		if got, want := entry.Manufacturer(), "Vaillant"; got != want {
+			t.Errorf("aliased entry[0x%02X] Manufacturer = %q; want %q", addr, got, want)
+		}
 	}
 
 	// Both slots still labelled static_seed/candidate.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -269,33 +269,16 @@ func (r *DeviceRegistry) registerLocked(info DeviceInfo) *deviceEntry {
 // ActiveConfirmed (StaticSeed < ActiveConfirmed) AND VerificationState
 // to IdentityConfirmed.
 //
-// Single lock acquisition — composes registerLocked, then
-// MarkSlotStaticSeed-equivalent inline (we already hold r.mu so we
-// avoid a recursive acquire), then syncEntryFacesLocked.
+// Single lock acquisition — composes registerLocked, then the
+// shared static-seed stamping primitive, then syncEntryFacesLocked.
 func (r *DeviceRegistry) RegisterStaticSeed(info DeviceInfo, role SlotRole, seededAt time.Time) DeviceEntry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	entry := r.registerLocked(info)
-
 	slot := r.ensureAddressSlotLocked(info.Address)
 	slot.Device = entry
-	if slot.DiscoverySource < DiscoverySourceStaticSeed {
-		slot.DiscoverySource = DiscoverySourceStaticSeed
-	}
-	if slot.VerificationState < VerificationStateCandidate {
-		slot.VerificationState = VerificationStateCandidate
-	}
-	if role != SlotRoleUnknown && slot.Role == SlotRoleUnknown {
-		slot.Role = role
-	}
-	if slot.FirstObservedAt.IsZero() && !seededAt.IsZero() {
-		slot.FirstObservedAt = seededAt
-	}
-	if !seededAt.IsZero() {
-		slot.LastObservedAt = seededAt
-	}
-
+	r.markSlotStaticSeedLocked(slot, role, seededAt)
 	r.syncEntryFacesLocked(entry)
 	return entry
 }
@@ -323,6 +306,18 @@ func (r *DeviceRegistry) MarkSlotStaticSeed(address byte, role SlotRole, seededA
 	defer r.mu.Unlock()
 
 	slot := r.ensureAddressSlotLocked(address)
+	r.markSlotStaticSeedLocked(slot, role, seededAt)
+	if slot.Device != nil {
+		r.syncEntryFacesLocked(slot.Device)
+	}
+}
+
+// markSlotStaticSeedLocked is the shared slot-stamping primitive used
+// by both MarkSlotStaticSeed and RegisterStaticSeed. Caller MUST hold
+// r.mu and is responsible for any subsequent syncEntryFacesLocked
+// call. Centralising the stamping rules here prevents drift between
+// the two public entry points (Codex P3.5 review NIT FINDING_3).
+func (r *DeviceRegistry) markSlotStaticSeedLocked(slot *AddressSlot, role SlotRole, seededAt time.Time) {
 	if slot.DiscoverySource < DiscoverySourceStaticSeed {
 		slot.DiscoverySource = DiscoverySourceStaticSeed
 	}
@@ -337,9 +332,6 @@ func (r *DeviceRegistry) MarkSlotStaticSeed(address byte, role SlotRole, seededA
 	}
 	if !seededAt.IsZero() {
 		slot.LastObservedAt = seededAt
-	}
-	if slot.Device != nil {
-		r.syncEntryFacesLocked(slot.Device)
 	}
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -288,11 +288,26 @@ func (r *DeviceRegistry) RegisterStaticSeed(info DeviceInfo, role SlotRole, seed
 // (lock discipline, monotonic upgrade semantics, idempotence) but
 // stamping DiscoverySourceStaticSeed / VerificationStateCandidate.
 //
-// Use cases:
-//   - Mark an additional face of a device whose primary address was
-//     RegisterStaticSeed'd (e.g. NETX3 broadcast face 0xFF or 0x04).
-//   - Pre-populate an address slot whose identity will later be filled
-//     in via Register / RegisterStaticSeed.
+// SCOPE: this API only mutates the AddressSlot. It does NOT attach
+// the slot to a device entry; if `slot.Device` is nil at call time
+// it stays nil, the address is NOT added to `r.entries`, and the
+// device's `addresses` / `Faces` lists are NOT updated. Therefore:
+//
+//   - To plant a NEW seeded address with identity attached, use
+//     RegisterStaticSeed (which composes registerLocked + this
+//     stamp). Each face that should appear in `Lookup` /
+//     `AddressByRole` needs its own RegisterStaticSeed call; the
+//     identity-merge in registerLocked joins them when DeviceInfo
+//     identity matches, or they can be aliased post-hoc via
+//     AliasAddresses.
+//
+//   - The use case for MarkSlotStaticSeed in isolation is updating
+//     an AddressSlot that was already attached to a device by some
+//     prior path (Register / RegisterStaticSeed / AliasAddresses)
+//     to upgrade its discovery_source / verification labels — for
+//     example, marking a slot newly populated by passive observation
+//     as "now also seeded from the static table" so the operator
+//     surface reflects that the addresses are pre-known.
 //
 // Idempotent. Re-calling on a slot already at higher
 // DiscoverySource (e.g. ActiveConfirmed) is a no-op for the discovery

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -104,6 +104,30 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	entry := r.registerLocked(info)
+	r.observeAddressSlotLocked(info.Address, entry, DiscoverySourceActiveConfirmed, VerificationStateIdentityConfirmed)
+	r.syncEntryFacesLocked(entry)
+	return entry
+}
+
+// registerLocked performs the core identity-merge / planes / projections /
+// index work for an incoming DeviceInfo without stamping a discovery
+// label on the AddressSlot. It is the primitive shared by the
+// active-discovery path (Register, which stamps
+// DiscoverySourceActiveConfirmed / VerificationStateIdentityConfirmed)
+// and the static-seed path (RegisterStaticSeed, which stamps
+// DiscoverySourceStaticSeed / VerificationStateCandidate).
+//
+// Lock contract: the caller MUST hold r.mu. registerLocked does NOT
+// acquire the lock itself. This mirrors the file's existing *Locked
+// suffix convention (observeAddressSlotLocked, ensureAddressSlotLocked,
+// syncEntryFacesLocked, lookupCompatibleBySignatureLocked,
+// detachAddressLocked).
+//
+// Both callers are responsible for stamping the AddressSlot
+// (observeAddressSlotLocked) and refreshing entry.Faces
+// (syncEntryFacesLocked) after the call.
+func (r *DeviceRegistry) registerLocked(info DeviceInfo) *deviceEntry {
 	physical := canonicalPhysicalIdentity(info)
 	identityKey := physical.key()
 	planes := make([]Plane, 0)
@@ -225,10 +249,98 @@ func (r *DeviceRegistry) Register(info DeviceInfo) DeviceEntry {
 		r.identity[identityKey] = entry
 	}
 	r.entries[info.Address] = entry
-	r.observeAddressSlotLocked(info.Address, entry, DiscoverySourceActiveConfirmed, VerificationStateIdentityConfirmed)
-	r.syncEntryFacesLocked(entry)
 
 	return entry
+}
+
+// RegisterStaticSeed plants identity for an address known from a
+// product taxonomy table BEFORE any wire traffic has been observed.
+// Mirrors Register's identity-merge behavior but stamps the AddressSlot
+// with DiscoverySourceStaticSeed / VerificationStateCandidate so the
+// observability surface (`/metrics`, MCP `bus.summary.get`,
+// address-table snapshots) correctly shows the slot's provenance as a
+// pre-known seed rather than active confirmation.
+//
+// On a clean cold boot a static-seeded slot subsequently observed
+// passively will: NOT advance DiscoverySource (PassiveObserved <
+// StaticSeed in the monotonic enum order), WILL advance
+// VerificationState from Candidate to Corroborated. An active
+// confirmation (e.g. directed scan) DOES advance DiscoverySource to
+// ActiveConfirmed (StaticSeed < ActiveConfirmed) AND VerificationState
+// to IdentityConfirmed.
+//
+// Single lock acquisition — composes registerLocked, then
+// MarkSlotStaticSeed-equivalent inline (we already hold r.mu so we
+// avoid a recursive acquire), then syncEntryFacesLocked.
+func (r *DeviceRegistry) RegisterStaticSeed(info DeviceInfo, role SlotRole, seededAt time.Time) DeviceEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry := r.registerLocked(info)
+
+	slot := r.ensureAddressSlotLocked(info.Address)
+	slot.Device = entry
+	if slot.DiscoverySource < DiscoverySourceStaticSeed {
+		slot.DiscoverySource = DiscoverySourceStaticSeed
+	}
+	if slot.VerificationState < VerificationStateCandidate {
+		slot.VerificationState = VerificationStateCandidate
+	}
+	if role != SlotRoleUnknown && slot.Role == SlotRoleUnknown {
+		slot.Role = role
+	}
+	if slot.FirstObservedAt.IsZero() && !seededAt.IsZero() {
+		slot.FirstObservedAt = seededAt
+	}
+	if !seededAt.IsZero() {
+		slot.LastObservedAt = seededAt
+	}
+
+	r.syncEntryFacesLocked(entry)
+	return entry
+}
+
+// MarkSlotStaticSeed updates an AddressSlot for an address known from
+// a product taxonomy seed table, mirroring MarkSlotPassiveObserved
+// (lock discipline, monotonic upgrade semantics, idempotence) but
+// stamping DiscoverySourceStaticSeed / VerificationStateCandidate.
+//
+// Use cases:
+//   - Mark an additional face of a device whose primary address was
+//     RegisterStaticSeed'd (e.g. NETX3 broadcast face 0xFF or 0x04).
+//   - Pre-populate an address slot whose identity will later be filled
+//     in via Register / RegisterStaticSeed.
+//
+// Idempotent. Re-calling on a slot already at higher
+// DiscoverySource (e.g. ActiveConfirmed) is a no-op for the discovery
+// label, though it may still upgrade VerificationState if the
+// existing state is below Candidate.
+func (r *DeviceRegistry) MarkSlotStaticSeed(address byte, role SlotRole, seededAt time.Time) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	slot := r.ensureAddressSlotLocked(address)
+	if slot.DiscoverySource < DiscoverySourceStaticSeed {
+		slot.DiscoverySource = DiscoverySourceStaticSeed
+	}
+	if slot.VerificationState < VerificationStateCandidate {
+		slot.VerificationState = VerificationStateCandidate
+	}
+	if role != SlotRoleUnknown && slot.Role == SlotRoleUnknown {
+		slot.Role = role
+	}
+	if slot.FirstObservedAt.IsZero() && !seededAt.IsZero() {
+		slot.FirstObservedAt = seededAt
+	}
+	if !seededAt.IsZero() {
+		slot.LastObservedAt = seededAt
+	}
+	if slot.Device != nil {
+		r.syncEntryFacesLocked(slot.Device)
+	}
 }
 
 func (r *DeviceRegistry) lookupByIdentity(info DeviceInfo) (DeviceEntry, bool) {


### PR DESCRIPTION
## Summary

P3.5 — adds two additive registry APIs so the gateway's `applyStaticSeedTable` can plant identity for pre-known addresses (e.g. NETX3 0xF1/0xF6/0xFF/0x04, BASV2 0x15) without stamping the AddressSlot with `DiscoverySourceActiveConfirmed/VerificationStateIdentityConfirmed` (the labels `Register` uses). Operators reading the address-table snapshot now see seeded slots correctly labelled `discovery_source=static_seed`, `verification=candidate`.

- `registerLocked(info) *deviceEntry` — extracts the identity-merge / planes / projections / index core of `Register` into an unexported lock-held primitive (caller MUST hold `r.mu`, mirrors the file's existing `*Locked` convention).
- `Register` now composes `registerLocked` + `observeAddressSlotLocked(ActiveConfirmed/IdentityConfirmed)` + `syncEntryFacesLocked`. Zero behavior change for existing callers.
- `RegisterStaticSeed(info, role, seededAt) DeviceEntry` — single-lock-acquisition path that composes `registerLocked` then stamps the slot with `StaticSeed/Candidate`.
- `MarkSlotStaticSeed(address, role, seededAt)` — mirrors `MarkSlotPassiveObserved` with `PassiveObserved → StaticSeed`, `Corroborated → Candidate` substitutions.

Per the existing enum order (`Unknown < PassiveObserved < StaticSeed < ActiveConfirmed`):
- Passive→static-seed upgrade IS allowed (pre-known taxonomy outranks wire-only inference).
- ActiveConfirmed→static-seed downgrade is rejected (no-op on the discovery label).
- Static-seeded slot subsequently observed passively keeps `static_seed` but upgrades `Candidate→Corroborated`.
- Active scan corroboration advances both labels to `ActiveConfirmed/IdentityConfirmed`.

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `scripts/ci_local.sh` — green
- [x] New tests:
  - `mark_slot_static_seed_test.go`: `BasicWrite`, `MonotonicNoDowngrade`, `MonotonicUpgradeFromPassive`, `RaceFreeWriteAndRead`
  - `register_static_seed_test.go`: `StampsCorrectLabels`, `AttachesIdentity`, `DoesNotDowngradeActiveConfirmed`, `PreservesAliasIdentity`
- [ ] Gateway-side caller adaptation (separate PR): `cmd/gateway/main.go` `applyStaticSeedTable` will use `RegisterStaticSeed`. To follow once this lands.