### PR TITLE
NETX3 static seed adds 0xFF (4-face seed)

### DIFF
--- a/vaillant/productids/seed_table_test.go
+++ b/vaillant/productids/seed_table_test.go
@@ -10,13 +10,21 @@ import (
 
 const staticSeedSource = "vaillant_static_seed_w19_26"
 
-func TestStaticSeedTable_NETX3_OwnsThreeAddresses(t *testing.T) {
+func TestStaticSeedTable_NETX3_OwnsFourAddresses(t *testing.T) {
+	// Operator observation 2026-05-10: NETX3 exposes four faces on the
+	// wire. The pair 0x04+0xFF (target / broadcast faces) must be
+	// seeded together so identity-merge collapses all four addresses
+	// into one DeviceEntry at boot — without 0xFF in the seed, passive
+	// observations of NETX3's 0xFF broadcasts land in a separate
+	// unidentified entry that never gets enriched (NETX3 does not
+	// respond to active identify probes on 0xFF).
 	entry := findStaticSeedEntry(t, productids.LoadSeedTable(true), "Vaillant", "NETX3")
 
 	assertSeedAddresses(t, entry.Addresses, []productids.SeedAddressEntry{
 		{Addr: 0xF1, Role: "initiator", Confidence: "candidate"},
 		{Addr: 0xF6, Role: "target", Confidence: "candidate"},
 		{Addr: 0x04, Role: "target", Confidence: "candidate"},
+		{Addr: 0xFF, Role: "target", Confidence: "candidate"},
 	})
 }
 

--- a/vaillant/productids/static_seeds.go
+++ b/vaillant/productids/static_seeds.go
@@ -26,9 +26,21 @@ func LoadSeedTable(enabled bool) []StaticSeedEntry {
 			DeviceID:     "NETX3",
 			Source:       staticSeedSource,
 			Addresses: []SeedAddressEntry{
+				// NETX3 exposes four faces on the wire (operator
+				// observation 2026-05-10): 0xF1 (master / initiator),
+				// 0xF6 (slave / target companion of 0xF1), and the
+				// pair 0x04 / 0xFF (target / broadcast faces). The
+				// pair 0x04+0xFF must be seeded together so the
+				// registry's identity-merge collapses all four
+				// addresses into one DeviceEntry at boot — without
+				// 0xFF in the seed, passive observations of NETX3's
+				// 0xFF broadcasts land in a separate unidentified
+				// entry that never gets enriched (NETX3 does not
+				// respond to active identify probes on 0xFF).
 				{Addr: 0xF1, Role: "initiator", Confidence: "candidate"},
 				{Addr: 0xF6, Role: "target", Confidence: "candidate"},
 				{Addr: 0x04, Role: "target", Confidence: "candidate"},
+				{Addr: 0xFF, Role: "target", Confidence: "candidate"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Operator observation 2026-05-10: NETX3 exposes four faces on the wire — 0xF1 (master), 0xF6 (slave companion of 0xF1), 0x04 (target broadcast), and 0xFF (target broadcast). Static seed table currently has only three; **0xFF is missing**.

Without 0xFF in the seed, passive observations of NETX3's 0xFF broadcasts land in a separate unidentified registry entry that never gets enriched. Active identify probes timed out on 0xF6 (observed live, fail err=context deadline exceeded after 10s). 0x04 happens to respond OK, but that single-face identification doesn't merge with 0xFF or with the 0xF1/0xF6 unidentified entry.

Net live state pre-fix:
- `0x04` entry: identified as Vaillant/NETX3
- `0xF6/0xF1` entry: unidentified  
- `0xFF` not in registry at all

Post-fix (with `enable_static_seed_table=true`): single NETX3 entry with addresses [0xF1, 0xF6, 0x04, 0xFF].

## Test plan

- [x] `TestStaticSeedTable_NETX3_OwnsFourAddresses` updated; passes
- [x] `go test -race -count=1 ./...` PASS
- [ ] Gateway PR bumps the dependency
- [ ] HA addon options enables `enable_static_seed_table=true`
- [ ] Post-deploy: registry shows ONE NETX3 entry with all 4 addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)