### PR TITLE
P8 — RegisterPassiveObserved (correct passive-observed label)

### DIFF
--- a/registry/register_passive_observed_test.go
+++ b/registry/register_passive_observed_test.go
@@ -1,0 +1,215 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// P8 — RegisterPassiveObserved correct-label contract.
+//
+// The gateway's address_table_inserter previously called Register
+// (which stamps DiscoverySourceActiveConfirmed /
+// VerificationStateIdentityConfirmed) followed by
+// MarkSlotPassiveObserved. The monotonic ladder
+// (PassiveObserved < ActiveConfirmed) made the second call a no-op,
+// so passively-observed slots were misreported as `active_confirmed`
+// in the observability surfaces.
+//
+// RegisterPassiveObserved performs identity-merge AND the passive-
+// observation slot stamping atomically under one lock acquisition.
+
+// TestRegisterPassiveObserved_StampsCorrectLabels asserts that
+// RegisterPassiveObserved stamps PassiveObserved / Corroborated
+// — NOT the ActiveConfirmed / IdentityConfirmed labels Register uses.
+// This is the central P8 contract.
+func TestRegisterPassiveObserved_StampsCorrectLabels(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	entry := reg.RegisterPassiveObserved(DeviceInfo{
+		Address: 0xF1,
+	}, SlotRoleMaster, now)
+	if entry == nil {
+		t.Fatalf("RegisterPassiveObserved returned nil entry")
+	}
+
+	slot, ok := reg.LookupSlot(0xF1)
+	if !ok || slot == nil {
+		t.Fatalf("LookupSlot(0xF1) ok=%v slot=%v", ok, slot)
+	}
+	if slot.DiscoverySource != DiscoverySourcePassiveObserved {
+		t.Errorf("slot.DiscoverySource = %v; want DiscoverySourcePassiveObserved", slot.DiscoverySource)
+	}
+	if slot.VerificationState != VerificationStateCorroborated {
+		t.Errorf("slot.VerificationState = %v; want VerificationStateCorroborated", slot.VerificationState)
+	}
+	if slot.Role != SlotRoleMaster {
+		t.Errorf("slot.Role = %v; want SlotRoleMaster", slot.Role)
+	}
+	if !slot.FirstObservedAt.Equal(now) {
+		t.Errorf("slot.FirstObservedAt = %v; want %v", slot.FirstObservedAt, now)
+	}
+	if !slot.LastObservedAt.Equal(now) {
+		t.Errorf("slot.LastObservedAt = %v; want %v", slot.LastObservedAt, now)
+	}
+}
+
+// TestRegisterPassiveObserved_AttachesEntryToSlot asserts that the
+// slot's Device pointer is set after RegisterPassiveObserved — the
+// passive insert must be queryable via Lookup, just like Register.
+// Without slot.Device the address-table snapshot would emit nil
+// device fields and break operator visibility.
+func TestRegisterPassiveObserved_AttachesEntryToSlot(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.RegisterPassiveObserved(DeviceInfo{
+		Address: 0xF1,
+	}, SlotRoleMaster, time.Now())
+
+	slot, _ := reg.LookupSlot(0xF1)
+	if slot.Device == nil {
+		t.Errorf("slot.Device is nil; want pointer to the registered entry")
+	}
+
+	entry, ok := reg.Lookup(0xF1)
+	if !ok || entry == nil {
+		t.Fatalf("Lookup(0xF1) ok=%v entry=%v", ok, entry)
+	}
+}
+
+// TestRegisterPassiveObserved_DoesNotDowngradeActiveConfirmed asserts
+// that a passive-observed call on an already-active-confirmed slot
+// does NOT downgrade the discovery label. A directed scan that
+// happens before passive observation produces ActiveConfirmed; a
+// later passive observation should leave the slot at ActiveConfirmed
+// per the monotonic ladder.
+func TestRegisterPassiveObserved_DoesNotDowngradeActiveConfirmed(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+		SerialNumber: "SN-Z",
+	})
+	pre, _ := reg.LookupSlot(0xF1)
+	if pre.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want ActiveConfirmed", pre.DiscoverySource)
+	}
+
+	reg.RegisterPassiveObserved(DeviceInfo{
+		Address: 0xF1,
+	}, SlotRoleMaster, time.Now())
+
+	post, _ := reg.LookupSlot(0xF1)
+	if post.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Errorf("slot.DiscoverySource after RegisterPassiveObserved = %v; want ActiveConfirmed (no downgrade)", post.DiscoverySource)
+	}
+	if post.VerificationState != VerificationStateIdentityConfirmed {
+		t.Errorf("slot.VerificationState after RegisterPassiveObserved = %v; want IdentityConfirmed (no downgrade)", post.VerificationState)
+	}
+}
+
+// TestRegisterPassiveObserved_FollowedByActiveScanUpgrades asserts the
+// reverse direction: a passive-observed slot subsequently active-
+// confirmed (via Register) DOES advance to ActiveConfirmed /
+// IdentityConfirmed. PassiveObserved < ActiveConfirmed in the
+// monotonic ladder, so the upgrade is allowed.
+func TestRegisterPassiveObserved_FollowedByActiveScanUpgrades(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.RegisterPassiveObserved(DeviceInfo{
+		Address: 0x15,
+	}, SlotRoleSlave, time.Now())
+	pre, _ := reg.LookupSlot(0x15)
+	if pre.DiscoverySource != DiscoverySourcePassiveObserved {
+		t.Fatalf("pre-condition: slot.DiscoverySource = %v; want PassiveObserved", pre.DiscoverySource)
+	}
+
+	reg.Register(DeviceInfo{
+		Address:      0x15,
+		Manufacturer: "Vaillant",
+		DeviceID:     "BASV2",
+		SerialNumber: "SN-X",
+	})
+
+	post, _ := reg.LookupSlot(0x15)
+	if post.DiscoverySource != DiscoverySourceActiveConfirmed {
+		t.Errorf("slot.DiscoverySource after directed scan = %v; want ActiveConfirmed (upgrade allowed)", post.DiscoverySource)
+	}
+	if post.VerificationState != VerificationStateIdentityConfirmed {
+		t.Errorf("slot.VerificationState after directed scan = %v; want IdentityConfirmed", post.VerificationState)
+	}
+}
+
+// TestRegisterPassiveObserved_StaticSeedAfterPassiveUpgrades asserts
+// that a static-seed mark on a previously passive-observed slot
+// upgrades the discovery label (StaticSeed > PassiveObserved). Static
+// seeds outrank wire-only inference because pre-known taxonomy is
+// more reliable.
+func TestRegisterPassiveObserved_StaticSeedAfterPassiveUpgrades(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.RegisterPassiveObserved(DeviceInfo{
+		Address: 0xF1,
+	}, SlotRoleMaster, time.Now())
+
+	reg.MarkSlotStaticSeed(0xF1, SlotRoleMaster, time.Now())
+
+	slot, _ := reg.LookupSlot(0xF1)
+	if slot.DiscoverySource != DiscoverySourceStaticSeed {
+		t.Errorf("slot.DiscoverySource = %v; want StaticSeed (upgrade from PassiveObserved)", slot.DiscoverySource)
+	}
+}
+
+// TestRegisterPassiveObserved_RaceFreeWriteAndRead exercises the lock
+// discipline: concurrent RegisterPassiveObserved calls and Lookup /
+// LookupSlot reads must not produce torn state. Race detector is the
+// authoritative gate.
+func TestRegisterPassiveObserved_RaceFreeWriteAndRead(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			reg.RegisterPassiveObserved(DeviceInfo{
+				Address: byte(0x10 + (i % 16)),
+			}, SlotRoleMaster, time.Now())
+		}
+		close(done)
+	}()
+	for i := 0; i < 200; i++ {
+		_, _ = reg.LookupSlot(byte(0x10 + (i % 16)))
+		_, _ = reg.Lookup(byte(0x10 + (i % 16)))
+	}
+	<-done
+}
+
+// TestMarkSlotPassiveObserved_StillStampsLabel proves the refactor
+// preserved MarkSlotPassiveObserved's existing behaviour — calls
+// against a pre-attached slot still mark PassiveObserved /
+// Corroborated. (Direct callers exist; the refactor must not break
+// them.)
+func TestMarkSlotPassiveObserved_StillStampsLabel(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.MarkSlotPassiveObserved(0x10, SlotRoleMaster, time.Now())
+
+	slot, ok := reg.LookupSlot(0x10)
+	if !ok {
+		t.Fatalf("LookupSlot(0x10) ok=%v", ok)
+	}
+	if slot.DiscoverySource != DiscoverySourcePassiveObserved {
+		t.Errorf("slot.DiscoverySource = %v; want PassiveObserved", slot.DiscoverySource)
+	}
+	if slot.VerificationState != VerificationStateCorroborated {
+		t.Errorf("slot.VerificationState = %v; want Corroborated", slot.VerificationState)
+	}
+}

--- a/registry/register_passive_observed_test.go
+++ b/registry/register_passive_observed_test.go
@@ -226,6 +226,26 @@ func TestRegisterPassiveObserved_IdentityMergePreservesPassiveLabels(t *testing.
 	if entry1.SerialNumber() != "SN-MERGE" || entry2.SerialNumber() != "SN-MERGE" {
 		t.Errorf("merged entries SerialNumber should be SN-MERGE; got %q / %q", entry1.SerialNumber(), entry2.SerialNumber())
 	}
+	// Codex P8 pass 2 NIT — assert SAME entry (alias), not just two
+	// entries with the same serial. The merged entry's Addresses()
+	// must contain both 0xF1 and 0xF6.
+	addrs1 := entry1.Addresses()
+	addrs2 := entry2.Addresses()
+	gotF1, gotF6 := false, false
+	for _, a := range addrs1 {
+		if a == 0xF1 {
+			gotF1 = true
+		}
+		if a == 0xF6 {
+			gotF6 = true
+		}
+	}
+	if !gotF1 || !gotF6 {
+		t.Errorf("entry1.Addresses() = %v; want both 0xF1 and 0xF6 (single merged entry)", addrs1)
+	}
+	if len(addrs1) != len(addrs2) {
+		t.Errorf("entry1.Addresses() len=%d != entry2.Addresses() len=%d (different entries — merge failed)", len(addrs1), len(addrs2))
+	}
 
 	// Both slots stay at passive_observed/corroborated — the identity
 	// merge must NOT silently promote either slot to active_confirmed.

--- a/registry/register_passive_observed_test.go
+++ b/registry/register_passive_observed_test.go
@@ -191,6 +191,58 @@ func TestRegisterPassiveObserved_RaceFreeWriteAndRead(t *testing.T) {
 	<-done
 }
 
+// TestRegisterPassiveObserved_IdentityMergePreservesPassiveLabels
+// covers Codex P8 review NIT FINDING_2: when two passively-observed
+// addresses share a stable identity (SerialNumber / MacAddress), the
+// underlying registerLocked merges them into a single device entry
+// with both addresses, AND both slots stay labelled at
+// PassiveObserved/Corroborated (NOT promoted to ActiveConfirmed).
+// Mirrors TestRegisterStaticSeed_PreservesAliasIdentity for the
+// passive-observed path.
+func TestRegisterPassiveObserved_IdentityMergePreservesPassiveLabels(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	now := time.Now()
+	reg.RegisterPassiveObserved(DeviceInfo{
+		Address:      0xF1,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+		SerialNumber: "SN-MERGE",
+	}, SlotRoleMaster, now)
+	reg.RegisterPassiveObserved(DeviceInfo{
+		Address:      0xF6,
+		Manufacturer: "Vaillant",
+		DeviceID:     "NETX3",
+		SerialNumber: "SN-MERGE",
+	}, SlotRoleSlave, now)
+
+	// Identity merge: both addresses must resolve to the same entry.
+	entry1, ok1 := reg.Lookup(0xF1)
+	entry2, ok2 := reg.Lookup(0xF6)
+	if !ok1 || !ok2 {
+		t.Fatalf("Lookup(0xF1)=%v Lookup(0xF6)=%v; both must resolve", ok1, ok2)
+	}
+	if entry1.SerialNumber() != "SN-MERGE" || entry2.SerialNumber() != "SN-MERGE" {
+		t.Errorf("merged entries SerialNumber should be SN-MERGE; got %q / %q", entry1.SerialNumber(), entry2.SerialNumber())
+	}
+
+	// Both slots stay at passive_observed/corroborated — the identity
+	// merge must NOT silently promote either slot to active_confirmed.
+	for _, addr := range []byte{0xF1, 0xF6} {
+		slot, ok := reg.LookupSlot(addr)
+		if !ok {
+			t.Fatalf("LookupSlot(0x%02X) ok=%v", addr, ok)
+		}
+		if slot.DiscoverySource != DiscoverySourcePassiveObserved {
+			t.Errorf("slot[0x%02X].DiscoverySource = %v; want PassiveObserved", addr, slot.DiscoverySource)
+		}
+		if slot.VerificationState != VerificationStateCorroborated {
+			t.Errorf("slot[0x%02X].VerificationState = %v; want Corroborated", addr, slot.VerificationState)
+		}
+	}
+}
+
 // TestMarkSlotPassiveObserved_StillStampsLabel proves the refactor
 // preserved MarkSlotPassiveObserved's existing behaviour — calls
 // against a pre-attached slot still mark PassiveObserved /

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -771,6 +771,16 @@ func (r *DeviceRegistry) ensureAddressSlotLocked(address byte) *AddressSlot {
 // DiscoverySource / VerificationState monotonically (the slot retains
 // the higher of the existing and new value, matching
 // observeAddressSlotLocked's monotonic semantics).
+//
+// SCOPE: this API only mutates the AddressSlot. It does NOT attach
+// the slot to a device entry. To plant a NEW passively-observed
+// address with identity attached AND label it correctly in a single
+// critical section, use RegisterPassiveObserved (which composes
+// registerLocked + this primitive). Calling Register followed by
+// MarkSlotPassiveObserved produces a label-misorder because Register
+// stamps DiscoverySourceActiveConfirmed and the monotonic guard then
+// refuses to downgrade — that was the P8 bug fixed in
+// RegisterPassiveObserved.
 func (r *DeviceRegistry) MarkSlotPassiveObserved(address byte, role SlotRole, observedAt time.Time) {
 	if r == nil {
 		return
@@ -779,6 +789,23 @@ func (r *DeviceRegistry) MarkSlotPassiveObserved(address byte, role SlotRole, ob
 	defer r.mu.Unlock()
 
 	slot := r.ensureAddressSlotLocked(address)
+	r.markSlotPassiveObservedLocked(slot, role, observedAt)
+	// Phase C M-C6a: refresh entry.Faces so AddressByRole sees the
+	// updated SlotRole. Without this sync, MarkSlotPassiveObserved
+	// would leave Faces stale and AddressByRole(SlotRoleSlave) on a
+	// just-passively-observed slot would return (0, false).
+	if slot.Device != nil {
+		r.syncEntryFacesLocked(slot.Device)
+	}
+}
+
+// markSlotPassiveObservedLocked is the shared slot-stamping primitive
+// used by both MarkSlotPassiveObserved and RegisterPassiveObserved.
+// Caller MUST hold r.mu and is responsible for any subsequent
+// syncEntryFacesLocked call. Centralising the stamping rules here
+// prevents drift between the two public entry points (mirrors the
+// markSlotStaticSeedLocked design from P3.5).
+func (r *DeviceRegistry) markSlotPassiveObservedLocked(slot *AddressSlot, role SlotRole, observedAt time.Time) {
 	if slot.DiscoverySource < DiscoverySourcePassiveObserved {
 		slot.DiscoverySource = DiscoverySourcePassiveObserved
 	}
@@ -794,13 +821,45 @@ func (r *DeviceRegistry) MarkSlotPassiveObserved(address byte, role SlotRole, ob
 	if !observedAt.IsZero() {
 		slot.LastObservedAt = observedAt
 	}
-	// Phase C M-C6a: refresh entry.Faces so AddressByRole sees the
-	// updated SlotRole. Without this sync, MarkSlotPassiveObserved
-	// would leave Faces stale and AddressByRole(SlotRoleSlave) on a
-	// just-passively-observed slot would return (0, false).
-	if slot.Device != nil {
-		r.syncEntryFacesLocked(slot.Device)
-	}
+}
+
+// RegisterPassiveObserved plants identity for an address newly observed
+// on the wire by the gateway's passive inserter. Mirrors Register's
+// identity-merge behaviour but stamps the AddressSlot with
+// DiscoverySourcePassiveObserved / VerificationStateCorroborated so
+// the observability surface (`/metrics`, MCP `bus.summary.get`,
+// address-table snapshots) correctly shows the slot's provenance as
+// passive observation rather than active confirmation.
+//
+// P8 fix: previously the gateway inserter called Register (which
+// stamps ActiveConfirmed/IdentityConfirmed) followed by
+// MarkSlotPassiveObserved. The monotonic ladder
+// (PassiveObserved < ActiveConfirmed) made the second call a no-op,
+// so passively-observed slots were misreported as `active_confirmed`.
+// RegisterPassiveObserved performs the identity-merge AND the
+// passive-label stamping atomically under a single lock acquisition,
+// avoiding the misorder.
+//
+// Subsequent label progression (after RegisterPassiveObserved):
+//   - An active confirmation (e.g. directed scan) DOES advance the
+//     DiscoverySource to ActiveConfirmed (PassiveObserved <
+//     ActiveConfirmed) AND VerificationState to IdentityConfirmed.
+//   - A static-seed mark on a passively-observed slot DOES advance
+//     DiscoverySource to StaticSeed (PassiveObserved < StaticSeed) —
+//     pre-known taxonomy outranks wire-only inference.
+//
+// Single lock acquisition — composes registerLocked, then the shared
+// passive-observation primitive, then syncEntryFacesLocked.
+func (r *DeviceRegistry) RegisterPassiveObserved(info DeviceInfo, role SlotRole, observedAt time.Time) DeviceEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry := r.registerLocked(info)
+	slot := r.ensureAddressSlotLocked(info.Address)
+	slot.Device = entry
+	r.markSlotPassiveObservedLocked(slot, role, observedAt)
+	r.syncEntryFacesLocked(entry)
+	return entry
 }
 
 func (r *DeviceRegistry) observeAddressSlotLocked(address byte, entry *deviceEntry, source DiscoverySource, state VerificationState) {


### PR DESCRIPTION
## Summary

- Gateway's address_table_inserter calls Register (stamps ActiveConfirmed/IdentityConfirmed) followed by MarkSlotPassiveObserved. The monotonic ladder makes the second call a no-op, so passively-observed slots are misreported as `active_confirmed`.
- Adds RegisterPassiveObserved that composes registerLocked + a new shared markSlotPassiveObservedLocked primitive in a single critical section. Stamps PassiveObserved/Corroborated correctly.
- MarkSlotPassiveObserved refactored to delegate to the shared primitive (mirrors P3.5's markSlotStaticSeedLocked drift-prevention design).

## Test plan

- [x] `go test -race -count=1 ./...` passes (full registry suite + 8 new RegisterPassiveObserved tests including identity-merge regression)
- [x] `./scripts/ci_local.sh` green
- [x] Tests cover: correct-label stamp, slot.Device attachment, no-downgrade on ActiveConfirmed, upgrade path (active scan + static seed after passive), race-free write+read, MarkSlotPassiveObserved refactor preserves public contract, **identity-merge preserves passive labels** (Codex P8 review NIT FINDING_2 addition)

## Doc-gate waiver (Codex P8 review MINOR FINDING_1)

This PR adds a new exported `(*DeviceRegistry).RegisterPassiveObserved` API but is explicitly **doc-gate-waived** for the same reasons as P3.5 (PR #137):

- **No protocol change**: no new opcode, no wire-format change, no new register, no new MCP/GraphQL enum or label.
- **No architecture change**: same identity-merge body (`registerLocked`) shared with `Register`/`RegisterStaticSeed`; same monotonic ladder semantics; same lock contract.
- **No semantic change at the observability surface**: the `discovery_source` enum value (`"passive_observed"`) and `verification` enum value (`"corroborated"`) were already documented and surfaced via `address_table.go:158-164`. We're fixing a misorder of API calls in the gateway that produced the wrong enum value; the enum surface is unchanged.

The new API is purely a fix-shape primitive. P3.5 set the precedent: the static-seed equivalent (`RegisterStaticSeed`) shipped without a docs-companion under the same reasoning.

## Sequencing

Gateway-side switch (`Register + MarkSlotPassiveObserved → RegisterPassiveObserved`) lands in a separate helianthus-ebusgateway PR after this merges (with a go.mod bump first commit for clean bisect). Codex P8 NIT FINDING_3 (whether to also drop the post-register `LookupSlot` for the cached `RegistrySlot` field) is addressed at that PR — current plan keeps the lookup since the field is benign and not an internal correctness concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)