### PR TITLE
P9.x: DeviceEntrySnapshot Planes+Projections (graphql.BuildSchema race)

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1251,6 +1251,47 @@ func deepCopyProjectionPathLocked(src ProjectionPath) ProjectionPath {
 	return out
 }
 
+// snapshotPlane wraps a registry-owned Plane so that Methods() returns
+// a snapshot-owned copy of the underlying methods slice. Without this
+// wrapper, the vaillant providers' plane.Methods() returns
+// plane.methods directly — a snapshot caller could write to the
+// returned slice and corrupt the live registry plane (Codex P9.x
+// review pass 2 GitHub-bot finding). The snapshot wrapper preserves
+// the Plane interface contract while shielding registry storage.
+//
+// The Method interface values in `methods` are shared with the
+// registry; vaillant Method implementations are immutable struct
+// values (verified in vaillant/system/system.go and analogous
+// providers), so sharing them is safe. Only the SLICE itself needs
+// to be snapshot-owned to prevent index-write corruption.
+type snapshotPlane struct {
+	name    string
+	methods []Method
+}
+
+// Name returns the wrapped plane's name, captured at snapshot time.
+func (p *snapshotPlane) Name() string { return p.name }
+
+// Methods returns a fresh copy of the snapshot-owned method slice on
+// every call. Callers therefore cannot mutate the slice another caller
+// holds (or the registry's underlying slice).
+func (p *snapshotPlane) Methods() []Method {
+	out := make([]Method, len(p.methods))
+	copy(out, p.methods)
+	return out
+}
+
+// snapshotPlaneFromLocked builds a snapshotPlane from a registry-owned
+// Plane. Caller MUST hold r.mu (read or write) so the underlying
+// plane's Methods() result is captured atomically with the rest of the
+// snapshot.
+func snapshotPlaneFromLocked(p Plane) *snapshotPlane {
+	src := p.Methods()
+	methods := make([]Method, len(src))
+	copy(methods, src)
+	return &snapshotPlane{name: p.Name(), methods: methods}
+}
+
 func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnapshot {
 	addresses := make([]byte, len(entry.addresses))
 	copy(addresses, entry.addresses)
@@ -1278,7 +1319,9 @@ func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnap
 	var planes []Plane
 	if len(entry.planes) > 0 {
 		planes = make([]Plane, len(entry.planes))
-		copy(planes, entry.planes)
+		for i, src := range entry.planes {
+			planes[i] = snapshotPlaneFromLocked(src)
+		}
 	}
 	var projections []Projection
 	if len(entry.projections) > 0 {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1237,6 +1237,20 @@ func (r *DeviceRegistry) IterateSnapshots(fn func(DeviceEntrySnapshot) bool) {
 // FINDING_1). This guarantees the snapshot is fully disconnected
 // from registry storage — consumer mutations of any nested slice
 // do NOT leak through.
+// deepCopyProjectionPathLocked returns a copy of `src` whose Segments
+// slice header points to a fresh backing array. Caller does NOT need
+// to hold any registry lock — operates on local copies only — but
+// snapshot construction holds RLock to ensure atomicity with the rest
+// of the snapshot. P9.x.
+func deepCopyProjectionPathLocked(src ProjectionPath) ProjectionPath {
+	out := ProjectionPath{Plane: src.Plane}
+	if len(src.Segments) > 0 {
+		out.Segments = make([]PathSegment, len(src.Segments))
+		copy(out.Segments, src.Segments)
+	}
+	return out
+}
+
 func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnapshot {
 	addresses := make([]byte, len(entry.addresses))
 	copy(addresses, entry.addresses)
@@ -1253,11 +1267,14 @@ func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnap
 	if primary == 0 {
 		primary = entry.info.Address
 	}
-	// P9.x — capture Planes + Projections slice headers under RLock.
-	// The interface elements are immutable after PlaneProvider.CreatePlanes /
-	// ProjectionProvider.CreateProjections; copying the slice header is
-	// sufficient to defend against a concurrent mergeEntries reassignment
-	// of entry.planes / entry.projections.
+	// P9.x — capture Planes + Projections under RLock. The Plane
+	// interface implementations are immutable after CreatePlanes
+	// returns (vaillant providers verified), so copying the slice
+	// header is sufficient there. Projections are concrete structs
+	// (Plane string, Nodes []Node, Edges []Edge) where each Node has
+	// a ProjectionPath.Segments []PathSegment slice; deep-copy those
+	// nested slices so callers cannot mutate registry-visible state
+	// through the snapshot (Codex P9.x review pass 1).
 	var planes []Plane
 	if len(entry.planes) > 0 {
 		planes = make([]Plane, len(entry.planes))
@@ -1266,7 +1283,24 @@ func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnap
 	var projections []Projection
 	if len(entry.projections) > 0 {
 		projections = make([]Projection, len(entry.projections))
-		copy(projections, entry.projections)
+		for i, src := range entry.projections {
+			proj := Projection{Plane: src.Plane}
+			if len(src.Nodes) > 0 {
+				proj.Nodes = make([]Node, len(src.Nodes))
+				for j, srcNode := range src.Nodes {
+					proj.Nodes[j] = Node{
+						ID:            srcNode.ID,
+						Path:          deepCopyProjectionPathLocked(srcNode.Path),
+						CanonicalPath: deepCopyProjectionPathLocked(srcNode.CanonicalPath),
+					}
+				}
+			}
+			if len(src.Edges) > 0 {
+				proj.Edges = make([]Edge, len(src.Edges))
+				copy(proj.Edges, src.Edges) // Edge has only string-typed fields
+			}
+			projections[i] = proj
+		}
 	}
 	return DeviceEntrySnapshot{
 		PrimaryAddress:  primary,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1105,12 +1105,25 @@ func (d *deviceEntry) Projections() []Projection {
 // safe to read concurrently. Slice copies (Addresses, Faces) prevent
 // callers from mutating registry state through the snapshot.
 //
-// SCOPE: Planes and Projections are intentionally omitted because
-// they're complex interface trees whose elements can transitively
-// expose registry-mutable state. Callers that need plane/projection
-// data should use Lookup (live-pointer API) and accept the lock-free
-// read tradeoff for those specific fields, OR a future
-// Plane/Projection-aware snapshot can be added.
+// SCOPE (P9.x): Planes and Projections were originally omitted on the
+// theory that their interface trees transitively exposed registry-
+// mutable state. In practice the *plane and *method implementations
+// (vaillant providers + similar) are constructed once in
+// PlaneProvider.CreatePlanes / ProjectionProvider.CreateProjections
+// and never mutated afterward; the only registry-side write to the
+// `entry.planes` / `entry.projections` slice headers happens during
+// the identity-merge path (mergeEntries dst.planes = src.planes /
+// dst.projections = src.projections). Capturing those slice headers
+// under RLock therefore produces a stable view: readers iterating
+// the snapshot's Planes / Projections see element references that
+// remain valid for the lifetime of the snapshot, with no risk of a
+// mid-iteration slice reassignment.
+//
+// P9.x adds Planes + Projections to DeviceEntrySnapshot so the
+// graphql.BuildSchema hot path can drop its live-pointer Iterate
+// usage. Callers that mutate the registry (registerLocked path) must
+// continue to use the live `*deviceEntry` pointer; the snapshot is
+// READ-ONLY by construction.
 type DeviceEntrySnapshot struct {
 	PrimaryAddress  byte
 	Addresses       []byte
@@ -1121,6 +1134,12 @@ type DeviceEntrySnapshot struct {
 	MacAddress      string
 	SoftwareVersion string
 	HardwareVersion string
+	// Planes + Projections — slice headers captured under RLock at
+	// snapshot time. The interface elements (Plane, Method, etc.) are
+	// immutable after PlaneProvider.CreatePlanes returns; safe to
+	// read after the lock has been released.
+	Planes      []Plane
+	Projections []Projection
 }
 
 // PrimaryDisplayAddress mirrors deviceEntry.PrimaryDisplayAddress for
@@ -1234,6 +1253,21 @@ func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnap
 	if primary == 0 {
 		primary = entry.info.Address
 	}
+	// P9.x — capture Planes + Projections slice headers under RLock.
+	// The interface elements are immutable after PlaneProvider.CreatePlanes /
+	// ProjectionProvider.CreateProjections; copying the slice header is
+	// sufficient to defend against a concurrent mergeEntries reassignment
+	// of entry.planes / entry.projections.
+	var planes []Plane
+	if len(entry.planes) > 0 {
+		planes = make([]Plane, len(entry.planes))
+		copy(planes, entry.planes)
+	}
+	var projections []Projection
+	if len(entry.projections) > 0 {
+		projections = make([]Projection, len(entry.projections))
+		copy(projections, entry.projections)
+	}
 	return DeviceEntrySnapshot{
 		PrimaryAddress:  primary,
 		Addresses:       addresses,
@@ -1244,6 +1278,8 @@ func (r *DeviceRegistry) snapshotEntryLocked(entry *deviceEntry) DeviceEntrySnap
 		MacAddress:      entry.info.MacAddress,
 		SoftwareVersion: entry.info.SoftwareVersion,
 		HardwareVersion: entry.info.HardwareVersion,
+		Planes:          planes,
+		Projections:     projections,
 	}
 }
 

--- a/registry/snapshot_planes_p9x_test.go
+++ b/registry/snapshot_planes_p9x_test.go
@@ -119,6 +119,38 @@ func TestIterateSnapshots_PlanesRaceFree(t *testing.T) {
 	}
 }
 
+// TestDeviceEntrySnapshot_ProjectionsDeepCopied verifies that mutating
+// the snapshot's nested Projection.Nodes[i].Path.Segments slice does
+// NOT affect the registry's state — Codex P9.x pass 1 finding.
+func TestDeviceEntrySnapshot_ProjectionsDeepCopied(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry([]PlaneProvider{stubPlaneProviderWithProjection{name: "stub"}})
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "P"})
+
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+	if len(snap.Projections) != 1 {
+		t.Fatalf("snap.Projections len = %d; want 1", len(snap.Projections))
+	}
+	if len(snap.Projections[0].Nodes) == 0 {
+		t.Fatalf("snap.Projections[0].Nodes is empty; want >=1")
+	}
+
+	// Mutate the snapshot's Path.Segments — must NOT leak into registry.
+	snap.Projections[0].Nodes[0].Path.Segments[0].Name = "MUTATED"
+
+	snap2, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) #2 ok=false")
+	}
+	if got := snap2.Projections[0].Nodes[0].Path.Segments[0].Name; got == "MUTATED" {
+		t.Errorf("registry observed mutation through snapshot: Path.Segments[0].Name = %q (want unmodified)", got)
+	}
+}
+
 // stubPlaneProvider creates immutable single-method planes for tests.
 type stubPlaneProvider struct {
 	name string
@@ -128,6 +160,28 @@ func (p stubPlaneProvider) Name() string                    { return p.name }
 func (p stubPlaneProvider) Match(info DeviceInfo) bool      { return true }
 func (p stubPlaneProvider) CreatePlanes(info DeviceInfo) []Plane {
 	return []Plane{&stubPlane{name: p.name}}
+}
+
+// stubPlaneProviderWithProjection adds a projection so the snapshot
+// has Nodes/Edges/Segments to verify the deep-copy.
+type stubPlaneProviderWithProjection struct {
+	name string
+}
+
+func (p stubPlaneProviderWithProjection) Name() string               { return p.name }
+func (p stubPlaneProviderWithProjection) Match(info DeviceInfo) bool { return true }
+func (p stubPlaneProviderWithProjection) CreatePlanes(info DeviceInfo) []Plane {
+	return []Plane{&stubPlane{name: p.name}}
+}
+func (p stubPlaneProviderWithProjection) CreateProjections(info DeviceInfo, planes []Plane) []Projection {
+	return []Projection{{
+		Plane: ServicePlane,
+		Nodes: []Node{{
+			ID:            NodeID(ServicePlane + ":/seg"),
+			Path:          ProjectionPath{Plane: ServicePlane, Segments: []PathSegment{{Name: "seg"}}},
+			CanonicalPath: ProjectionPath{Plane: ServicePlane, Segments: []PathSegment{{Name: "seg"}}},
+		}},
+	}}
 }
 
 type stubPlane struct {

--- a/registry/snapshot_planes_p9x_test.go
+++ b/registry/snapshot_planes_p9x_test.go
@@ -1,0 +1,154 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/schema"
+)
+
+// P9.x — DeviceEntrySnapshot extended with Planes + Projections.
+//
+// The graphql.BuildSchema hot path used to iterate via reg.Iterate
+// (live *deviceEntry pointer) and dereference entry.Planes() /
+// entry.Projections() after the Iterate RLock had been released.
+// During an identity-merge in mergeEntries, dst.planes /
+// dst.projections are reassigned — readers iterating the live entry
+// could observe a torn slice header. Snapshot now copies the slice
+// header under RLock; downstream readers see a stable view.
+
+// TestDeviceEntrySnapshot_PlanesPopulated verifies that Planes
+// captured from registerLocked are present on the snapshot.
+func TestDeviceEntrySnapshot_PlanesPopulated(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry([]PlaneProvider{stubPlaneProvider{name: "stub-plane"}})
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "X"})
+
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+	if len(snap.Planes) != 1 {
+		t.Fatalf("snap.Planes len = %d; want 1", len(snap.Planes))
+	}
+	if got := snap.Planes[0].Name(); got != "stub-plane" {
+		t.Errorf("snap.Planes[0].Name = %q; want stub-plane", got)
+	}
+}
+
+// TestDeviceEntrySnapshot_PlanesIsolatedFromRegistryRebind verifies the
+// snapshot's Planes slice is unaffected by a subsequent identity merge
+// that rebinds entry.planes. This is the regression test for the
+// graphql.BuildSchema race.
+func TestDeviceEntrySnapshot_PlanesIsolatedFromRegistryRebind(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry([]PlaneProvider{stubPlaneProvider{name: "first"}})
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "Y"})
+
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+
+	// Re-register with a new identity that triggers a merge path. Then
+	// also wire a new provider for the next register so planes change.
+	reg.RegisterProvider(stubPlaneProvider{name: "second"})
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "Y"})
+
+	// snap captured BEFORE the second register — must remain "first".
+	if len(snap.Planes) != 1 {
+		t.Fatalf("snap.Planes len = %d; want 1 (snapshot captured before re-register)", len(snap.Planes))
+	}
+	if got := snap.Planes[0].Name(); got != "first" {
+		t.Errorf("snap.Planes[0].Name = %q; want first (snapshot must be isolated from registry rebind)", got)
+	}
+}
+
+// TestIterateSnapshots_PlanesRaceFree models the production race:
+// concurrent BuildSchema-style iteration vs identity-merge writes.
+// With the live-pointer Iterate path, this would race on entry.planes
+// reassignment. With IterateSnapshots + Plane snapshot, no race.
+func TestIterateSnapshots_PlanesRaceFree(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry([]PlaneProvider{stubPlaneProvider{name: "plane-1"}})
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "Z"})
+
+	stop := atomic.Bool{}
+	var wg sync.WaitGroup
+
+	// Reader: iterates snapshots and reads Planes. Must not race.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			reg.IterateSnapshots(func(snap DeviceEntrySnapshot) bool {
+				for _, plane := range snap.Planes {
+					_ = plane.Name()
+					for _, method := range plane.Methods() {
+						_ = method.Name()
+					}
+				}
+				return true
+			})
+		}
+		stop.Store(true)
+	}()
+
+	// Writer: continuously re-registers until reader signals stop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "Z"})
+		}
+	}()
+
+	wg.Wait()
+
+	// Final snapshot must still have planes populated.
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+	if len(snap.Planes) == 0 {
+		t.Errorf("final snap.Planes empty; want populated")
+	}
+}
+
+// stubPlaneProvider creates immutable single-method planes for tests.
+type stubPlaneProvider struct {
+	name string
+}
+
+func (p stubPlaneProvider) Name() string                    { return p.name }
+func (p stubPlaneProvider) Match(info DeviceInfo) bool      { return true }
+func (p stubPlaneProvider) CreatePlanes(info DeviceInfo) []Plane {
+	return []Plane{&stubPlane{name: p.name}}
+}
+
+type stubPlane struct {
+	name string
+}
+
+func (p *stubPlane) Name() string             { return p.name }
+func (p *stubPlane) Methods() []Method        { return []Method{stubMethod{name: "noop"}} }
+
+type stubMethod struct {
+	name string
+}
+
+func (m stubMethod) Name() string                   { return m.name }
+func (m stubMethod) ReadOnly() bool                 { return true }
+func (m stubMethod) Template() FrameTemplate        { return stubTemplate{} }
+func (m stubMethod) ResponseSchema() schema.SchemaSelector {
+	return schema.SchemaSelector{}
+}
+
+type stubTemplate struct{}
+
+func (stubTemplate) Primary() byte   { return 0xB5 }
+func (stubTemplate) Secondary() byte { return 0x09 }

--- a/registry/snapshot_planes_p9x_test.go
+++ b/registry/snapshot_planes_p9x_test.go
@@ -119,6 +119,57 @@ func TestIterateSnapshots_PlanesRaceFree(t *testing.T) {
 	}
 }
 
+// TestDeviceEntrySnapshot_PlaneMethodsIsolated verifies that the
+// Method slice returned by snap.Planes[i].Methods() is snapshot-owned:
+// mutating it must NOT corrupt registry-visible state on a subsequent
+// LookupEntrySnapshot. Codex P9.x pass 2 GitHub-bot finding — vaillant
+// providers' Plane.Methods() returns the live methods slice directly,
+// so a snapshot caller writing to the result would leak into registry
+// storage without the snapshotPlane wrapper.
+func TestDeviceEntrySnapshot_PlaneMethodsIsolated(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry([]PlaneProvider{stubPlaneProvider{name: "stub"}})
+	reg.Register(DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "M"})
+
+	snap1, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+	if len(snap1.Planes) != 1 {
+		t.Fatalf("snap1.Planes len = %d; want 1", len(snap1.Planes))
+	}
+
+	// Mutate the slice returned by Methods() on the FIRST snapshot.
+	methods1 := snap1.Planes[0].Methods()
+	if len(methods1) == 0 {
+		t.Fatalf("snap1 Methods() empty; want >=1")
+	}
+	methods1[0] = nil // try to corrupt registry storage via snapshot
+
+	// A subsequent snapshot must observe the registry's original
+	// methods, not the nil we wrote.
+	snap2, _ := reg.LookupEntrySnapshot(0x10)
+	methods2 := snap2.Planes[0].Methods()
+	if len(methods2) == 0 {
+		t.Fatalf("snap2 Methods() empty; want >=1")
+	}
+	if methods2[0] == nil {
+		t.Errorf("snap2 Methods()[0] = nil — snapshot mutation leaked into registry")
+	}
+
+	// Two calls to the SAME snapshot's Methods() must return
+	// independent slices (no cross-mutation between callers).
+	methodsA := snap1.Planes[0].Methods()
+	methodsB := snap1.Planes[0].Methods()
+	if len(methodsA) > 0 && len(methodsB) > 0 {
+		methodsA[0] = nil
+		if methodsB[0] == nil {
+			t.Errorf("Methods() returned aliased slice — caller A's mutation visible to caller B")
+		}
+	}
+}
+
 // TestDeviceEntrySnapshot_ProjectionsDeepCopied verifies that mutating
 // the snapshot's nested Projection.Nodes[i].Path.Segments slice does
 // NOT affect the registry's state — Codex P9.x pass 1 finding.


### PR DESCRIPTION
## Summary

Pre-P9.x `DeviceEntrySnapshot` intentionally omitted Planes and Projections. The `graphql.BuildSchema` hot path on the gateway therefore had to use the live-pointer `Iterate` API and dereference `entry.Planes()` / `entry.Projections()` *after* the Iterate RLock had been released — racing against `mergeEntries`' reassignment of `entry.planes` / `entry.projections` in the identity-merge path.

## Why this is safe

The plane / method / template implementations (vaillant providers) construct their internals once in `CreatePlanes` / `CreateProjections` and never mutate them afterward. The only registry-side write is the slice-header reassignment during identity merge. Capturing the slice header under RLock therefore produces a stable view: snapshot readers see element references that remain valid for the snapshot's lifetime, with no risk of mid-iteration slice reassignment.

## Changes

- `snapshotEntryLocked` now copies `entry.planes` / `entry.projections` slice headers under RLock and surfaces them on `DeviceEntrySnapshot.Planes` / `Projections`.
- Field doc on `DeviceEntrySnapshot` reflects the new scope.
- New tests in `registry/snapshot_planes_p9x_test.go`:
  - `TestDeviceEntrySnapshot_PlanesPopulated` — Planes captured by registerLocked are present.
  - `TestDeviceEntrySnapshot_PlanesIsolatedFromRegistryRebind` — snapshot is unaffected by subsequent re-register.
  - `TestIterateSnapshots_PlanesRaceFree` — concurrent IterateSnapshots reader vs Register writer (regression for the BuildSchema race; bounded to keep CI runtime sub-2s).

## Test plan

- [x] `go test -race -count=1 ./...` PASS (incl. 3 new tests)
- [x] No public-API break — DeviceEntrySnapshot is additive (two new fields)
- [ ] Gateway companion PR (P9.x-gateway) consumes the new fields in `graphql/schema.go BuildSchema` and migrates the Registry interface to `IterateSnapshots` (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)