### PR TITLE
P9 — DeviceEntrySnapshot value-typed entry-identity API (race-free)

### DIFF
--- a/registry/lookup_entry_snapshot_test.go
+++ b/registry/lookup_entry_snapshot_test.go
@@ -275,12 +275,12 @@ func TestDeviceEntrySnapshot_AddressByRole_FacesPath(t *testing.T) {
 		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
 	}
 
-	masterAddr, masterOK := snap.AddressByRole(SlotRoleMaster)
-	if !masterOK {
-		t.Errorf("AddressByRole(SlotRoleMaster) ok=false; want true (entry has 0x10 master face)")
+	initiatorAddr, initiatorOK := snap.AddressByRole(SlotRoleMaster)
+	if !initiatorOK {
+		t.Errorf("AddressByRole(SlotRoleMaster) ok=false; want true (entry has 0x10 initiator-class face)")
 	}
-	if masterAddr != 0x10 {
-		t.Errorf("master address = 0x%02X; want 0x10", masterAddr)
+	if initiatorAddr != 0x10 {
+		t.Errorf("initiator address = 0x%02X; want 0x10", initiatorAddr)
 	}
 }
 

--- a/registry/lookup_entry_snapshot_test.go
+++ b/registry/lookup_entry_snapshot_test.go
@@ -1,0 +1,310 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// P9 — DeviceEntrySnapshot value-typed entry-identity snapshot API.
+//
+// Pre-P9 the DeviceEntry interface methods (Manufacturer, DeviceID,
+// etc.) read d.info.<Field> lock-free. Concurrent Register replaces
+// entry.info; readers can observe a torn read of string fields
+// (string is ptr+len). LookupEntrySnapshot copies all observable
+// identity fields under r.mu.RLock — race-free.
+
+// TestLookupEntrySnapshot_ReturnsCurrentIdentity asserts the snapshot
+// reflects the registered entry's current identity fields.
+func TestLookupEntrySnapshot_ReturnsCurrentIdentity(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{
+		Address:         0x10,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SerialNumber:    "SN-X",
+		MacAddress:      "AA:BB:CC",
+		SoftwareVersion: "1.2",
+		HardwareVersion: "3.4",
+	})
+
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+	if snap.Manufacturer != "Vaillant" {
+		t.Errorf("Manufacturer = %q; want Vaillant", snap.Manufacturer)
+	}
+	if snap.DeviceID != "BASV2" {
+		t.Errorf("DeviceID = %q; want BASV2", snap.DeviceID)
+	}
+	if snap.SerialNumber != "SN-X" {
+		t.Errorf("SerialNumber = %q; want SN-X", snap.SerialNumber)
+	}
+	if snap.MacAddress != "AA:BB:CC" {
+		t.Errorf("MacAddress = %q; want AA:BB:CC", snap.MacAddress)
+	}
+	if snap.SoftwareVersion != "1.2" {
+		t.Errorf("SoftwareVersion = %q; want 1.2", snap.SoftwareVersion)
+	}
+	if snap.HardwareVersion != "3.4" {
+		t.Errorf("HardwareVersion = %q; want 3.4", snap.HardwareVersion)
+	}
+	if snap.PrimaryAddress != 0x10 {
+		t.Errorf("PrimaryAddress = 0x%02X; want 0x10", snap.PrimaryAddress)
+	}
+	if len(snap.Addresses) != 1 || snap.Addresses[0] != 0x10 {
+		t.Errorf("Addresses = %v; want [0x10]", snap.Addresses)
+	}
+}
+
+// TestLookupEntrySnapshot_AbsentEntryReturnsZero verifies the false
+// return for an address with no entry.
+func TestLookupEntrySnapshot_AbsentEntryReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	snap, ok := reg.LookupEntrySnapshot(0x42)
+	if ok {
+		t.Errorf("ok=true; want false (no entry)")
+	}
+	if snap.Manufacturer != "" || snap.PrimaryAddress != 0 {
+		t.Errorf("snap = %+v; want zero", snap)
+	}
+}
+
+// TestLookupEntrySnapshot_ReflectsLaterUpdate verifies the snapshot is
+// taken at call time — a Register-level identity update visible to a
+// later snapshot call.
+func TestLookupEntrySnapshot_ReflectsLaterUpdate(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Initial"})
+
+	pre, _ := reg.LookupEntrySnapshot(0x10)
+	if pre.Manufacturer != "Initial" {
+		t.Fatalf("pre.Manufacturer = %q; want Initial", pre.Manufacturer)
+	}
+
+	reg.Register(DeviceInfo{
+		Address:      0x10,
+		Manufacturer: "Updated",
+		DeviceID:     "DEV",
+		SerialNumber: "SN-Y",
+	})
+
+	post, _ := reg.LookupEntrySnapshot(0x10)
+	if post.Manufacturer != "Updated" {
+		t.Errorf("post.Manufacturer = %q; want Updated", post.Manufacturer)
+	}
+	if post.DeviceID != "DEV" {
+		t.Errorf("post.DeviceID = %q; want DEV", post.DeviceID)
+	}
+}
+
+// TestLookupEntrySnapshot_SliceCopyIsolatedFromRegistry verifies the
+// snapshot's Addresses slice is a copy — mutating it must NOT affect
+// registry state. Uses AliasAddresses to plant a multi-address
+// entry deterministically.
+func TestLookupEntrySnapshot_SliceCopyIsolatedFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x10, SerialNumber: "SN-X"})
+	reg.Register(DeviceInfo{Address: 0x15, SerialNumber: "SN-Y"})
+	if err := reg.AliasAddresses(0x10, 0x15); err != nil {
+		t.Fatalf("AliasAddresses(0x10, 0x15) error = %v", err)
+	}
+
+	snap, _ := reg.LookupEntrySnapshot(0x10)
+	if len(snap.Addresses) < 2 {
+		t.Fatalf("Addresses = %v; want both 0x10 and 0x15 (alias-merge)", snap.Addresses)
+	}
+
+	// Record the original byte at index 0 so we can prove the registry
+	// didn't change after mutating the snapshot's slice.
+	preMutationAddr0 := snap.Addresses[0]
+
+	// Mutate the snapshot's slice.
+	snap.Addresses[0] = 0xFF
+
+	// Re-fetch the snapshot from the registry — it must still have
+	// the original addresses.
+	snap2, _ := reg.LookupEntrySnapshot(0x10)
+	if len(snap2.Addresses) == 0 || snap2.Addresses[0] != preMutationAddr0 {
+		t.Errorf("snap2.Addresses[0] = 0x%02X; want 0x%02X (mutation leaked through to registry storage)", snap2.Addresses[0], preMutationAddr0)
+	}
+	for _, a := range snap2.Addresses {
+		if a == 0xFF {
+			t.Errorf("snap2.Addresses contains 0xFF; mutation leaked through")
+		}
+	}
+}
+
+// TestIterateSnapshots_VisitsAllEntries asserts the snapshot iteration
+// visits every registered entry.
+func TestIterateSnapshots_VisitsAllEntries(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "M1"})
+	reg.Register(DeviceInfo{Address: 0x26, Manufacturer: "M2"})
+
+	visited := make(map[byte]string)
+	reg.IterateSnapshots(func(snap DeviceEntrySnapshot) bool {
+		visited[snap.PrimaryAddress] = snap.Manufacturer
+		return true
+	})
+
+	if len(visited) != 2 {
+		t.Errorf("visited %d entries; want 2 (got %v)", len(visited), visited)
+	}
+	if visited[0x10] != "M1" {
+		t.Errorf("visited[0x10] = %q; want M1", visited[0x10])
+	}
+	if visited[0x26] != "M2" {
+		t.Errorf("visited[0x26] = %q; want M2", visited[0x26])
+	}
+}
+
+// TestIterateSnapshots_StopOnFalse verifies the early-stop semantic.
+func TestIterateSnapshots_StopOnFalse(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x10})
+	reg.Register(DeviceInfo{Address: 0x20})
+	reg.Register(DeviceInfo{Address: 0x30})
+
+	count := 0
+	reg.IterateSnapshots(func(snap DeviceEntrySnapshot) bool {
+		count++
+		return false // stop after first
+	})
+	if count != 1 {
+		t.Errorf("callback invocations = %d; want 1 (early stop)", count)
+	}
+}
+
+// TestDeviceEntrySnapshot_AddressByRole_FacesPath verifies the
+// snapshot's AddressByRole resolves via the Faces slice (mirrors the
+// live deviceEntry.AddressByRole behaviour).
+func TestDeviceEntrySnapshot_AddressByRole_FacesPath(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	now := time.Now()
+	reg.RegisterPassiveObserved(DeviceInfo{Address: 0x10}, SlotRoleMaster, now)
+	reg.RegisterPassiveObserved(DeviceInfo{Address: 0x15, SerialNumber: "SN-X"}, SlotRoleSlave, now)
+	reg.Register(DeviceInfo{Address: 0x10, SerialNumber: "SN-X"})
+
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+
+	masterAddr, masterOK := snap.AddressByRole(SlotRoleMaster)
+	if !masterOK {
+		t.Errorf("AddressByRole(SlotRoleMaster) ok=false; want true (entry has 0x10 master face)")
+	}
+	if masterAddr != 0x10 {
+		t.Errorf("master address = 0x%02X; want 0x10", masterAddr)
+	}
+}
+
+// TestLookupEntrySnapshot_RaceFreeUnderConcurrentRegisters is the
+// central P9 contract: the snapshot's identity fields are stable for
+// the caller's lifetime regardless of concurrent Register calls.
+//
+// Methodology: a writer goroutine repeatedly Register(s) the same
+// address with rotating Manufacturer / DeviceID strings. The reader
+// snapshots and reads the local copy's fields. Race detector flags
+// any unsynced access via the snapshot path.
+//
+// Pre-P9 a reader doing entry.Manufacturer() on a live *deviceEntry
+// pointer would race with the writer's `entry.info = storedInfo` —
+// the race detector would trip. The snapshot copy under RLock
+// eliminates that surface.
+func TestLookupEntrySnapshot_RaceFreeUnderConcurrentRegisters(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	addr := byte(0x10)
+	reg.Register(DeviceInfo{Address: addr, Manufacturer: "Initial"})
+
+	stop := make(chan struct{})
+	var writes uint64
+	var writerWg sync.WaitGroup
+	var readerWg sync.WaitGroup
+
+	writerWg.Add(1)
+	go func() {
+		defer writerWg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			reg.Register(DeviceInfo{
+				Address:      addr,
+				Manufacturer: "Manufacturer-" + string(rune('A'+(i%26))),
+				DeviceID:     "Device-" + string(rune('A'+(i%26))),
+				SerialNumber: "Serial-" + string(rune('A'+(i%26))),
+			})
+			atomic.AddUint64(&writes, 1)
+			i++
+		}
+	}()
+
+	// Start barrier — wait for at least one Register before reads.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadUint64(&writes) == 0 {
+		if time.Now().After(deadline) {
+			close(stop)
+			writerWg.Wait()
+			t.Fatal("writer made no Register calls within 2s")
+		}
+		time.Sleep(time.Microsecond)
+	}
+
+	startWrites := atomic.LoadUint64(&writes)
+
+	// 4 readers using LookupEntrySnapshot.
+	const numReaders = 4
+	for r := 0; r < numReaders; r++ {
+		readerWg.Add(1)
+		go func() {
+			defer readerWg.Done()
+			for j := 0; j < 1000; j++ {
+				snap, ok := reg.LookupEntrySnapshot(addr)
+				if !ok {
+					continue
+				}
+				_ = snap.Manufacturer
+				_ = snap.DeviceID
+				_ = snap.SerialNumber
+				_ = snap.PrimaryAddress
+				_ = snap.Addresses
+				_ = snap.Faces
+			}
+		}()
+	}
+
+	// Wait for readers FIRST so the writer keeps producing Registers
+	// throughout the reader phase.
+	readerWg.Wait()
+	endWrites := atomic.LoadUint64(&writes)
+
+	close(stop)
+	writerWg.Wait()
+
+	if endWrites-startWrites < 1 {
+		t.Errorf("writer Register count advanced by 0 during reader phase; want >= 1 (overlap not exercised)")
+	}
+}

--- a/registry/lookup_entry_snapshot_test.go
+++ b/registry/lookup_entry_snapshot_test.go
@@ -171,6 +171,74 @@ func TestIterateSnapshots_VisitsAllEntries(t *testing.T) {
 	}
 }
 
+// TestLookupEntrySnapshot_FacesAccessProtocolsDeepCopied verifies
+// that BusFace.AccessProtocols is deep-copied (Codex P9 pass 1
+// MINOR FINDING_1). Mutating snap.Faces[i].AccessProtocols must
+// NOT leak through to registry storage. The existing
+// syncEntryFacesLocked path doesn't currently populate
+// AccessProtocols, so this test injects a face directly via the
+// internal entry to exercise the deep-copy.
+func TestLookupEntrySnapshot_FacesAccessProtocolsDeepCopied(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x10, SerialNumber: "SN-X"})
+
+	// Inject AccessProtocols directly under the registry's lock so
+	// we can verify the snapshot deep-copies the slice.
+	reg.mu.Lock()
+	entry := reg.entries[0x10]
+	if len(entry.Faces) == 0 {
+		entry.Faces = []BusFace{{Addr: 0x10, Role: SlotRoleMaster}}
+	}
+	entry.Faces[0].AccessProtocols = []string{"raw-write", "raw-read"}
+	reg.mu.Unlock()
+
+	snap, _ := reg.LookupEntrySnapshot(0x10)
+	if len(snap.Faces) == 0 || len(snap.Faces[0].AccessProtocols) != 2 {
+		t.Fatalf("snap.Faces[0].AccessProtocols = %v; want [raw-write raw-read]", snap.Faces)
+	}
+
+	// Mutate the snapshot's nested slice.
+	snap.Faces[0].AccessProtocols[0] = "MUTATED"
+
+	// Re-fetch — the registry must still have the original strings.
+	snap2, _ := reg.LookupEntrySnapshot(0x10)
+	if snap2.Faces[0].AccessProtocols[0] != "raw-write" {
+		t.Errorf("snap2.Faces[0].AccessProtocols[0] = %q; want raw-write (mutation leaked through)", snap2.Faces[0].AccessProtocols[0])
+	}
+}
+
+// TestIterateSnapshots_CallbackCanCallRegistry verifies the
+// IterateSnapshots callback runs OUTSIDE the registry lock — Codex
+// P9 pass 1 MINOR FINDING_2 fix. Calling LookupEntrySnapshot from
+// within the callback would deadlock if the lock were still held.
+func TestIterateSnapshots_CallbackCanCallRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "M1"})
+	reg.Register(DeviceInfo{Address: 0x20, Manufacturer: "M2"})
+
+	calls := 0
+	reg.IterateSnapshots(func(snap DeviceEntrySnapshot) bool {
+		calls++
+		// Re-entrant call into the registry — this would deadlock
+		// if IterateSnapshots held r.mu during the callback.
+		nestedSnap, ok := reg.LookupEntrySnapshot(snap.PrimaryAddress)
+		if !ok {
+			t.Errorf("nested LookupEntrySnapshot(0x%02X) ok=false", snap.PrimaryAddress)
+		}
+		if nestedSnap.Manufacturer != snap.Manufacturer {
+			t.Errorf("nested.Manufacturer = %q; want %q", nestedSnap.Manufacturer, snap.Manufacturer)
+		}
+		return true
+	})
+	if calls != 2 {
+		t.Errorf("callback invocations = %d; want 2", calls)
+	}
+}
+
 // TestIterateSnapshots_StopOnFalse verifies the early-stop semantic.
 func TestIterateSnapshots_StopOnFalse(t *testing.T) {
 	t.Parallel()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1085,6 +1085,150 @@ func (d *deviceEntry) Projections() []Projection {
 	return d.projections
 }
 
+// DeviceEntrySnapshot is a value-typed copy of a DeviceEntry's
+// observable identity fields. Snapshots are taken under r.mu.RLock
+// so callers can read the fields without holding any registry lock
+// and without risking torn reads from concurrent writers
+// (Register / RegisterStaticSeed / RegisterPassiveObserved /
+// AliasAddresses / detachAddressLocked).
+//
+// P9 — addresses Codex post-P8.3 audit: the DeviceEntry interface
+// methods (Manufacturer / DeviceID / SerialNumber / etc.) read
+// `d.info.<Field>` lock-free. Concurrent Register replaces
+// `entry.info` with a new DeviceInfo struct (line 240
+// `entry.info = storedInfo`); a reader holding the *deviceEntry
+// pointer can observe a torn read of the string fields
+// (string is a 16-byte ptr+len header).
+//
+// DeviceEntrySnapshot copies all string and slice fields under
+// RLock; the snapshot is disconnected from registry storage and
+// safe to read concurrently. Slice copies (Addresses, Faces) prevent
+// callers from mutating registry state through the snapshot.
+//
+// SCOPE: Planes and Projections are intentionally omitted because
+// they're complex interface trees whose elements can transitively
+// expose registry-mutable state. Callers that need plane/projection
+// data should use Lookup (live-pointer API) and accept the lock-free
+// read tradeoff for those specific fields, OR a future
+// Plane/Projection-aware snapshot can be added.
+type DeviceEntrySnapshot struct {
+	PrimaryAddress  byte
+	Addresses       []byte
+	Faces           []BusFace
+	Manufacturer    string
+	DeviceID        string
+	SerialNumber    string
+	MacAddress      string
+	SoftwareVersion string
+	HardwareVersion string
+}
+
+// PrimaryDisplayAddress mirrors deviceEntry.PrimaryDisplayAddress for
+// callers that work with the value-typed snapshot.
+func (s DeviceEntrySnapshot) PrimaryDisplayAddress() byte {
+	return s.PrimaryAddress
+}
+
+// AddressByRole mirrors deviceEntry.AddressByRole using the snapshot's
+// Faces slice. Returns (0, false) when no face matches the requested
+// role (after the same role-class fallback rules used by the live
+// implementation).
+func (s DeviceEntrySnapshot) AddressByRole(role SlotRole) (byte, bool) {
+	for _, face := range s.Faces {
+		if face.Role == role {
+			return face.Addr, true
+		}
+	}
+	for _, face := range s.Faces {
+		if face.Role != SlotRoleUnknown {
+			continue
+		}
+		switch protocol.AddressClassOf(face.Addr) {
+		case protocol.AddressClassMaster:
+			if role == SlotRoleMaster {
+				return face.Addr, true
+			}
+		case protocol.AddressClassSlave:
+			if role == SlotRoleSlave {
+				return face.Addr, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// LookupEntrySnapshot returns a value-typed snapshot of the
+// DeviceEntry registered for addr, taken under r.mu.RLock. The
+// race-free counterpart to Lookup for callers that only need the
+// entry's observable identity fields (gateway MCP / GraphQL /
+// observability projections). Returns (zero, false) when no entry
+// exists for the address.
+//
+// P9 — Lookup remains for callers that need the live entry pointer
+// (e.g. registry-internal mutation paths or callers that need
+// Planes/Projections).
+func (r *DeviceRegistry) LookupEntrySnapshot(address byte) (DeviceEntrySnapshot, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry := r.entries[address]
+	if entry == nil {
+		return DeviceEntrySnapshot{}, false
+	}
+	return r.snapshotEntryLocked(entry), true
+}
+
+// IterateSnapshots visits each registered device entry as a
+// value-typed snapshot. The snapshot for each entry is taken under
+// r.mu.RLock and the callback is invoked with the lock STILL HELD —
+// callers can append the snapshot to a slice for later use, but
+// MUST NOT call any DeviceRegistry method from within the callback
+// (would deadlock on r.mu).
+//
+// Lock-held callbacks match the existing Iterate API contract; the
+// only difference is the value-typed snapshot vs the live pointer.
+//
+// P9 — Iterate remains for callers that need live entry pointers.
+// New consumers SHOULD prefer IterateSnapshots.
+func (r *DeviceRegistry) IterateSnapshots(fn func(DeviceEntrySnapshot) bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, entry := range r.order {
+		if entry == nil {
+			continue
+		}
+		snap := r.snapshotEntryLocked(entry)
+		if !fn(snap) {
+			return
+		}
+	}
+}
+
+// snapshotEntryLocked builds a DeviceEntrySnapshot from a live
+// *deviceEntry. Caller MUST hold r.mu.RLock or r.mu.Lock.
+func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnapshot {
+	addresses := make([]byte, len(entry.addresses))
+	copy(addresses, entry.addresses)
+	faces := make([]BusFace, len(entry.Faces))
+	copy(faces, entry.Faces)
+	primary := entry.primaryAddress
+	if primary == 0 {
+		primary = entry.info.Address
+	}
+	return DeviceEntrySnapshot{
+		PrimaryAddress:  primary,
+		Addresses:       addresses,
+		Faces:           faces,
+		Manufacturer:    entry.info.Manufacturer,
+		DeviceID:        entry.info.DeviceID,
+		SerialNumber:    entry.info.SerialNumber,
+		MacAddress:      entry.info.MacAddress,
+		SoftwareVersion: entry.info.SoftwareVersion,
+		HardwareVersion: entry.info.HardwareVersion,
+	}
+}
+
 func CanonicalIndexForEntry(entry DeviceEntry) (CanonicalIndex, error) {
 	if entry == nil {
 		return CanonicalIndex{}, ErrProjectionInvalidNode

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1179,26 +1179,31 @@ func (r *DeviceRegistry) LookupEntrySnapshot(address byte) (DeviceEntrySnapshot,
 }
 
 // IterateSnapshots visits each registered device entry as a
-// value-typed snapshot. The snapshot for each entry is taken under
-// r.mu.RLock and the callback is invoked with the lock STILL HELD —
-// callers can append the snapshot to a slice for later use, but
-// MUST NOT call any DeviceRegistry method from within the callback
-// (would deadlock on r.mu).
+// value-typed snapshot. Snapshots are built under r.mu.RLock; the
+// lock is released BEFORE the callback runs. Callers can therefore
+// safely call any DeviceRegistry method from within the callback
+// (no deadlock risk).
 //
-// Lock-held callbacks match the existing Iterate API contract; the
-// only difference is the value-typed snapshot vs the live pointer.
+// This matches the existing Iterate API's lock-then-snapshot-then-
+// unlock contract. The only behavioural difference vs Iterate is
+// the value-typed snapshot vs live entry pointer (Codex P9 review
+// pass 1 MINOR FINDING_2).
 //
-// P9 — Iterate remains for callers that need live entry pointers.
-// New consumers SHOULD prefer IterateSnapshots.
+// P9 — Iterate remains for callers that need live entry pointers
+// (or Planes / Projections, which the snapshot intentionally
+// omits). New consumers SHOULD prefer IterateSnapshots.
 func (r *DeviceRegistry) IterateSnapshots(fn func(DeviceEntrySnapshot) bool) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-
+	snapshots := make([]DeviceEntrySnapshot, 0, len(r.order))
 	for _, entry := range r.order {
 		if entry == nil {
 			continue
 		}
-		snap := r.snapshotEntryLocked(entry)
+		snapshots = append(snapshots, r.snapshotEntryLocked(entry))
+	}
+	r.mu.RUnlock()
+
+	for _, snap := range snapshots {
 		if !fn(snap) {
 			return
 		}
@@ -1207,11 +1212,24 @@ func (r *DeviceRegistry) IterateSnapshots(fn func(DeviceEntrySnapshot) bool) {
 
 // snapshotEntryLocked builds a DeviceEntrySnapshot from a live
 // *deviceEntry. Caller MUST hold r.mu.RLock or r.mu.Lock.
+//
+// Each BusFace is deep-copied: the AccessProtocols slice is
+// copied per face, not aliased (Codex P9 review pass 1 MINOR
+// FINDING_1). This guarantees the snapshot is fully disconnected
+// from registry storage — consumer mutations of any nested slice
+// do NOT leak through.
 func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnapshot {
 	addresses := make([]byte, len(entry.addresses))
 	copy(addresses, entry.addresses)
 	faces := make([]BusFace, len(entry.Faces))
-	copy(faces, entry.Faces)
+	for i, src := range entry.Faces {
+		face := src
+		if len(src.AccessProtocols) > 0 {
+			face.AccessProtocols = make([]string, len(src.AccessProtocols))
+			copy(face.AccessProtocols, src.AccessProtocols)
+		}
+		faces[i] = face
+	}
 	primary := entry.primaryAddress
 	if primary == 0 {
 		primary = entry.info.Address


### PR DESCRIPTION
## Summary

Addresses the #2 remaining race surface from Codex post-P8.3 consult: \`DeviceEntry\` interface methods read \`d.info.<Field>\` lock-free, racing with \`Register\`'s in-place \`entry.info = storedInfo\` mutation. String fields (16-byte ptr+len) can tear under concurrent access.

Adds:
- \`DeviceEntrySnapshot\` value type (PrimaryAddress, Addresses, Faces, Manufacturer, DeviceID, SerialNumber, MacAddress, SoftwareVersion, HardwareVersion)
- \`AddressByRole\` / \`PrimaryDisplayAddress\` methods on the snapshot
- \`LookupEntrySnapshot\` and \`IterateSnapshots\` accessors taken under \`r.mu.RLock\`

\`Lookup\` and \`Iterate\` (live-pointer APIs) retained — no public-API breakage.

## Test plan

- [x] \`go test -race -count=5 ./registry\` passes
- [x] 8 tests cover: current-identity, absent entry, later update, slice-copy isolation, IterateSnapshots visit + early-stop, AddressByRole faces path, race-free under concurrent Registers (race detector authoritative)
- [x] \`./scripts/ci_local.sh\` green

## Doc-gate waiver

Additive API (mirrors \`LookupSlotSnapshot\` from PR #139). No protocol / architecture / semantic surface change. Same precedent as P3.5 / P8 / P8.1.

## Sequencing

Gateway migration of MCP / GraphQL / observability call sites lands in a separate helianthus-ebusgateway PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)