### PR TITLE
fix(registry): P0 — don't preserve fallback sig keys as identity aliases

### DIFF
--- a/registry/alias_identity_preservation_test.go
+++ b/registry/alias_identity_preservation_test.go
@@ -295,3 +295,115 @@ func TestAliasAddresses_BothEmpty(t *testing.T) {
 		t.Errorf("after Register(0xF6, NETX3), Lookup(0xF1).SerialNumber() = %q; want \"SN-NETX3-001\"", entry.SerialNumber())
 	}
 }
+
+// TestRegister_FallbackSignatureNotPreservedAsAlias asserts that when
+// an entry is first registered with only a model signature (no serial /
+// MAC observed yet) and is later refreshed with a stable serial-derived
+// key, the OLD `sig|...` fallback key is NOT preserved as an identity
+// alias. Otherwise a second device with the same fingerprint that
+// becomes ambiguous-by-signature would silently merge into the first
+// entry on a subsequent bare sig-only observation, bypassing
+// `lookupCompatibleBySignatureLocked`'s ambiguity-refusal scan.
+//
+// (Codex P2 round-7 finding 2026-05-08 on PR #136 thread
+// PRRT_kwDORGIkfM6ArzFY: "Don't keep fallback signatures as identity
+// aliases".)
+func TestRegister_FallbackSignatureNotPreservedAsAlias(t *testing.T) {
+	t.Parallel()
+
+	reg := NewDeviceRegistry(nil)
+
+	// Step 1: register entry A at 0x10 with signature-only identity
+	// (no serial, no MAC). canonicalPhysicalIdentity.key() falls
+	// back to "sig|VAILLANT|BAI00|0204|0102".
+	reg.Register(DeviceInfo{
+		Address:         0x10,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0204",
+		HardwareVersion: "0102",
+	})
+
+	// Step 2: refresh entry A with a stable serial — promotes
+	// identityKey from "sig|..." to "sn|VAILLANT|SN-A-001".
+	reg.Register(DeviceInfo{
+		Address:         0x10,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SerialNumber:    "SN-A-001",
+		SoftwareVersion: "0204",
+		HardwareVersion: "0102",
+	})
+
+	// Step 3: register entry B at 0x11 with the SAME signature but a
+	// DIFFERENT serial. Both entries now share the same fallback
+	// model signature, so `lookupCompatibleBySignatureLocked` would
+	// correctly refuse the ambiguous match.
+	reg.Register(DeviceInfo{
+		Address:         0x11,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SerialNumber:    "SN-B-001",
+		SoftwareVersion: "0204",
+		HardwareVersion: "0102",
+	})
+
+	// Step 4: a bare sig-only observation arrives at a NEW address
+	// 0x12. canonicalPhysicalIdentity.key() returns
+	// "sig|VAILLANT|BAI00|0204|0102". If the old sig key was
+	// preserved as an alias to A, registerLocked's
+	// `r.identity[identityKey]` lookup hits A directly, bypassing
+	// the ambiguity scan, and 0x12 is incorrectly merged into A.
+	reg.Register(DeviceInfo{
+		Address:         0x12,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "0204",
+		HardwareVersion: "0102",
+	})
+
+	// Expected: 0x12 is NOT merged into A. It must either be its
+	// own new entry (because the ambiguity scan refused both A and
+	// B) or remain unbound from any identity row. Critically, A's
+	// addresses must NOT include 0x12, and B's must not either.
+	entryA, _ := reg.Lookup(0x10)
+	entryB, _ := reg.Lookup(0x11)
+
+	if entryA == nil {
+		t.Fatalf("Lookup(0x10) returned nil; want entry A")
+	}
+	if entryB == nil {
+		t.Fatalf("Lookup(0x11) returned nil; want entry B")
+	}
+
+	for _, a := range entryA.Addresses() {
+		if a == 0x12 {
+			t.Errorf("entry A (0x10, sn=SN-A-001) absorbed 0x12 via stale sig|... alias; want 0x12 NOT in entry A's address set")
+		}
+	}
+	for _, a := range entryB.Addresses() {
+		if a == 0x12 {
+			t.Errorf("entry B (0x11, sn=SN-B-001) absorbed 0x12 via stale sig|... alias; want 0x12 NOT in entry B's address set")
+		}
+	}
+
+	// A and B must remain distinct entries with their own serials.
+	if entryA.SerialNumber() != "SN-A-001" {
+		t.Errorf("entryA.SerialNumber() = %q; want \"SN-A-001\"", entryA.SerialNumber())
+	}
+	if entryB.SerialNumber() != "SN-B-001" {
+		t.Errorf("entryB.SerialNumber() = %q; want \"SN-B-001\"", entryB.SerialNumber())
+	}
+
+	// The bare sig-only observation at 0x12 should resolve to its
+	// own entry (registerLocked falls through to creating a fresh
+	// entry when neither identity-by-key nor the ambiguity-checked
+	// signature lookup matches).
+	entry12, ok := reg.Lookup(0x12)
+	if !ok {
+		t.Fatalf("Lookup(0x12) = false; want a fresh entry from bare sig-only Register")
+	}
+	if entry12.SerialNumber() == "SN-A-001" || entry12.SerialNumber() == "SN-B-001" {
+		t.Errorf("entry at 0x12 inherited a serial from A or B (= %q); want empty (fresh entry)", entry12.SerialNumber())
+	}
+}

--- a/registry/alias_identity_preservation_test.go
+++ b/registry/alias_identity_preservation_test.go
@@ -407,3 +407,72 @@ func TestRegister_FallbackSignatureNotPreservedAsAlias(t *testing.T) {
 		t.Errorf("entry at 0x12 inherited a serial from A or B (= %q); want empty (fresh entry)", entry12.SerialNumber())
 	}
 }
+
+// TestAbsorbIdentity_RecomputesPhysicalAfterModelSigAbsorb (P0 round-7
+// Codex P2 follow-up on PR #143). When a stable-key canonical (e.g.
+// MAC-only at boot) absorbs the model-signature fields (DeviceID +
+// SW + HW) from a sig-only secondary, the canonical's physicalIdentity
+// must be recomputed so withFallbackModelSignature reflects the new
+// fields. Without recompute, lookupCompatibleBySignatureLocked won't
+// find the merged device on a future bare sig-only Register and a
+// duplicate entry is created.
+func TestAbsorbIdentity_RecomputesPhysicalAfterModelSigAbsorb(t *testing.T) {
+	reg := NewDeviceRegistry(nil)
+
+	// Step 1: register canonical at 0x10 with MAC only.
+	reg.Register(DeviceInfo{
+		Address:      0x10,
+		Manufacturer: "Vaillant",
+		MacAddress:   "AA:BB:CC:11:22:33",
+	})
+
+	// Step 2: register secondary at 0x11 with sig only (no MAC).
+	reg.Register(DeviceInfo{
+		Address:         0x11,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "1201",
+		HardwareVersion: "7603",
+	})
+
+	// Step 3: alias 0x11 into canonical at 0x10. AliasAddresses calls
+	// absorbIdentityLocked which copies DeviceID/SW/HW from secondary
+	// into canonical.info. canonical.physical was {Manufacturer,
+	// MacAddress}; without the round-7 fix it stays stale and
+	// withFallbackModelSignature returns "" for it.
+	if err := reg.AliasAddresses(0x10, 0x11); err != nil {
+		t.Fatalf("AliasAddresses(0x10, 0x11) err=%v", err)
+	}
+
+	// Step 4: bare sig-only Register at 0x12. With the recompute fix,
+	// lookupCompatibleBySignatureLocked finds canonical via
+	// canonical.physical.withFallbackModelSignature() and routes 0x12
+	// to it. Pre-fix canonical.physical lacked DeviceID/SW/HW so the
+	// candidate scan returned no match and a duplicate entry was
+	// created at 0x12.
+	reg.Register(DeviceInfo{
+		Address:         0x12,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BAI00",
+		SoftwareVersion: "1201",
+		HardwareVersion: "7603",
+	})
+
+	entry10, ok := reg.Lookup(0x10)
+	if !ok {
+		t.Fatalf("Lookup(0x10) = false; want merged canonical")
+	}
+	entry12, ok := reg.Lookup(0x12)
+	if !ok {
+		t.Fatalf("Lookup(0x12) = false; want routed via sig fingerprint to merged canonical")
+	}
+	if entry10 != entry12 {
+		t.Errorf("entry at 0x10 != entry at 0x12; bare sig-only Register failed to route via withFallbackModelSignature — canonical.physical was not recomputed after absorb")
+	}
+	if entry10.MacAddress() != "AA:BB:CC:11:22:33" {
+		t.Errorf("entry.MacAddress = %q; want AA:BB:CC:11:22:33", entry10.MacAddress())
+	}
+	if entry10.DeviceID() != "BAI00" {
+		t.Errorf("entry.DeviceID = %q; want BAI00", entry10.DeviceID())
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -234,8 +235,28 @@ func (r *DeviceRegistry) registerLocked(info DeviceInfo) *deviceEntry {
 		// info.MacAddress. Now `lookupByIdentity` by either key
 		// continues to resolve to the merged entry, and
 		// detachAddressLocked cleans up both via identityKeyAliases.
-		r.identity[entry.identityKey] = entry
-		entry.identityKeyAliases = appendUniqueString(entry.identityKeyAliases, entry.identityKey)
+		//
+		// P0 round-7 (Codex P2 follow-up 2026-05-10 on PR #136
+		// thread PRRT_kwDORGIkfM6ArzFY): only preserve STABLE keys
+		// (sn|... / mac|...) as aliases. Fallback signature keys
+		// (`sig|...`) are NOT stable identifiers — multiple units
+		// of the same model share the identical fallback signature.
+		// If the old primary was sig-derived (entry first seen
+		// without serial/MAC, then enriched with a stable serial),
+		// preserving the sig key as an alias would silently bypass
+		// `lookupCompatibleBySignatureLocked`'s ambiguity-refusal
+		// scan when a second device with the same fingerprint
+		// exists. A subsequent bare sig-only observation at a new
+		// address would resolve directly to this entry via
+		// r.identity instead of being routed through the ambiguity
+		// check, incorrectly merging into this entry. Drop sig keys
+		// rather than aliasing them.
+		if isStableIdentityKey(entry.identityKey) {
+			r.identity[entry.identityKey] = entry
+			entry.identityKeyAliases = appendUniqueString(entry.identityKeyAliases, entry.identityKey)
+		} else {
+			delete(r.identity, entry.identityKey)
+		}
 	}
 	entry.info = storedInfo
 	entry.physical = physical
@@ -577,8 +598,23 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 						// this, the orphan key would resolve to a
 						// removed *deviceEntry until r.identity gets
 						// rebuilt. (Codex P2 round-4 finding.)
-						r.identity[secondary.identityKey] = canonical
-						canonical.identityKeyAliases = appendUniqueString(canonical.identityKeyAliases, secondary.identityKey)
+						//
+						// P0 round-7 (Codex P2 round-7 finding
+						// 2026-05-10 on PR #136 thread
+						// PRRT_kwDORGIkfM6ArzFY): only preserve
+						// STABLE keys (sn|... / mac|...) as aliases.
+						// `sig|...` fallback keys are NOT
+						// per-device — preserving one would let a
+						// later bare sig-only observation bypass
+						// `lookupCompatibleBySignatureLocked`'s
+						// ambiguity-refusal scan and silently merge
+						// into canonical.
+						if isStableIdentityKey(secondary.identityKey) {
+							r.identity[secondary.identityKey] = canonical
+							canonical.identityKeyAliases = appendUniqueString(canonical.identityKeyAliases, secondary.identityKey)
+						} else {
+							delete(r.identity, secondary.identityKey)
+						}
 					}
 				}
 				r.order = removeEntry(r.order, secondary)
@@ -641,8 +677,23 @@ func (r *DeviceRegistry) AliasAddresses(a, b byte) error {
 						// this, the orphan key would resolve to a
 						// removed *deviceEntry until r.identity gets
 						// rebuilt. (Codex P2 round-4 finding.)
-						r.identity[secondary.identityKey] = canonical
-						canonical.identityKeyAliases = appendUniqueString(canonical.identityKeyAliases, secondary.identityKey)
+						//
+						// P0 round-7 (Codex P2 round-7 finding
+						// 2026-05-10 on PR #136 thread
+						// PRRT_kwDORGIkfM6ArzFY): only preserve
+						// STABLE keys (sn|... / mac|...) as aliases.
+						// `sig|...` fallback keys are NOT
+						// per-device — preserving one would let a
+						// later bare sig-only observation bypass
+						// `lookupCompatibleBySignatureLocked`'s
+						// ambiguity-refusal scan and silently merge
+						// into canonical.
+						if isStableIdentityKey(secondary.identityKey) {
+							r.identity[secondary.identityKey] = canonical
+							canonical.identityKeyAliases = appendUniqueString(canonical.identityKeyAliases, secondary.identityKey)
+						} else {
+							delete(r.identity, secondary.identityKey)
+						}
 					}
 				}
 				r.order = removeEntry(r.order, secondary)
@@ -675,6 +726,27 @@ func appendUniqueString(dst []string, s string) []string {
 		}
 	}
 	return append(dst, s)
+}
+
+// isStableIdentityKey reports whether key is a stable, per-device
+// identity key (serial- or MAC-derived) versus a fallback model
+// signature key (`sig|...`) shared by every unit of the same model.
+//
+// Only stable keys are safe to preserve in r.identity as identity
+// aliases when the entry's primary identityKey is rotated (e.g. on
+// late-enrichment from sig-only → serial). Preserving a `sig|...` key
+// would silently bypass `lookupCompatibleBySignatureLocked`'s
+// ambiguity-refusal scan when a second device with the same
+// fingerprint exists in the registry: a subsequent bare sig-only
+// observation at a new address would resolve directly to the first
+// entry via r.identity instead of being routed through the ambiguity
+// check. (Codex P2 round-7 finding 2026-05-08 on PR #136 thread
+// PRRT_kwDORGIkfM6ArzFY.)
+//
+// Mirrors the prefix taxonomy in physicalIdentity.key() /
+// withFallbackModelSignature() in registry/identity.go.
+func isStableIdentityKey(key string) bool {
+	return strings.HasPrefix(key, "sn|") || strings.HasPrefix(key, "mac|")
 }
 
 // absorbIdentityLocked copies non-empty identity-bearing fields and

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -797,6 +797,19 @@ func (r *DeviceRegistry) absorbIdentityLocked(dst, src *deviceEntry) {
 	emptyPhysical := physicalIdentity{}
 	if dst.physical == emptyPhysical && src.physical != emptyPhysical {
 		dst.physical = src.physical
+	} else if dst.physical != emptyPhysical {
+		// P0 round-7 follow-up (Codex P2 on PR #143): when dst.physical
+		// is non-zero we don't replace it, but we just absorbed
+		// info.DeviceID / SoftwareVersion / HardwareVersion above from
+		// src. dst.physical is stale (was computed pre-absorb). A
+		// future bare sig-only Register goes through
+		// lookupCompatibleBySignatureLocked which compares
+		// candidate.physical.withFallbackModelSignature() — if dst.physical
+		// still lacks the absorbed sig fields, the candidate scan
+		// won't match and a duplicate device is created. Recompute
+		// dst.physical from the freshly-merged dst.info so the model
+		// signature reflects everything we've absorbed.
+		dst.physical = canonicalPhysicalIdentity(dst.info)
 	}
 	// NOTE: identityKey transfer is intentionally NOT done here.
 	// absorbIdentityLocked runs BEFORE AliasAddresses removes


### PR DESCRIPTION
## Summary

- Round-7 follow-up to merged PR #136 addressing Codex P2 thread `PRRT_kwDORGIkfM6ArzFY` ("Don't keep fallback signatures as identity aliases").
- Adds `isStableIdentityKey(key)` predicate distinguishing per-device keys (`sn|...`, `mac|...`) from shared model-fallback keys (`sig|...`).
- Gates the round-6 alias-preservation logic at all three sites (`registerLocked` + both `AliasAddresses` distinct-keys branches) so only stable keys are preserved as `identityKeyAliases`. Fallback `sig|...` keys are deleted from `r.identity`, routing subsequent bare sig-only observations through `lookupCompatibleBySignatureLocked`'s ambiguity-refusal scan instead of resolving directly to a stale `r.identity["sig|..."]` row.

## Why

When entry A is first registered with only `manufacturer + deviceID + sw + hw` (no serial/MAC observed yet — happens during early discovery), `physicalIdentity.key()` returns `sig|<mfr>|<deviceID>|<sw>|<hw>`. A later refresh with a stable serial rotates the primary key to `sn|...`. Pre-fix, the old `sig|...` was preserved as an alias pointing at A.

If a second device B with the same fingerprint is then registered with its own serial (entirely valid — multiple BAI00 of the same firmware revision share the fallback signature), both entries coexist with the same `physical.withFallbackModelSignature()`. A subsequent bare sig-only `Register` at a new address resolves directly to A via the stale `r.identity["sig|..."]` row, never reaching `lookupCompatibleBySignatureLocked` which would have refused the ambiguous match.

## Test plan

- [x] New regression test `TestRegister_FallbackSignatureNotPreservedAsAlias` reproduces the bug pre-fix (RED), passes post-fix (GREEN).
- [x] Full registry suite `go test ./registry/...` — PASS (existing identity / alias / static-seed / passive-observed tests unaffected).
- [x] Full module suite `go test ./...` — PASS.
- [x] `go build ./...` clean. `go vet ./...` clean.

## Notes

- No public API change. `identityKeyAliases` slice contract is now monotonically more conservative (fewer aliases). `detachAddressLocked`'s alias cleanup loop already iterates only stable keys post-fix.
- Falsifiability: a hypothetical future registration where two entries with different stable identities ever map to the SAME `sig|...` would expose ambiguity. Such a case is already handled correctly by `lookupCompatibleBySignatureLocked` returning `nil, false`.